### PR TITLE
Use a different store for the host.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,9 @@ jobs:
       run: dotnet build -c ${{ matrix.config }} --no-restore
     - name: Test
       run: dotnet test -c ${{ matrix.config }}
+    - name: Benchmark
+      if: matrix.config == 'release'
+      run: dotnet run -c ${{ matrix.config }} --project benchmarks/simple/simple.csproj
     - name: Create package
       run: |
         cd src

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,14 @@ jobs:
     - name: Benchmark
       if: matrix.config == 'release'
       run: dotnet run -c ${{ matrix.config }} --project benchmarks/simple/simple.csproj
+    - name: Run examples
+      run: |
+        cd examples/hello
+        dotnet run
+        cd ../global
+        dotnet run
+        cd ../memory
+        dotnet run
     - name: Create package
       run: |
         cd src

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 bin/
 obj/
+
+BenchmarkDotNet.Artifacts/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 You can add a package reference with the [.NET Core SDK](https://dotnet.microsoft.com/):
 
 ```text
-$ dotnet add package --version 0.15.0-preview1 wasmtime
+$ dotnet add package --version 0.18.1-preview1 wasmtime
 ```
 
 _Note that the `--version` option is required because the package is currently prerelease._
@@ -54,7 +54,7 @@ $ dotnet new console
 Next, add a reference to the [Wasmtime package](https://www.nuget.org/packages/Wasmtime):
 
 ```
-$ dotnet add package --version 0.15.0-preview1 wasmtime
+$ dotnet add package --version 0.18.1-preview1 wasmtime
 ```
 
 Replace the contents of `Program.cs` with the following code:

--- a/README.md
+++ b/README.md
@@ -69,14 +69,15 @@ namespace Tutorial
     {
         static void Main(string[] args)
         {
-            using var store = new Store();
+            using var engine = new Engine();
+            using var store = new Store(engine);
 
             using var module = store.LoadModuleText(
               "hello",
               "(module (func $hello (import \"\" \"hello\")) (func (export \"run\") (call $hello)))"
             );
 
-            using var host = new Host(store);
+            using var host = new Host(engine);
 
             host.DefineFunction(
                 "",

--- a/benchmarks/simple/Program.cs
+++ b/benchmarks/simple/Program.cs
@@ -1,13 +1,28 @@
 ﻿using System;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
 using Wasmtime;
 
 namespace Simple
 {
+    [Config(typeof(Config))]
     public class Benchmark
     {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddJob(Job.MediumRun
+                    .WithLaunchCount(1)
+                    .WithToolchain(InProcessEmitToolchain.Instance)
+                    .WithId("InProcess"));
+            }
+        }
+
         public Benchmark()
         {
             _store = new Store();

--- a/benchmarks/simple/Program.cs
+++ b/benchmarks/simple/Program.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Wasmtime;
+
+namespace Simple
+{
+    public class Benchmark
+    {
+        public Benchmark()
+        {
+            _store = new Store();
+            _module = _store.LoadModuleText("hello", @"
+(module
+  (type $t0 (func))
+  (import """" ""hello"" (func $.hello (type $t0)))
+  (func $run
+    call $.hello
+  )
+  (export ""run"" (func $run))
+)");
+        }
+
+        [Benchmark]
+        public void SayHello()
+        {
+            using var host = new Host(_store);
+
+            host.DefineFunction("", "hello", () => {});
+
+            // Define a memory to add memory pressure if not disposed in the benchmark test
+            using var memory = host.DefineMemory("", "memory", 3);
+
+            using dynamic instance = host.Instantiate(_module);
+            instance.run();
+        }
+
+        private Store _store;
+        private Module _module;
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<Benchmark>();
+        }
+    }
+}

--- a/benchmarks/simple/Program.cs
+++ b/benchmarks/simple/Program.cs
@@ -25,7 +25,8 @@ namespace Simple
 
         public Benchmark()
         {
-            _store = new Store();
+            _engine = new Engine();
+            _store = new Store(_engine);
             _module = _store.LoadModuleText("hello", @"
 (module
   (type $t0 (func))
@@ -40,7 +41,7 @@ namespace Simple
         [Benchmark]
         public void SayHello()
         {
-            using var host = new Host(_store);
+            using var host = new Host(_engine);
 
             host.DefineFunction("", "hello", () => { });
 
@@ -51,6 +52,7 @@ namespace Simple
             instance.run();
         }
 
+        private Engine _engine;
         private Store _store;
         private Module _module;
     }

--- a/benchmarks/simple/simple.csproj
+++ b/benchmarks/simple/simple.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <ProjectReference Include="..\..\src\Wasmtime.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/articles/intro.md
+++ b/docs/articles/intro.md
@@ -65,9 +65,10 @@ namespace Tutorial
     {
         static void Main(string[] args)
         {
-            using var store = new Store();
+            using var engine = new Engine();
+            using var store = new Store(engine);
             using var module = store.LoadModuleText("hello", "(module (func $hello (import \"\" \"hello\")) (func (export \"run\") (call $hello)))");
-            using var host = new Host(store);
+            using var host = new Host(engine);
 
             host.DefineFunction(
                 "",

--- a/docs/articles/intro.md
+++ b/docs/articles/intro.md
@@ -44,7 +44,7 @@ dotnet new console
 To use the .NET embedding of Wasmtime from the project, we need to add a reference to the [Wasmtime NuGet package](https://www.nuget.org/packages/Wasmtime):
 
 ```text
-dotnet add package --version 0.15.0-preview1 wasmtime
+dotnet add package --version 0.18.1-preview1 wasmtime
 ```
 
 _Note that the `--version` option is required because the package is currently prerelease._

--- a/examples/global/Program.cs
+++ b/examples/global/Program.cs
@@ -7,9 +7,10 @@ namespace HelloExample
     {
         static void Main(string[] args)
         {
-            using var store = new Store();
+            using var engine = new Engine();
+            using var store = new Store(engine);
             using var module = store.LoadModuleText("global.wat");
-            using var host = new Host(store);
+            using var host = new Host(engine);
 
             var global = host.DefineMutableGlobal("", "global", 1);
 

--- a/examples/hello/Program.cs
+++ b/examples/hello/Program.cs
@@ -7,9 +7,10 @@ namespace HelloExample
     {
         static void Main(string[] args)
         {
-            using var store = new Store();
+            using var engine = new Engine();
+            using var store = new Store(engine);
             using var module = store.LoadModuleText("hello.wat");
-            using var host = new Host(store);
+            using var host = new Host(engine);
 
             host.DefineFunction(
                 "",

--- a/examples/memory/Program.cs
+++ b/examples/memory/Program.cs
@@ -7,9 +7,10 @@ namespace HelloExample
     {
         static void Main(string[] args)
         {
-            using var store = new Store();
+            using var engine = new Engine();
+            using var store = new Store(engine);
             using var module = store.LoadModuleText("memory.wat");
-            using var host = new Host(store);
+            using var host = new Host(engine);
 
             host.DefineFunction(
                 "",

--- a/src/Engine.cs
+++ b/src/Engine.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Collections.Generic;
+
+namespace Wasmtime
+{
+    /// <summary>
+    /// Represents a WebAssembly engine.
+    /// </summary>
+    public class Engine : IDisposable
+    {
+        /// <summary>
+        /// Constructs a new default engine.
+        /// </summary>
+        public Engine()
+        {
+            _handle = Interop.wasm_engine_new();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (!_handle.IsInvalid)
+            {
+                _handle.Dispose();
+                _handle.SetHandleAsInvalid();
+            }
+        }
+
+        internal Engine(Interop.WasmConfigHandle config)
+        {
+            if (config.IsInvalid)
+            {
+                throw new WasmtimeException("Failed to create Wasmtime engine.");
+            }
+
+            _handle = Interop.wasm_engine_new_with_config(config);
+            config.SetHandleAsInvalid();
+        }
+
+        internal Interop.EngineHandle Handle
+        {
+            get
+            {
+                if (_handle.IsInvalid)
+                {
+                    throw new ObjectDisposedException(typeof(Engine).FullName);
+                }
+
+                return _handle;
+            }
+        }
+
+        private Interop.EngineHandle _handle;
+    }
+}

--- a/src/EngineBuilder.cs
+++ b/src/EngineBuilder.cs
@@ -43,16 +43,16 @@ namespace Wasmtime
     }
 
     /// <summary>
-    /// Represents a builder of <see cref="Store"/> instances.
+    /// Represents a builder of <see cref="Engine"/> instances.
     /// </summary>
-    public class StoreBuilder
+    public class EngineBuilder
     {
         /// <summary>
         /// Sets whether or not to enable debug information.
         /// </summary>
         /// <param name="enable">True to enable debug information or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public StoreBuilder WithDebugInfo(bool enable)
+        public EngineBuilder WithDebugInfo(bool enable)
         {
             _enableDebugInfo = enable;
             return this;
@@ -63,7 +63,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable WebAssembly threads support or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public StoreBuilder WithWasmThreads(bool enable)
+        public EngineBuilder WithWasmThreads(bool enable)
         {
             _enableWasmThreads = enable;
             return this;
@@ -74,7 +74,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable WebAssembly reference types support or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public StoreBuilder WithReferenceTypes(bool enable)
+        public EngineBuilder WithReferenceTypes(bool enable)
         {
             _enableReferenceTypes = enable;
             return this;
@@ -85,7 +85,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable WebAssembly SIMD support or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public StoreBuilder WithSIMD(bool enable)
+        public EngineBuilder WithSIMD(bool enable)
         {
             _enableSIMD = enable;
             return this;
@@ -96,7 +96,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable WebAssembly multi-value support or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public StoreBuilder WithMultiValue(bool enable)
+        public EngineBuilder WithMultiValue(bool enable)
         {
             _enableMultiValue = enable;
             return this;
@@ -107,7 +107,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable WebAssembly bulk memory support or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public StoreBuilder WithBulkMemory(bool enable)
+        public EngineBuilder WithBulkMemory(bool enable)
         {
             _enableBulkMemory = enable;
             return this;
@@ -118,7 +118,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="strategy">The compiler strategy to use.</param>
         /// <returns>Returns the current builder.</returns>
-        public StoreBuilder WithCompilerStrategy(CompilerStrategy strategy)
+        public EngineBuilder WithCompilerStrategy(CompilerStrategy strategy)
         {
             switch (strategy)
             {
@@ -145,7 +145,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="enable">True to enable the Cranelift debug verifier or false to disable.</param>
         /// <returns>Returns the current builder.</returns>
-        public StoreBuilder WithCraneliftDebugVerifier(bool enable)
+        public EngineBuilder WithCraneliftDebugVerifier(bool enable)
         {
             _enableCraneliftDebugVerifier = enable;
             return this;
@@ -156,7 +156,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="level">The optimization level to use.</param>
         /// <returns>Returns the current builder.</returns>
-        public StoreBuilder WithOptimizationLevel(OptimizationLevel level)
+        public EngineBuilder WithOptimizationLevel(OptimizationLevel level)
         {
             switch (level)
             {
@@ -179,10 +179,10 @@ namespace Wasmtime
         }
 
         /// <summary>
-        /// Builds the <see cref="Store" /> instance.
+        /// Builds the <see cref="Engine" /> instance.
         /// </summary>
-        /// <returns>Returns the new <see cref="Store" /> instance.</returns>
-        public Store Build()
+        /// <returns>Returns the new <see cref="Engine" /> instance.</returns>
+        public Engine Build()
         {
             var config = Interop.wasm_config_new();
 
@@ -231,7 +231,7 @@ namespace Wasmtime
                 Interop.wasmtime_config_cranelift_opt_level_set(config, _optLevel.Value);
             }
 
-            return new Store(config);
+            return new Engine(config);
         }
 
         private bool? _enableDebugInfo;

--- a/src/Host.cs
+++ b/src/Host.cs
@@ -16,16 +16,16 @@ namespace Wasmtime
         /// <summary>
         /// Constructs a new host.
         /// </summary>
-        /// <param name="store">Store to use for the host.</param>
-        public Host(Store store)
+        /// <param name="engine">The engine to use for the host.</param>
+        public Host(Engine engine)
         {
-            if (store is null)
+            if (engine is null)
             {
-                throw new ArgumentNullException(nameof(store));
+                throw new ArgumentNullException(nameof(engine));
             }
 
             // Create a separate store for the host
-            _store = Interop.wasm_store_new(store.EngineHandle);
+            _store = Interop.wasm_store_new(engine.Handle);
 
             var linker = Interop.wasmtime_linker_new(_store);
             if (linker.IsInvalid)

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -206,6 +206,15 @@ namespace Wasmtime
             }
         }
 
+        internal Interop.EngineHandle EngineHandle
+        {
+            get
+            {
+                CheckDisposed();
+                return _engine;
+            }
+        }
+
         private void CheckDisposed()
         {
             if (_handle.IsInvalid)

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -18,7 +18,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RepositoryUrl>https://github.com/bytecodealliance/wasmtime-dotnet</RepositoryUrl>
-    <PackageReleaseNotes>Update Wasmtime to 0.15.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>Update Wasmtime to 0.18.0.</PackageReleaseNotes>
     <Summary>A .NET API for Wasmtime, a standalone WebAssembly runtime</Summary>
     <PackageTags>webassembly, .net, wasm, wasmtime</PackageTags>
     <Title>Wasmtime</Title>

--- a/tests/Fixtures/ModuleFixture.cs
+++ b/tests/Fixtures/ModuleFixture.cs
@@ -8,10 +8,12 @@ namespace Wasmtime.Tests
     {
         public ModuleFixture()
         {
-            Store = new StoreBuilder()
+            Engine = new EngineBuilder()
                 .WithMultiValue(true)
                 .WithReferenceTypes(true)
                 .Build();
+
+            Store = new Store(Engine);
 
             Module = Store.LoadModuleText(Path.Combine("Modules", ModuleFileName));
         }
@@ -31,6 +33,7 @@ namespace Wasmtime.Tests
             }
         }
 
+        public Engine Engine { get; set; }
         public Store Store { get; set; }
         public Module Module { get; set; }
 

--- a/tests/FunctionThunkingTests.cs
+++ b/tests/FunctionThunkingTests.cs
@@ -18,7 +18,7 @@ namespace Wasmtime.Tests
         public FunctionThunkingTests(FunctionThunkingFixture fixture)
         {
             Fixture = fixture;
-            Host = new Host(Fixture.Store);
+            Host = new Host(Fixture.Engine);
 
             Host.DefineFunction("env", "add", (int x, int y) => x + y);
             Host.DefineFunction("env", "swap", (int x, int y) => (y, x));

--- a/tests/GlobalExportsTests.cs
+++ b/tests/GlobalExportsTests.cs
@@ -19,7 +19,7 @@ namespace Wasmtime.Tests
         public GlobalExportsTests(GlobalExportsFixture fixture)
         {
             Fixture = fixture;
-            Host = new Host(Fixture.Store);
+            Host = new Host(Fixture.Engine);
         }
 
         private GlobalExportsFixture Fixture { get; set; }

--- a/tests/GlobalImportBindingTests.cs
+++ b/tests/GlobalImportBindingTests.cs
@@ -16,7 +16,7 @@ namespace Wasmtime.Tests
         public GlobalImportBindingTests(GlobalImportBindingFixture fixture)
         {
             Fixture = fixture;
-            Host = new Host(Fixture.Store);
+            Host = new Host(Fixture.Engine);
         }
 
         private GlobalImportBindingFixture Fixture { get; set; }

--- a/tests/InvalidModuleTests.cs
+++ b/tests/InvalidModuleTests.cs
@@ -9,7 +9,8 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItThrowsWithErrorMessageForInvalidModules()
         {
-            using var store = new Store();
+            using var engine = new Engine();
+            using var store = new Store(engine);
 
             Action action = () => store.LoadModule("invalid", new byte[] { });
 

--- a/tests/MemoryExportsTests.cs
+++ b/tests/MemoryExportsTests.cs
@@ -18,7 +18,7 @@ namespace Wasmtime.Tests
         public MemoryExportsTests(MemoryExportsFixture fixture)
         {
             Fixture = fixture;
-            Host = new Host(Fixture.Store);
+            Host = new Host(Fixture.Engine);
         }
 
         private MemoryExportsFixture Fixture { get; set; }

--- a/tests/MemoryImportBindingTests.cs
+++ b/tests/MemoryImportBindingTests.cs
@@ -16,7 +16,7 @@ namespace Wasmtime.Tests
         public MemoryImportBindingTests(MemoryImportBindingFixture fixture)
         {
             Fixture = fixture;
-            Host = new Host(Fixture.Store);
+            Host = new Host(Fixture.Engine);
         }
 
         private MemoryImportBindingFixture Fixture { get; set; }

--- a/tests/ModuleLoadTests.cs
+++ b/tests/ModuleLoadTests.cs
@@ -14,7 +14,8 @@ namespace Wasmtime.Tests
             using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("hello.wasm");
             stream.Should().NotBeNull();
 
-            using var store = new Store();
+            using var engine = new Engine();
+            using var store = new Store(engine);
             store.LoadModule("hello.wasm", stream).Should().NotBeNull();
 
             // `LoadModule` is not supposed to close the supplied stream,
@@ -29,7 +30,8 @@ namespace Wasmtime.Tests
             using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("hello.wat");
             stream.Should().NotBeNull();
 
-            using var store = new Store();
+            using var engine = new Engine();
+            using var store = new Store(engine);
             store.LoadModuleText("hello.wat", stream).Should().NotBeNull();
 
             // `LoadModuleText` is not supposed to close the supplied stream,

--- a/tests/TableExportsTests.cs
+++ b/tests/TableExportsTests.cs
@@ -18,7 +18,7 @@ namespace Wasmtime.Tests
         public TableExportsTests(TableExportsFixture fixture)
         {
             Fixture = fixture;
-            Host = new Host(Fixture.Store);
+            Host = new Host(Fixture.Engine);
         }
 
         private TableExportsFixture Fixture { get; set; }

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -16,7 +16,7 @@ namespace Wasmtime.Tests
         public TrapTests(TrapFixture fixture)
         {
             Fixture = fixture;
-            Host = new Host(Fixture.Store);
+            Host = new Host(Fixture.Engine);
         }
 
         private TrapFixture Fixture { get; set; }

--- a/tests/WasiSnapshot0Tests.cs
+++ b/tests/WasiSnapshot0Tests.cs
@@ -19,7 +19,7 @@ namespace Wasmtime.Tests
         public WasiSnapshot0Tests(WasiSnapshot0Fixture fixture)
         {
             Fixture = fixture;
-            Host = new Host(Fixture.Store);
+            Host = new Host(Fixture.Engine);
         }
 
         private WasiSnapshot0Fixture Fixture { get; set; }

--- a/tests/WasiTests.cs
+++ b/tests/WasiTests.cs
@@ -19,7 +19,7 @@ namespace Wasmtime.Tests
         public WasiTests(WasiFixture fixture)
         {
             Fixture = fixture;
-            Host = new Host(Fixture.Store);
+            Host = new Host(Fixture.Engine);
         }
 
         private WasiFixture Fixture { get; set; }


### PR DESCRIPTION
The host was using the same store as was given in the constructor for the
underlying linker and defined memories/functions/globals.

As a result, a memory defined in a host, for example, would not get freed when
the host (and all instances) were disposed.

This prevents the use case where a module gets loaded once into a store and then
a host is created to instantiate the module.  If the operation to create the
host and instantiate the module is performed in a loop (e.g. a benchmark), then
memory continues to grow as the original store is never released.