### PR TITLE
Enhance array-based methods with Span<T> API

### DIFF
--- a/src/Externs/ExternFunction.cs
+++ b/src/Externs/ExternFunction.cs
@@ -44,6 +44,21 @@ namespace Wasmtime.Externs
             return Function.Invoke(_func, Parameters, Results, arguments);
         }
 
+        // TODO: remove overload when https://github.com/dotnet/csharplang/issues/1757 is resolved
+        /// <summary>
+        /// Invokes the WebAssembly function.
+        /// </summary>
+        /// <param name="arguments">The array of arguments to pass to the function.</param>
+        /// <returns>
+        ///   Returns null if the function has no return value.
+        ///   Returns the value if the function returns a single value.
+        ///   Returns an array of values if the function returns more than one value.
+        /// </returns>
+        public object? Invoke(ReadOnlySpan<object?> arguments)
+        {
+            return Function.Invoke(_func, Parameters, Results, arguments);
+        }
+
         private FunctionExport _export;
         private IntPtr _func;
     }

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -552,7 +552,7 @@ namespace Wasmtime
         ///   Returns the value if the function returns a single value.
         ///   Returns an array of values if the function returns more than one value.
         /// </returns>
-        public object? Invoke(params object[] arguments)
+        public object? Invoke(params object?[] arguments)
         {
             if (IsNull)
             {
@@ -860,7 +860,7 @@ namespace Wasmtime
             {
                 // reflection API does not offer any Span<object> overloads, so must allocate
                 var offset = (caller == null ? 0 : 1);
-                var reflectionArgs = new object[argumentCount + offset];
+                var reflectionArgs = new object?[argumentCount + offset];
 
                 if (caller != null)
                 {

--- a/src/Interop.cs
+++ b/src/Interop.cs
@@ -718,7 +718,7 @@ namespace Wasmtime
         public static extern void wasm_byte_vec_new_uninitialized(out wasm_byte_vec_t vec, UIntPtr length);
 
         [DllImport(LibraryName)]
-        public static extern void wasm_byte_vec_new(out wasm_byte_vec_t vec, UIntPtr length, byte[] data);
+        public static unsafe extern void wasm_byte_vec_new(out wasm_byte_vec_t vec, UIntPtr length, byte* data);
 
         [DllImport(LibraryName)]
         public static extern void wasm_byte_vec_copy(out wasm_byte_vec_t vec, ref wasm_byte_vec_t src);
@@ -735,7 +735,7 @@ namespace Wasmtime
         public static extern void wasm_valtype_vec_new_uninitialized(out wasm_valtype_vec_t vec, UIntPtr length);
 
         [DllImport(LibraryName)]
-        public static extern void wasm_valtype_vec_new(out wasm_valtype_vec_t vec, UIntPtr length, IntPtr[] data);
+        public static unsafe extern void wasm_valtype_vec_new(out wasm_valtype_vec_t vec, UIntPtr length, IntPtr* data);
 
         [DllImport(LibraryName)]
         public static extern void wasm_valtype_vec_copy(out wasm_valtype_vec_t vec, ref wasm_valtype_vec_t src);
@@ -752,7 +752,7 @@ namespace Wasmtime
         public static extern void wasm_extern_vec_new_uninitialized(out wasm_extern_vec_t vec, UIntPtr length);
 
         [DllImport(LibraryName)]
-        public static extern void wasm_extern_vec_new(out wasm_extern_vec_t vec, UIntPtr length, IntPtr[] data);
+        public static unsafe extern void wasm_extern_vec_new(out wasm_extern_vec_t vec, UIntPtr length, IntPtr* data);
 
         [DllImport(LibraryName)]
         public static extern void wasm_extern_vec_copy(out wasm_extern_vec_t vec, ref wasm_extern_vec_t src);
@@ -769,7 +769,7 @@ namespace Wasmtime
         public static extern void wasm_importtype_vec_new_uninitialized(out wasm_importtype_vec_t vec, UIntPtr length);
 
         [DllImport(LibraryName)]
-        public static extern void wasm_importtype_vec_new(out wasm_importtype_vec_t vec, UIntPtr length, IntPtr[] data);
+        public static extern unsafe void wasm_importtype_vec_new(out wasm_importtype_vec_t vec, UIntPtr length, IntPtr* data);
 
         [DllImport(LibraryName)]
         public static extern void wasm_importtype_vec_copy(out wasm_importtype_vec_t vec, ref wasm_importtype_vec_t src);
@@ -786,7 +786,7 @@ namespace Wasmtime
         public static extern void wasm_exporttype_vec_new_uninitialized(out wasm_exporttype_vec_t vec, UIntPtr length);
 
         [DllImport(LibraryName)]
-        public static extern void wasm_exporttype_vec_new(out wasm_exporttype_vec_t vec, UIntPtr length, IntPtr[] data);
+        public static unsafe extern void wasm_exporttype_vec_new(out wasm_exporttype_vec_t vec, UIntPtr length, IntPtr* data);
 
         [DllImport(LibraryName)]
         public static extern void wasm_exporttype_vec_copy(out wasm_exporttype_vec_t vec, ref wasm_exporttype_vec_t src);
@@ -917,7 +917,7 @@ namespace Wasmtime
         // Instance imports
 
         [DllImport(LibraryName)]
-        public static extern unsafe InstanceHandle wasm_instance_new(StoreHandle store, ModuleHandle module, IntPtr[] imports, out IntPtr trap);
+        public static extern unsafe InstanceHandle wasm_instance_new(StoreHandle store, ModuleHandle module, IntPtr* imports, out IntPtr trap);
 
         [DllImport(LibraryName)]
         public static extern void wasm_instance_delete(IntPtr ext);
@@ -1094,7 +1094,7 @@ namespace Wasmtime
         public static extern void wasi_config_delete(IntPtr config);
 
         [DllImport(LibraryName)]
-        public unsafe static extern void wasi_config_set_argv(WasiConfigHandle config, int argc, byte*[] argv);
+        public unsafe static extern void wasi_config_set_argv(WasiConfigHandle config, int argc, byte** argv);
 
         [DllImport(LibraryName)]
         public static extern void wasi_config_inherit_argv(WasiConfigHandle config);

--- a/src/Module.cs
+++ b/src/Module.cs
@@ -33,7 +33,7 @@ namespace Wasmtime
         /// <param name="name">The name of the module.</param>
         /// <param name="bytes">The bytes of the module.</param>
         /// <returns>Returns a new <see cref="Module"/>.</returns>
-        public static Module FromBytes(Engine engine, string name, byte[] bytes)
+        public static Module FromBytes(Engine engine, string name, ReadOnlySpan<byte> bytes)
         {
             if (engine is null)
             {
@@ -43,11 +43,6 @@ namespace Wasmtime
             if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentNullException(nameof(name));
-            }
-
-            if (bytes is null)
-            {
-                throw new ArgumentNullException(nameof(bytes));
             }
 
             return new Module(engine.Handle, name, bytes);
@@ -192,7 +187,7 @@ namespace Wasmtime
             }
         }
 
-        internal Module(Interop.EngineHandle engine, string name, byte[] bytes)
+        internal Module(Interop.EngineHandle engine, string name, ReadOnlySpan<byte> bytes)
         {
             unsafe
             {

--- a/src/WasiConfiguration.cs
+++ b/src/WasiConfiguration.cs
@@ -49,10 +49,7 @@ namespace Wasmtime
                 _inheritArgs = false;
             }
 
-            foreach (var arg in args)
-            {
-                _args.Add(arg);
-            }
+            _args.AddRange(args);
             return this;
         }
 

--- a/src/WasiConfiguration.cs
+++ b/src/WasiConfiguration.cs
@@ -66,6 +66,28 @@ namespace Wasmtime
             return WithArgs((IEnumerable<string>)args);
         }
 
+        // TODO: remove overload when https://github.com/dotnet/csharplang/issues/1757 is resolved
+        /// <summary>
+        /// Adds multiple command line arguments to the configuration.
+        /// </summary>
+        /// <param name="args">The command line arguments to add.</param>
+        /// <returns>Returns the current configuration.</returns>
+        public WasiConfiguration WithArgs(ReadOnlySpan<string> args)
+        {
+            if (_inheritArgs)
+            {
+                _args.Clear();
+                _inheritArgs = false;
+            }
+
+            // TODO: use AddRange when https://github.com/dotnet/runtime/issues/1530 is resolved
+            foreach (var arg in args)
+            {
+                _args.Add(arg);
+            }
+            return this;
+        }
+
         /// <summary>
         /// Sets the configuration to inherit command line arguments.
         /// </summary>

--- a/src/WasiConfiguration.cs
+++ b/src/WasiConfiguration.cs
@@ -308,7 +308,10 @@ namespace Wasmtime
 
             try
             {
-                Interop.wasi_config_set_argv(config, _args.Count, args);
+                fixed (byte** arrayOfStringsPtrNamedArgs = args)
+                {
+                    Interop.wasi_config_set_argv(config, _args.Count, arrayOfStringsPtrNamedArgs);
+                }
             }
             finally
             {


### PR DESCRIPTION
In 2018, Span<T> and its friends were added to C#. This allowed developers to wrap various kinds of contiguous memory buffers (arrays, pointers, others) into a single data type. Its ability to slice allowed developers to very ergonomically prevent copying data, in a .NET way. This PR overhauls the existing public API to make use of Span<T> and friends.

For `Interop.InvokeCallback`, I would like feedback on why the object array was being allocated outside the invocation. This PR may need more inspection on that front, but for me on Windows all the tests pass.

In addition, DLL imports from the Interop class were modified from arrays to pointers, as it's a more "universal" datatype and understood the exact same. You can convert arrays into pointers easily, but you can't convert stackalloc'd or other pointers into an array easily. I would like feedback on this change as well.