### PR TITLE
Add the Store type back to the API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,19 @@ namespace Tutorial
     {
         static void Main(string[] args)
         {
-            using var host = new Host();
+            using var store = new Store();
+
+            using var module = store.LoadModuleText(
+              "hello",
+              "(module (func $hello (import \"\" \"hello\")) (func (export \"run\") (call $hello)))"
+            );
+
+            using var host = new Host(store);
 
             host.DefineFunction(
                 "",
                 "hello",
                 () => Console.WriteLine("Hello from C#!")
-            );
-
-            using var module = host.LoadModuleText(
-              "hello",
-              "(module (func $hello (import \"\" \"hello\")) (func (export \"run\") (call $hello)))"
             );
 
             using dynamic instance = host.Instantiate(module);
@@ -89,9 +91,11 @@ namespace Tutorial
 }
 ```
 
-This host defines a function called `hello` that simply prints a hello message.
+A `Store` is created and the WebAssembly module, in text format, is loaded into the store.
 
-It then loads the module into the host in WebAssembly text format and invokes the module's `run` export.
+A `Host` defines a function called `hello` that simply prints a hello message.
+
+The module is instantiated into the host and the module's `run` export is invoked.
 
 To run the application, simply use `dotnet`:
 

--- a/docs/articles/intro.md
+++ b/docs/articles/intro.md
@@ -65,15 +65,15 @@ namespace Tutorial
     {
         static void Main(string[] args)
         {
-            using var host = new Host();
+            using var store = new Store();
+            using var module = host.LoadModuleText("hello", "(module (func $hello (import \"\" \"hello\")) (func (export \"run\") (call $hello)))");
+            using var host = new Host(store);
 
             host.DefineFunction(
                 "",
                 "hello",
                 () => Console.WriteLine("Hello from C#!")
             );
-
-            using var module = host.LoadModuleText("hello", "(module (func $hello (import \"\" \"hello\")) (func (export \"run\") (call $hello)))");
 
             using dynamic instance = host.Instantiate(module);
             instance.run();

--- a/docs/articles/intro.md
+++ b/docs/articles/intro.md
@@ -66,7 +66,7 @@ namespace Tutorial
         static void Main(string[] args)
         {
             using var store = new Store();
-            using var module = host.LoadModuleText("hello", "(module (func $hello (import \"\" \"hello\")) (func (export \"run\") (call $hello)))");
+            using var module = store.LoadModuleText("hello", "(module (func $hello (import \"\" \"hello\")) (func (export \"run\") (call $hello)))");
             using var host = new Host(store);
 
             host.DefineFunction(

--- a/examples/global/Program.cs
+++ b/examples/global/Program.cs
@@ -7,7 +7,9 @@ namespace HelloExample
     {
         static void Main(string[] args)
         {
-            using var host = new Host();
+            using var store = new Store();
+            using var module = store.LoadModuleText("global.wat");
+            using var host = new Host(store);
 
             var global = host.DefineMutableGlobal("", "global", 1);
 
@@ -18,8 +20,6 @@ namespace HelloExample
                     Console.WriteLine($"The value of the global is: {global.Value}.");
                 }
             );
-
-            using var module = host.LoadModuleText("global.wat");
 
             using dynamic instance = host.Instantiate(module);
             instance.run(20);

--- a/examples/hello/Program.cs
+++ b/examples/hello/Program.cs
@@ -7,15 +7,15 @@ namespace HelloExample
     {
         static void Main(string[] args)
         {
-            using var host = new Host();
+            using var store = new Store();
+            using var module = store.LoadModuleText("hello.wat");
+            using var host = new Host(store);
 
             host.DefineFunction(
                 "",
                 "hello",
                 () => Console.WriteLine("Hello from C#, WebAssembly!")
             );
-
-            using var module = host.LoadModuleText("hello.wat");
 
             using dynamic instance = host.Instantiate(module);
             instance.run();

--- a/examples/memory/Program.cs
+++ b/examples/memory/Program.cs
@@ -7,7 +7,9 @@ namespace HelloExample
     {
         static void Main(string[] args)
         {
-            using var host = new Host();
+            using var store = new Store();
+            using var module = store.LoadModuleText("memory.wat");
+            using var host = new Host(store);
 
             host.DefineFunction(
                 "",
@@ -17,8 +19,6 @@ namespace HelloExample
                     Console.WriteLine($"Message from WebAssembly: {message}");
                 }
             );
-
-            using var module = host.LoadModuleText("memory.wat");
 
             using dynamic instance = host.Instantiate(module);
             instance.run();

--- a/src/Interop.cs
+++ b/src/Interop.cs
@@ -1096,5 +1096,5 @@ namespace Wasmtime
 
         [DllImport(LibraryName)]
         public static extern void wasmtime_error_delete(IntPtr error);
-   }
+    }
 }

--- a/src/Module.cs
+++ b/src/Module.cs
@@ -43,7 +43,7 @@ namespace Wasmtime
         {
             unsafe
             {
-                fixed (byte *ptr = bytes)
+                fixed (byte* ptr = bytes)
                 {
                     Interop.wasm_byte_vec_t vec;
                     vec.size = (UIntPtr)bytes.Length;

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -100,7 +100,7 @@ namespace Wasmtime
             var textBytes = Encoding.UTF8.GetBytes(text);
             unsafe
             {
-                fixed (byte *ptr = textBytes)
+                fixed (byte* ptr = textBytes)
                 {
                     Interop.wasm_byte_vec_t textVec;
                     textVec.size = (UIntPtr)textBytes.Length;

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -1,0 +1,220 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Collections.Generic;
+
+namespace Wasmtime
+{
+    /// <summary>
+    /// Represents a WebAssembly store.
+    /// </summary>
+    /// <remarks>
+    /// A store is used for loading WebAssembly modules.
+    /// </remarks>
+    public class Store : IDisposable
+    {
+        /// <summary>
+        /// Constructs a new store.
+        /// </summary>
+        public Store()
+        {
+            Initialize(Interop.wasm_engine_new());
+        }
+
+        /// <summary>
+        /// Loads a <see cref="Module"/> given the module name and bytes.
+        /// </summary>
+        /// <param name="name">The name of the module.</param>
+        /// <param name="bytes">The bytes of the module.</param>
+        /// <returns>Returns a new <see cref="Module"/>.</returns>
+        public Module LoadModule(string name, byte[] bytes)
+        {
+            CheckDisposed();
+
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (bytes is null)
+            {
+                throw new ArgumentNullException(nameof(bytes));
+            }
+
+            return new Module(Handle, name, bytes);
+        }
+
+        /// <summary>
+        /// Loads a <see cref="Module"/> given the path to the WebAssembly file.
+        /// </summary>
+        /// <param name="path">The path to the WebAssembly file.</param>
+        /// <returns>Returns a new <see cref="Module"/>.</returns>
+        public Module LoadModule(string path)
+        {
+            return LoadModule(Path.GetFileNameWithoutExtension(path), File.ReadAllBytes(path));
+        }
+
+        /// <summary>
+        /// Loads a <see cref="Module"/> given a stream.
+        /// </summary>
+        /// <param name="name">The name of the module.</param>
+        /// <param name="stream">The stream of the module data.</param>
+        /// <returns>Returns a new <see cref="Module"/>.</returns>
+        public Module LoadModule(string name, Stream stream)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+            return LoadModule(name, ms.ToArray());
+        }
+
+        /// <summary>
+        /// Loads a <see cref="Module"/> based on a WebAssembly text format representation.
+        /// </summary>
+        /// <param name="name">The name of the module.</param>
+        /// <param name="text">The WebAssembly text format representation of the module.</param>
+        /// <returns>Returns a new <see cref="Module"/>.</returns>
+        public Module LoadModuleText(string name, string text)
+        {
+            CheckDisposed();
+
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (text is null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            var textBytes = Encoding.UTF8.GetBytes(text);
+            unsafe
+            {
+                fixed (byte *ptr = textBytes)
+                {
+                    Interop.wasm_byte_vec_t textVec;
+                    textVec.size = (UIntPtr)textBytes.Length;
+                    textVec.data = ptr;
+
+                    var error = Interop.wasmtime_wat2wasm(ref textVec, out var bytes);
+                    if (error != IntPtr.Zero)
+                    {
+                        throw WasmtimeException.FromOwnedError(error);
+                    }
+
+                    var byteSpan = new ReadOnlySpan<byte>(bytes.data, checked((int)bytes.size));
+                    var moduleBytes = byteSpan.ToArray();
+                    Interop.wasm_byte_vec_delete(ref bytes);
+                    return LoadModule(name, moduleBytes);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loads a <see cref="Module"/> based on the path to a WebAssembly text format file.
+        /// </summary>
+        /// <param name="path">The path to the WebAssembly text format file.</param>
+        /// <returns>Returns a new <see cref="Module"/>.</returns>
+        public Module LoadModuleText(string path)
+        {
+            return LoadModuleText(Path.GetFileNameWithoutExtension(path), File.ReadAllText(path));
+        }
+
+        /// <summary>
+        /// Loads a <see cref="Module"/> given stream as WebAssembly text format stream.
+        /// </summary>
+        /// <param name="name">The name of the module.</param>
+        /// <param name="stream">The stream of the module data.</param>
+        /// <returns>Returns a new <see cref="Module"/>.</returns>
+        public Module LoadModuleText(string name, Stream stream)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (stream is null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            // Create a `StreamReader` to read a text from the supplied stream. The minimum buffer
+            // size and other parameters are hard-coded based on the default values used by the
+            // `StreamReader(Stream)` constructor. Make sure to leave `stream` open by specifying
+            // `leaveOpen`.
+            using var reader = new StreamReader(stream, Encoding.UTF8, true, 1024, leaveOpen: true);
+            return LoadModuleText(name, reader.ReadToEnd());
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (!Handle.IsInvalid)
+            {
+                Handle.Dispose();
+                Handle.SetHandleAsInvalid();
+            }
+
+            if (!_engine.IsInvalid)
+            {
+                _engine.Dispose();
+                _engine.SetHandleAsInvalid();
+            }
+        }
+
+        internal Store(Interop.WasmConfigHandle config)
+        {
+            var engine = Interop.wasm_engine_new_with_config(config);
+            config.SetHandleAsInvalid();
+
+            Initialize(engine);
+        }
+
+        private void Initialize(Interop.EngineHandle engine)
+        {
+            if (engine.IsInvalid)
+            {
+                throw new WasmtimeException("Failed to create Wasmtime engine.");
+            }
+
+            var store = Interop.wasm_store_new(engine);
+            if (store.IsInvalid)
+            {
+                throw new WasmtimeException("Failed to create Wasmtime store.");
+            }
+
+            _engine = engine;
+            _handle = store;
+        }
+
+        internal Interop.StoreHandle Handle
+        {
+            get
+            {
+                CheckDisposed();
+                return _handle;
+            }
+        }
+
+        private void CheckDisposed()
+        {
+            if (_handle.IsInvalid)
+            {
+                throw new ObjectDisposedException(typeof(Store).FullName);
+            }
+        }
+
+        private Interop.EngineHandle _engine;
+        private Interop.StoreHandle _handle;
+    }
+}

--- a/src/StoreBuilder.cs
+++ b/src/StoreBuilder.cs
@@ -43,16 +43,16 @@ namespace Wasmtime
     }
 
     /// <summary>
-    /// Represents a builder of <see cref="Host"/> instances.
+    /// Represents a builder of <see cref="Store"/> instances.
     /// </summary>
-    public class HostBuilder
+    public class StoreBuilder
     {
         /// <summary>
         /// Sets whether or not to enable debug information.
         /// </summary>
         /// <param name="enable">True to enable debug information or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public HostBuilder WithDebugInfo(bool enable)
+        public StoreBuilder WithDebugInfo(bool enable)
         {
             _enableDebugInfo = enable;
             return this;
@@ -63,7 +63,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable WebAssembly threads support or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public HostBuilder WithWasmThreads(bool enable)
+        public StoreBuilder WithWasmThreads(bool enable)
         {
             _enableWasmThreads = enable;
             return this;
@@ -74,7 +74,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable WebAssembly reference types support or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public HostBuilder WithReferenceTypes(bool enable)
+        public StoreBuilder WithReferenceTypes(bool enable)
         {
             _enableReferenceTypes = enable;
             return this;
@@ -85,7 +85,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable WebAssembly SIMD support or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public HostBuilder WithSIMD(bool enable)
+        public StoreBuilder WithSIMD(bool enable)
         {
             _enableSIMD = enable;
             return this;
@@ -96,7 +96,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable WebAssembly multi-value support or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public HostBuilder WithMultiValue(bool enable)
+        public StoreBuilder WithMultiValue(bool enable)
         {
             _enableMultiValue = enable;
             return this;
@@ -107,7 +107,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable WebAssembly bulk memory support or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public HostBuilder WithBulkMemory(bool enable)
+        public StoreBuilder WithBulkMemory(bool enable)
         {
             _enableBulkMemory = enable;
             return this;
@@ -118,7 +118,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="strategy">The compiler strategy to use.</param>
         /// <returns>Returns the current builder.</returns>
-        public HostBuilder WithCompilerStrategy(CompilerStrategy strategy)
+        public StoreBuilder WithCompilerStrategy(CompilerStrategy strategy)
         {
             switch (strategy)
             {
@@ -145,7 +145,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable the Cranelift debug verifier or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public HostBuilder WithCraneliftDebugVerifier(bool enable)
+        public StoreBuilder WithCraneliftDebugVerifier(bool enable)
         {
             _enableCraneliftDebugVerifier = enable;
             return this;
@@ -156,7 +156,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="level">The optimization level to use.</param>
         /// <returns>Returns the current builder.</returns>
-        public HostBuilder WithOptimizationLevel(OptimizationLevel level)
+        public StoreBuilder WithOptimizationLevel(OptimizationLevel level)
         {
             switch (level)
             {
@@ -179,10 +179,10 @@ namespace Wasmtime
         }
 
         /// <summary>
-        /// Builds the <see cref="Host" /> instance.
+        /// Builds the <see cref="Store" /> instance.
         /// </summary>
-        /// <returns>Returns the new <see cref="Host" /> instance.</returns>
-        public Host Build()
+        /// <returns>Returns the new <see cref="Store" /> instance.</returns>
+        public Store Build()
         {
             var config = Interop.wasm_config_new();
 
@@ -231,7 +231,7 @@ namespace Wasmtime
                 Interop.wasmtime_config_cranelift_opt_level_set(config, _optLevel.Value);
             }
 
-            return new Host(config);
+            return new Store(config);
         }
 
         private bool? _enableDebugInfo;

--- a/src/WasiConfiguration.cs
+++ b/src/WasiConfiguration.cs
@@ -48,7 +48,7 @@ namespace Wasmtime
                 _args.Clear();
                 _inheritArgs = false;
             }
-            
+
             foreach (var arg in args)
             {
                 _args.Add(arg);
@@ -111,7 +111,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="vars">The name-value tuples of the environment variables to add.</param>
         /// <returns>Returns the current configuration.</returns>
-        public WasiConfiguration WithEnvironmentVariables(IEnumerable<(string,string)> vars)
+        public WasiConfiguration WithEnvironmentVariables(IEnumerable<(string, string)> vars)
         {
             if (vars is null)
             {
@@ -119,7 +119,7 @@ namespace Wasmtime
             }
 
             _inheritEnv = false;
-           
+
             foreach (var v in vars)
             {
                 _vars.Add(v);
@@ -286,7 +286,7 @@ namespace Wasmtime
             }
 
             var (args, handles) = Interop.ToUTF8PtrArray(_args);
-            
+
             try
             {
                 Interop.wasi_config_set_argv(config, _args.Count, args);
@@ -315,7 +315,7 @@ namespace Wasmtime
 
             var (names, nameHandles) = Interop.ToUTF8PtrArray(_vars.Select(var => var.Name).ToArray());
             var (values, valueHandles) = Interop.ToUTF8PtrArray(_vars.Select(var => var.Value).ToArray());
-            
+
             try
             {
                 Interop.wasi_config_set_env(config, _vars.Count, names, values);
@@ -367,7 +367,7 @@ namespace Wasmtime
                 }
             }
         }
-        
+
         private void SetStandardError(Interop.WasiConfigHandle config)
         {
             if (_inheritStandardError)
@@ -407,5 +407,5 @@ namespace Wasmtime
         private bool _inheritStandardInput = false;
         private bool _inheritStandardOutput = false;
         private bool _inheritStandardError = false;
-    }   
+    }
 }

--- a/tests/Fixtures/ModuleFixture.cs
+++ b/tests/Fixtures/ModuleFixture.cs
@@ -8,12 +8,12 @@ namespace Wasmtime.Tests
     {
         public ModuleFixture()
         {
-            Host = new HostBuilder()
+            Store = new StoreBuilder()
                 .WithMultiValue(true)
                 .WithReferenceTypes(true)
                 .Build();
 
-            Module = Host.LoadModuleText(Path.Combine("Modules", ModuleFileName));
+            Module = Store.LoadModuleText(Path.Combine("Modules", ModuleFileName));
         }
 
         public void Dispose()
@@ -24,14 +24,14 @@ namespace Wasmtime.Tests
                 Module = null;
             }
 
-            if (!(Host is null))
+            if (!(Store is null))
             {
-                Host.Dispose();
-                Host = null;
+                Store.Dispose();
+                Store = null;
             }
         }
 
-        public Host Host { get; set; }
+        public Store Store { get; set; }
         public Module Module { get; set; }
 
         protected abstract string ModuleFileName { get; }

--- a/tests/FunctionThunkingTests.cs
+++ b/tests/FunctionThunkingTests.cs
@@ -23,7 +23,8 @@ namespace Wasmtime.Tests
             Host.DefineFunction("env", "add", (int x, int y) => x + y);
             Host.DefineFunction("env", "swap", (int x, int y) => (y, x));
             Host.DefineFunction("env", "do_throw", () => throw new Exception(THROW_MESSAGE));
-            Host.DefineFunction("env", "check_string", (Caller caller, int address, int length) => {
+            Host.DefineFunction("env", "check_string", (Caller caller, int address, int length) =>
+            {
                 caller.GetMemory("mem").ReadString(address, length).Should().Be("Hello World");
             });
         }

--- a/tests/GlobalExportsTests.cs
+++ b/tests/GlobalExportsTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using FluentAssertions;
 using Wasmtime;
@@ -13,11 +12,14 @@ namespace Wasmtime.Tests
         protected override string ModuleFileName => "GlobalExports.wat";
     }
 
-    public class GlobalExportsTests : IClassFixture<GlobalExportsFixture>
+    public class GlobalExportsTests : IClassFixture<GlobalExportsFixture>, IDisposable
     {
+        private Host Host { get; set; }
+
         public GlobalExportsTests(GlobalExportsFixture fixture)
         {
             Fixture = fixture;
+            Host = new Host(Fixture.Store);
         }
 
         private GlobalExportsFixture Fixture { get; set; }
@@ -41,7 +43,7 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItCreatesExternsForTheGlobals()
         {
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
 
             dynamic dyn = instance;
             var globals = instance.Externs.Globals;
@@ -209,6 +211,11 @@ namespace Wasmtime.Tests
                 ValueKind.Float64,
                 true
             };
+        }
+
+        public void Dispose()
+        {
+            Host.Dispose();
         }
     }
 }

--- a/tests/InvalidModuleTests.cs
+++ b/tests/InvalidModuleTests.cs
@@ -11,7 +11,7 @@ namespace Wasmtime.Tests
         {
             using var store = new Store();
 
-            Action action = () => store.LoadModule("invalid", new byte[] {});
+            Action action = () => store.LoadModule("invalid", new byte[] { });
 
             action
                 .Should()

--- a/tests/InvalidModuleTests.cs
+++ b/tests/InvalidModuleTests.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using FluentAssertions;
 using Xunit;
 
@@ -11,9 +9,9 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItThrowsWithErrorMessageForInvalidModules()
         {
-            var host = new Host();
+            using var store = new Store();
 
-            Action action = () => host.LoadModule("invalid", new byte[] {});
+            Action action = () => store.LoadModule("invalid", new byte[] {});
 
             action
                 .Should()

--- a/tests/MemoryExportsTests.cs
+++ b/tests/MemoryExportsTests.cs
@@ -11,11 +11,14 @@ namespace Wasmtime.Tests
         protected override string ModuleFileName => "MemoryExports.wat";
     }
 
-    public class MemoryExportsTests : IClassFixture<MemoryExportsFixture>
+    public class MemoryExportsTests : IClassFixture<MemoryExportsFixture>, IDisposable
     {
+        private Host Host { get; set; }
+
         public MemoryExportsTests(MemoryExportsFixture fixture)
         {
             Fixture = fixture;
+            Host = new Host(Fixture.Store);
         }
 
         private MemoryExportsFixture Fixture { get; set; }
@@ -39,7 +42,7 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItCreatesExternsForTheMemories()
         {
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
 
             instance.Externs.Memories.Count.Should().Be(1);
 
@@ -84,6 +87,11 @@ namespace Wasmtime.Tests
                 1,
                 2
             };
+        }
+
+        public void Dispose()
+        {
+            Host.Dispose();
         }
     }
 }

--- a/tests/ModuleLoadTests.cs
+++ b/tests/ModuleLoadTests.cs
@@ -14,8 +14,8 @@ namespace Wasmtime.Tests
             using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("hello.wasm");
             stream.Should().NotBeNull();
 
-            using var host = new Host();
-            host.LoadModule("hello.wasm", stream).Should().NotBeNull();
+            using var store = new Store();
+            store.LoadModule("hello.wasm", stream).Should().NotBeNull();
 
             // `LoadModule` is not supposed to close the supplied stream,
             // so the following statement should complete without throwing
@@ -29,8 +29,8 @@ namespace Wasmtime.Tests
             using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("hello.wat");
             stream.Should().NotBeNull();
 
-            using var host = new Host();
-            host.LoadModuleText("hello.wat", stream).Should().NotBeNull();
+            using var store = new Store();
+            store.LoadModuleText("hello.wat", stream).Should().NotBeNull();
 
             // `LoadModuleText` is not supposed to close the supplied stream,
             // so the following statement should complete without throwing

--- a/tests/TableExportsTests.cs
+++ b/tests/TableExportsTests.cs
@@ -11,11 +11,14 @@ namespace Wasmtime.Tests
         protected override string ModuleFileName => "TableExports.wat";
     }
 
-    public class TableExportsTests : IClassFixture<TableExportsFixture>
+    public class TableExportsTests : IClassFixture<TableExportsFixture>, IDisposable
     {
+        private Host Host { get; set; }
+
         public TableExportsTests(TableExportsFixture fixture)
         {
             Fixture = fixture;
+            Host = new Host(Fixture.Store);
         }
 
         private TableExportsFixture Fixture { get; set; }
@@ -40,7 +43,7 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItCreatesExternsForTheTables()
         {
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
 
             var tables = instance.Externs.Tables;
             tables.Count.Should().Be(3);
@@ -86,6 +89,11 @@ namespace Wasmtime.Tests
                 100,
                 1000
             };
+        }
+
+        public void Dispose()
+        {
+            Host.Dispose();
         }
     }
 }

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -9,13 +9,14 @@ namespace Wasmtime.Tests
         protected override string ModuleFileName => "Trap.wat";
     }
 
-    public class TrapTests : IClassFixture<TrapFixture>
+    public class TrapTests : IClassFixture<TrapFixture>, IDisposable
     {
+        private Host Host { get; set; }
+
         public TrapTests(TrapFixture fixture)
         {
             Fixture = fixture;
-
-            Fixture.Host.ClearDefinitions();
+            Host = new Host(Fixture.Store);
         }
 
         private TrapFixture Fixture { get; set; }
@@ -25,7 +26,7 @@ namespace Wasmtime.Tests
         {
             Action action = () =>
             {
-                using dynamic instance = Fixture.Host.Instantiate(Fixture.Module);
+                using dynamic instance = Host.Instantiate(Fixture.Module);
                 instance.run();
             };
 
@@ -38,6 +39,11 @@ namespace Wasmtime.Tests
                             e.Frames[2].FunctionName == "first" &&
                             e.Frames[3].FunctionName == "run")
                 .WithMessage("wasm trap: unreachable*");
+        }
+
+        public void Dispose()
+        {
+            Host.Dispose();
         }
     }
 }

--- a/tests/WasiSnapshot0Tests.cs
+++ b/tests/WasiSnapshot0Tests.cs
@@ -12,13 +12,14 @@ namespace Wasmtime.Tests
         protected override string ModuleFileName => "WasiSnapshot0.wat";
     }
 
-    public class WasiSnapshot0Tests : IClassFixture<WasiSnapshot0Fixture>
+    public class WasiSnapshot0Tests : IClassFixture<WasiSnapshot0Fixture>, IDisposable
     {
+        private Host Host { get; set; }
+
         public WasiSnapshot0Tests(WasiSnapshot0Fixture fixture)
         {
             Fixture = fixture;
-
-            Fixture.Host.ClearDefinitions();
+            Host = new Host(Fixture.Store);
         }
 
         private WasiSnapshot0Fixture Fixture { get; set; }
@@ -26,8 +27,8 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItHasNoEnvironmentByDefault()
         {
-            Fixture.Host.DefineWasi("wasi_unstable");
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            Host.DefineWasi("wasi_unstable");
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -49,9 +50,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithEnvironmentVariables(env.Select(kvp => (kvp.Key, kvp.Value)));
 
-            Fixture.Host.DefineWasi("wasi_unstable", config);
+            Host.DefineWasi("wasi_unstable", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -74,9 +75,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithInheritedEnvironment();
 
-            Fixture.Host.DefineWasi("wasi_unstable", config);
+            Host.DefineWasi("wasi_unstable", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -88,9 +89,9 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItHasNoArgumentsByDefault()
         {
-            Fixture.Host.DefineWasi("wasi_unstable");
+            Host.DefineWasi("wasi_unstable");
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -113,9 +114,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithArgs(args);
 
-            Fixture.Host.DefineWasi("wasi_unstable", config);
+            Host.DefineWasi("wasi_unstable", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -138,9 +139,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithInheritedArgs();
 
-            Fixture.Host.DefineWasi("wasi_unstable", config);
+            Host.DefineWasi("wasi_unstable", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -160,9 +161,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithStandardInput(file.Path);
 
-            Fixture.Host.DefineWasi("wasi_unstable", config);
+            Host.DefineWasi("wasi_unstable", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -193,9 +194,9 @@ namespace Wasmtime.Tests
                 config.WithStandardError(file.Path);
             }
 
-            Fixture.Host.DefineWasi("wasi_unstable", config);
+            Host.DefineWasi("wasi_unstable", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -219,9 +220,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithPreopenedDirectory(Path.GetDirectoryName(file.Path), "/foo");
 
-            Fixture.Host.DefineWasi("wasi_unstable", config);
+            Host.DefineWasi("wasi_unstable", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -252,6 +253,11 @@ namespace Wasmtime.Tests
             Assert.Equal(MESSAGE.Length, memory.ReadInt32(64));
             Assert.Equal(0, inst.call_fd_close(fileFd));
             Assert.Equal(MESSAGE, File.ReadAllText(file.Path));
+        }
+
+        public void Dispose()
+        {
+            Host.Dispose();
         }
     }
 }

--- a/tests/WasiSnapshot0Tests.cs
+++ b/tests/WasiSnapshot0Tests.cs
@@ -242,7 +242,7 @@ namespace Wasmtime.Tests
                 )
             );
 
-            var fileFd = (int) memory.ReadInt32(64);
+            var fileFd = (int)memory.ReadInt32(64);
             Assert.True(fileFd > 3);
 
             memory.WriteInt32(0, 8);

--- a/tests/WasiTests.cs
+++ b/tests/WasiTests.cs
@@ -12,11 +12,14 @@ namespace Wasmtime.Tests
         protected override string ModuleFileName => "Wasi.wat";
     }
 
-    public class WasiTests : IClassFixture<WasiFixture>
+    public class WasiTests : IClassFixture<WasiFixture>, IDisposable
     {
+        private Host Host { get; set; }
+
         public WasiTests(WasiFixture fixture)
         {
             Fixture = fixture;
+            Host = new Host(Fixture.Store);
         }
 
         private WasiFixture Fixture { get; set; }
@@ -24,9 +27,9 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItHasNoEnvironmentByDefault()
         {
-            Fixture.Host.DefineWasi("wasi_snapshot_preview1");
+            Host.DefineWasi("wasi_snapshot_preview1");
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -48,9 +51,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithEnvironmentVariables(env.Select(kvp => (kvp.Key, kvp.Value)));
 
-            Fixture.Host.DefineWasi("wasi_snapshot_preview1", config);
+            Host.DefineWasi("wasi_snapshot_preview1", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -73,9 +76,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithInheritedEnvironment();
 
-            Fixture.Host.DefineWasi("wasi_snapshot_preview1", config);
+            Host.DefineWasi("wasi_snapshot_preview1", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -87,9 +90,9 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItHasNoArgumentsByDefault()
         {
-            Fixture.Host.DefineWasi("wasi_snapshot_preview1");
+            Host.DefineWasi("wasi_snapshot_preview1");
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -112,9 +115,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithArgs(args);
 
-            Fixture.Host.DefineWasi("wasi_snapshot_preview1", config);
+            Host.DefineWasi("wasi_snapshot_preview1", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -137,9 +140,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithInheritedArgs();
 
-            Fixture.Host.DefineWasi("wasi_snapshot_preview1", config);
+            Host.DefineWasi("wasi_snapshot_preview1", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -159,9 +162,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithStandardInput(file.Path);
 
-            Fixture.Host.DefineWasi("wasi_snapshot_preview1", config);
+            Host.DefineWasi("wasi_snapshot_preview1", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -192,9 +195,9 @@ namespace Wasmtime.Tests
                 config.WithStandardError(file.Path);
             }
 
-            Fixture.Host.DefineWasi("wasi_snapshot_preview1", config);
+            Host.DefineWasi("wasi_snapshot_preview1", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -218,9 +221,9 @@ namespace Wasmtime.Tests
             var config = new WasiConfiguration()
                 .WithPreopenedDirectory(Path.GetDirectoryName(file.Path), "/foo");
 
-            Fixture.Host.DefineWasi("wasi_snapshot_preview1", config);
+            Host.DefineWasi("wasi_snapshot_preview1", config);
 
-            using var instance = Fixture.Host.Instantiate(Fixture.Module);
+            using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
             var memory = instance.Externs.Memories[0];
@@ -251,6 +254,11 @@ namespace Wasmtime.Tests
             Assert.Equal(MESSAGE.Length, memory.ReadInt32(64));
             Assert.Equal(0, inst.call_fd_close(fileFd));
             Assert.Equal(MESSAGE, File.ReadAllText(file.Path));
+        }
+
+        public void Dispose()
+        {
+            Host.Dispose();
         }
     }
 }

--- a/tests/WasiTests.cs
+++ b/tests/WasiTests.cs
@@ -243,7 +243,7 @@ namespace Wasmtime.Tests
                 )
             );
 
-            var fileFd = (int) memory.ReadInt32(64);
+            var fileFd = (int)memory.ReadInt32(64);
             Assert.True(fileFd > 3);
 
             memory.WriteInt32(0, 8);


### PR DESCRIPTION
This is a breaking API change.

The `Host` class was split back into a `Store` type, where loading of modules
will occur.

This allows for loading modules into a single store and defining one or more
hosts that instantiate the modules without having to load the modules again.

Fixes #9.