### PR TITLE
Leave the supplied stream open in `LoadModuleText`

### DIFF
--- a/src/Host.cs
+++ b/src/Host.cs
@@ -686,7 +686,11 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            using var reader = new StreamReader(stream);
+            // Create a `StreamReader` to read a text from the supplied stream. The minimum buffer
+            // size and other parameters are hard-coded based on the default values used by the
+            // `StreamReader(Stream)` constructor. Make sure to leave `stream` open by specifying
+            // `leaveOpen`.
+            using var reader = new StreamReader(stream, Encoding.UTF8, true, 1024, leaveOpen: true);
             return LoadModuleText(name, reader.ReadToEnd());
         }
         

--- a/tests/ModuleLoadTests.cs
+++ b/tests/ModuleLoadTests.cs
@@ -16,6 +16,11 @@ namespace Wasmtime.Tests
 
             using var host = new Host();
             host.LoadModule("hello.wasm", stream).Should().NotBeNull();
+
+            // `LoadModule` is not supposed to close the supplied stream,
+            // so the following statement should complete without throwing
+            // `ObjectDisposedException`
+            stream.Read(new byte[0], 0, 0);
         }
 
         [Fact]
@@ -26,6 +31,11 @@ namespace Wasmtime.Tests
 
             using var host = new Host();
             host.LoadModuleText("hello.wat", stream).Should().NotBeNull();
+
+            // `LoadModuleText` is not supposed to close the supplied stream,
+            // so the following statement should complete without throwing
+            // `ObjectDisposedException`
+            stream.Read(new byte[0], 0, 0);
         }
     }
 }


### PR DESCRIPTION
This PR modifies `Host.LoadModuleText(string, Stream)` to leave the supplied stream open like `Host.LoadModule(string, Stream)` does.

It also includes tests to check this behavior for both of `LoadModule` and `LoadModuleText`.