### PR TITLE
Use nullable reference types to annotate nullability

### DIFF
--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -42,7 +42,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="name">The name of the exported memory.</param>
         /// <returns>Returns the exported memory if found or null if a memory of the requested name is not exported.</returns>
-        public CallerMemory GetMemory(string name)
+        public CallerMemory? GetMemory(string name)
         {
             if (Handle == IntPtr.Zero)
             {

--- a/src/Externs/ExternFunction.cs
+++ b/src/Externs/ExternFunction.cs
@@ -39,7 +39,7 @@ namespace Wasmtime.Externs
         ///   Returns the value if the function returns a single value.
         ///   Returns an array of values if the function returns more than one value.
         /// </returns>
-        public object Invoke(params object[] arguments)
+        public object? Invoke(params object?[] arguments)
         {
             return Function.Invoke(_func, Parameters, Results, arguments);
         }

--- a/src/Externs/ExternGlobal.cs
+++ b/src/Externs/ExternGlobal.cs
@@ -29,7 +29,7 @@ namespace Wasmtime.Externs
         /// </summary>
         public bool IsMutable => _export.IsMutable;
 
-        public object Value
+        public object? Value
         {
             get
             {

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -552,7 +552,7 @@ namespace Wasmtime
         ///   Returns the value if the function returns a single value.
         ///   Returns an array of values if the function returns more than one value.
         /// </returns>
-        public object Invoke(params object[] arguments)
+        public object? Invoke(params object[] arguments)
         {
             if (IsNull)
             {
@@ -573,7 +573,7 @@ namespace Wasmtime
             }
         }
 
-        internal static object Invoke(IntPtr func, IReadOnlyList<ValueKind> funcParameters, IReadOnlyList<ValueKind> funcResults, object[] arguments)
+        internal static object? Invoke(IntPtr func, IReadOnlyList<ValueKind> funcParameters, IReadOnlyList<ValueKind> funcResults, object?[] arguments)
         {
             if (arguments.Length != funcParameters.Count)
             {
@@ -614,7 +614,7 @@ namespace Wasmtime
                     return result;
                 }
 
-                var ret = new object[funcResults.Count];
+                var ret = new object?[funcResults.Count];
                 for (int i = 0; i < funcResults.Count; ++i)
                 {
                     ret[i] = Interop.ToObject(&results[i]);
@@ -633,7 +633,7 @@ namespace Wasmtime
 
             var type = callback.GetType();
             Span<Type> parameterTypes = null;
-            Type returnType = null;
+            Type? returnType = null;
 
             if (hasReturn)
             {
@@ -743,7 +743,7 @@ namespace Wasmtime
             }).ToArray();
         }
 
-        private static IEnumerable<Type> EnumerateReturnTypes(Type returnType)
+        private static IEnumerable<Type> EnumerateReturnTypes(Type? returnType)
         {
             if (returnType is null)
             {
@@ -832,7 +832,7 @@ namespace Wasmtime
         private unsafe static IntPtr InvokeCallback(
             Interop.StoreHandle store,
             Delegate callback,
-            object[] args,
+            object?[] args,
             IReadOnlyList<ValueKind> resultKinds,
             IntPtr caller,
             Interop.wasm_val_t* arguments,
@@ -844,7 +844,7 @@ namespace Wasmtime
                 if (caller != IntPtr.Zero)
                 {
                     offset = 1;
-                    ((Caller)args[0]).Handle = caller;
+                    ((Caller)args[0]!).Handle = caller;
                 }
 
                 for (int i = 0; i < args.Length - offset; ++i)
@@ -861,7 +861,7 @@ namespace Wasmtime
 
                 if (caller != IntPtr.Zero)
                 {
-                    ((Caller)args[0]).Handle = IntPtr.Zero;
+                    ((Caller)args[0]!).Handle = IntPtr.Zero;
                 }
 
                 if (resultKinds.Count > 0)

--- a/src/Global.cs
+++ b/src/Global.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wasmtime
 {
@@ -10,6 +11,7 @@ namespace Wasmtime
         /// <summary>
         /// The value of the global.
         /// </summary>
+        [MaybeNull]
         public T Value
         {
             get
@@ -50,7 +52,7 @@ namespace Wasmtime
 
             Kind = kind;
 
-            var value = Interop.ToValue((object)initialValue, Kind);
+            var value = Interop.ToValue((object?)initialValue, Kind);
 
             var valueType = Interop.wasm_valtype_new(value.kind);
             var valueTypeHandle = valueType.DangerousGetHandle();

--- a/src/Host.cs
+++ b/src/Host.cs
@@ -68,7 +68,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="name">The name of the WASI module to define.</param>
         /// <param name="config">The <see cref="WasiConfiguration"/> to configure the WASI implementation with.</param>
-        public void DefineWasi(string name, WasiConfiguration config = null)
+        public void DefineWasi(string name, WasiConfiguration? config = null)
         {
             CheckDisposed();
 
@@ -611,7 +611,7 @@ namespace Wasmtime
         /// <param name="maximum">The maximum number of elements for the table.</param>
         /// <typeparam name="T">The element type of the host table.</typeparam>
         /// <returns>Returns a new <see cref="Table{T}"/> representing the defined table.</returns>
-        public Table<T> DefineTable<T>(string moduleName, string name, T initialValue, uint initial, uint maximum = uint.MaxValue) where T : class
+        public Table<T> DefineTable<T>(string moduleName, string name, T? initialValue, uint initial, uint maximum = uint.MaxValue) where T : class
         {
             CheckDisposed();
 
@@ -707,7 +707,7 @@ namespace Wasmtime
             return function;
         }
 
-        private WasmtimeException Define(string moduleName, string name, IntPtr ext)
+        private WasmtimeException? Define(string moduleName, string name, IntPtr ext)
         {
             var moduleNameBytes = Encoding.UTF8.GetBytes(moduleName);
             var nameBytes = Encoding.UTF8.GetBytes(name);

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -62,7 +62,7 @@ namespace Wasmtime
         }
 
         /// <inheritdoc/>
-        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object? result)
+        public override bool TryInvokeMember(InvokeMemberBinder binder, object?[] args, out object? result)
         {
             if (!_functions.TryGetValue(binder.Name, out var func))
             {

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -39,7 +39,7 @@ namespace Wasmtime
         }
 
         /// <inheritdoc/>
-        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        public override bool TryGetMember(GetMemberBinder binder, out object? result)
         {
             if (_globals.TryGetValue(binder.Name, out var global))
             {
@@ -62,7 +62,7 @@ namespace Wasmtime
         }
 
         /// <inheritdoc/>
-        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object? result)
         {
             if (!_functions.TryGetValue(binder.Name, out var func))
             {

--- a/src/Interop.cs
+++ b/src/Interop.cs
@@ -435,7 +435,7 @@ namespace Wasmtime
             public uint max;
         }
 
-        public static wasm_val_t CreateExternRefValue(object o)
+        public static wasm_val_t CreateExternRefValue(object? o)
         {
             wasm_val_t value = new wasm_val_t();
             value.kind = wasm_valkind_t.WASM_EXTERNREF;
@@ -454,7 +454,7 @@ namespace Wasmtime
         }
 
         // NOTE: DeleteValue should be called for any value that does not have ownership transferred to Wasmtime
-        public static wasm_val_t ToValue(object o, ValueKind kind)
+        public static wasm_val_t ToValue(object? o, ValueKind kind)
         {
             wasm_val_t value = new wasm_val_t();
             switch (kind)
@@ -515,7 +515,7 @@ namespace Wasmtime
             }
         }
 
-        public static unsafe object ToObject(wasm_val_t* v)
+        public static unsafe object? ToObject(wasm_val_t* v)
         {
             switch (v->kind)
             {
@@ -550,7 +550,7 @@ namespace Wasmtime
             }
         }
 
-        public static unsafe object ToObject(IntPtr reference, ValueKind kind)
+        public static unsafe object? ToObject(IntPtr reference, ValueKind kind)
         {
             wasm_val_t v = new wasm_val_t();
 

--- a/src/Module.cs
+++ b/src/Module.cs
@@ -181,10 +181,14 @@ namespace Wasmtime
                 Handle.Dispose();
                 Handle.SetHandleAsInvalid();
             }
+
             if (!(Imports is null))
             {
                 Imports.Dispose();
-                Imports = null;
+
+                // once Module is disposed, nothing in Module should be used anyways.
+                // keeping `Imports` to appear as a non-nullable makes things simpler for developers.
+                Imports = null!;
             }
         }
 

--- a/src/MutableGlobal.cs
+++ b/src/MutableGlobal.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wasmtime
 {
@@ -10,6 +11,7 @@ namespace Wasmtime
         /// <summary>
         /// The value of the global.
         /// </summary>
+        [MaybeNull]
         public T Value
         {
             get
@@ -61,7 +63,7 @@ namespace Wasmtime
 
             Kind = kind;
 
-            var value = Interop.ToValue((object)initialValue, Kind);
+            var value = Interop.ToValue((object?)initialValue, Kind);
 
             var valueType = Interop.wasm_valtype_new(value.kind);
             var valueTypeHandle = valueType.DangerousGetHandle();

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wasmtime
 {
@@ -27,7 +28,7 @@ namespace Wasmtime
         /// Gets or sets a value in the table at the given index.
         /// </summary>
         /// <value>The value to set in the table.</value>
-        public T this[uint index]
+        public T? this[uint index]
         {
             get
             {
@@ -36,7 +37,7 @@ namespace Wasmtime
                 unsafe
                 {
                     using var reference = Interop.wasm_table_get(Handle.DangerousGetHandle(), index);
-                    return (T)Interop.ToObject(reference.DangerousGetHandle(), Kind);
+                    return (T?)Interop.ToObject(reference.DangerousGetHandle(), Kind);
                 }
             }
             set
@@ -101,7 +102,7 @@ namespace Wasmtime
             }
         }
 
-        internal Table(Interop.StoreHandle store, T initialValue, uint initial, uint maximum)
+        internal Table(Interop.StoreHandle store, T? initialValue, uint initial, uint maximum)
         {
             if (!Interop.TryGetValueKind(typeof(T), out var kind))
             {
@@ -129,7 +130,7 @@ namespace Wasmtime
 
             unsafe
             {
-                var value = Interop.ToValue((object)initialValue, Kind);
+                var value = Interop.ToValue((object?)initialValue, Kind);
 
                 var valueType = Interop.wasm_valtype_new(value.kind);
                 var valueTypeHandle = valueType.DangerousGetHandle();

--- a/src/TrapException.cs
+++ b/src/TrapException.cs
@@ -39,7 +39,7 @@ namespace Wasmtime
         /// <summary>
         /// Gets the frame's function name.
         /// </summary>
-        public string FunctionName { get; private set; }
+        public string? FunctionName { get; private set; }
 
         /// <summary>
         /// Gets the frame's module offset from the start of the module.
@@ -49,7 +49,7 @@ namespace Wasmtime
         /// <summary>
         /// Gets the frame's module name.
         /// </summary>
-        public string ModuleName { get; private set; }
+        public string? ModuleName { get; private set; }
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ namespace Wasmtime
         /// <summary>
         /// Gets the trap's frames.
         /// </summary>
-        public IReadOnlyList<TrapFrame> Frames { get; private set; }
+        public IReadOnlyList<TrapFrame>? Frames { get; private set; }
 
         /// <inheritdoc/>
         protected TrapException(SerializationInfo info, StreamingContext context) : base(info, context) { }

--- a/src/WasiConfiguration.cs
+++ b/src/WasiConfiguration.cs
@@ -398,9 +398,9 @@ namespace Wasmtime
 
         private readonly List<string> _args = new List<string>();
         private readonly List<(string Name, string Value)> _vars = new List<(string, string)>();
-        private string _standardInputPath;
-        private string _standardOutputPath;
-        private string _standardErrorPath;
+        private string? _standardInputPath;
+        private string? _standardOutputPath;
+        private string? _standardErrorPath;
         private readonly List<(string Path, string GuestPath)> _preopenDirs = new List<(string, string)>();
         private bool _inheritArgs = false;
         private bool _inheritEnv = false;

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With C# 8 brings NRT (Nullable Reference Types) which enforce nullability at compile time of reference types. This PR updates the signatures of method headers, properties, and other relevant data types to use NRTs where applicable to more clearly inform developers that certain return values may be null when they are not.

Perhaps the possibility of removing many of the manual null parameter checks could be accompanied for in this PR. Removing the nullability checks in methods yields (minor) performance gains, and removes lots of boilerplate from the codebase.