### PR TITLE
Update expected trap message for backtrace.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
     name: Test .NET embedding of Wasmtime
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         build: [linux-debug, linux-release, macos-debug, macos-release, windows-debug, windows-release]
         include:

--- a/tests/FunctionThunkingTests.cs
+++ b/tests/FunctionThunkingTests.cs
@@ -66,7 +66,7 @@ namespace Wasmtime.Tests
             action
                 .Should()
                 .Throw<TrapException>()
-                .WithMessage(THROW_MESSAGE);
+                .WithMessage(THROW_MESSAGE + "\nwasm backtrace:\n  0:   0xad - <unknown>!do_throw\n");
         }
     }
 }

--- a/tests/FunctionThunkingTests.cs
+++ b/tests/FunctionThunkingTests.cs
@@ -66,7 +66,9 @@ namespace Wasmtime.Tests
             action
                 .Should()
                 .Throw<TrapException>()
-                .WithMessage(THROW_MESSAGE + "\nwasm backtrace:\n  0:   0xad - <unknown>!do_throw\n");
+                // Ideally this should contain a check for the backtrace
+                // See: https://github.com/bytecodealliance/wasmtime/issues/1845
+                .WithMessage(THROW_MESSAGE + "*");
         }
     }
 }


### PR DESCRIPTION
This will get CI green once bytecodealliance/wasmtime#1600 is merged (should be today).