### PR TITLE
Implement module linking. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,19 +53,10 @@ jobs:
       if: matrix.config == 'release'
       run: dotnet run -c ${{ matrix.config }} --project benchmarks/simple/simple.csproj
     - name: Run examples
+      env:
+        EXAMPLES: externref funcref global hello linking memory table
       run: |
-        cd examples/hello
-        dotnet run
-        cd ../global
-        dotnet run
-        cd ../memory
-        dotnet run
-        cd ../table
-        dotnet run
-        cd ../externref
-        dotnet run
-        cd ../funcref
-        dotnet run
+        for e in $EXAMPLES; do cd examples/$e && dotnet run && cd ../..; done
     - name: Create package
       run: |
         cd src

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">true</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">0.21.0</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">0.22.0</WasmtimeVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)-preview1-dev</WasmtimePackageVersion>
     <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">$(WasmtimeVersion)-preview1</WasmtimePackageVersion>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Installation
 
-You can add a package reference with the [.NET Core SDK](https://dotnet.microsoft.com/):
+You can add a package reference with the [.NET SDK](https://dotnet.microsoft.com/):
 
 ```text
 $ dotnet add package --version 0.22.0-preview1 wasmtime

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 You can add a package reference with the [.NET Core SDK](https://dotnet.microsoft.com/):
 
 ```text
-$ dotnet add package --version 0.21.0-preview1 wasmtime
+$ dotnet add package --version 0.22.0-preview1 wasmtime
 ```
 
 _Note that the `--version` option is required because the package is currently prerelease._
@@ -54,7 +54,7 @@ $ dotnet new console
 Next, add a reference to the [Wasmtime package](https://www.nuget.org/packages/Wasmtime):
 
 ```
-$ dotnet add package --version 0.21.0-preview1 wasmtime
+$ dotnet add package --version 0.22.0-preview1 wasmtime
 ```
 
 Replace the contents of `Program.cs` with the following code:

--- a/benchmarks/simple/simple.csproj
+++ b/benchmarks/simple/simple.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/articles/intro.md
+++ b/docs/articles/intro.md
@@ -4,7 +4,7 @@
 
 The [.NET embedding of Wasmtime](https://github.com/bytecodealliance/wasmtime-dotnet) enables .NET developers to easily instantiate and execute WebAssembly modules using Wasmtime.
 
-For this tutorial, we will create a WebAssembly module and use that WebAssembly module from a .NET Core 3.1 application.
+For this tutorial, we will create a WebAssembly module and use that WebAssembly module from a .NET 5 application.
 
 # A simple WebAssembly module
 
@@ -23,13 +23,13 @@ This module simply imports a `hello` function from the host and exports a `run` 
 
 # Using the WebAssembly module from .NET
 
-## Installing a .NET Core 3.0 SDK
+## Installing a .NET 5 SDK
 
-Install a [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1) for your platform if you haven't already.
+Install a [.NET 5 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) for your platform if you haven't already.
 
 This will add a `dotnet` command to your PATH.
 
-## Creating the .NET Core project
+## Creating the .NET project
 
 The .NET program will be a simple console application, so create a new console project with `dotnet new`:
 
@@ -100,7 +100,7 @@ Use `dotnet build` to build the .NET application:
 dotnet build
 ```
 
-This will create a `tutorial` (or `tutorial.exe` on Windows) executable in the `bin/Debug/netcoreapp3.1` directory that implements the .NET Core application.
+This will create a `tutorial` (or `tutorial.exe` on Windows) executable in the `bin/Debug/net5.0` directory that implements the .NET application.
 
 ## Running the .NET application
  

--- a/docs/articles/intro.md
+++ b/docs/articles/intro.md
@@ -44,7 +44,7 @@ dotnet new console
 To use the .NET embedding of Wasmtime from the project, we need to add a reference to the [Wasmtime NuGet package](https://www.nuget.org/packages/Wasmtime):
 
 ```text
-dotnet add package --version 0.21.0-preview1 wasmtime
+dotnet add package --version 0.22.0-preview1 wasmtime
 ```
 
 _Note that the `--version` option is required because the package is currently prerelease._

--- a/examples/externref/externref.csproj
+++ b/examples/externref/externref.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/funcref/funcref.csproj
+++ b/examples/funcref/funcref.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/global/Program.cs
+++ b/examples/global/Program.cs
@@ -16,7 +16,8 @@ namespace Example
             using var function = host.DefineFunction(
                 "",
                 "print_global",
-                () => {
+                () =>
+                {
                     Console.WriteLine($"The value of the global is: {global.Value}.");
                 }
             );

--- a/examples/global/global.csproj
+++ b/examples/global/global.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/hello/hello.csproj
+++ b/examples/hello/hello.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/linking/Program.cs
+++ b/examples/linking/Program.cs
@@ -1,0 +1,30 @@
+using System;
+using Wasmtime;
+
+namespace Example
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            using var engine = new EngineBuilder().WithModuleLinking(true).Build();
+            using var module = Module.FromTextFile(engine, "name.wat");
+            using var program = Module.FromTextFile(engine, "program.wat");
+            
+            using var store = new Store(engine);
+            using var host = new Host(store);
+
+            using var memory = host.DefineMemory("", "mem");
+
+            host.DefineInstance("", "inst", module.Instantiate(store, memory));
+
+            host.DefineFunction("", "print", (Caller caller, int addr, int len) => {
+                Console.WriteLine(caller.GetMemory("mem").ReadString(addr, len));
+            });
+
+            using dynamic instance = host.Instantiate(program);
+            
+            instance.run();
+        }
+    }
+}

--- a/examples/linking/Program.cs
+++ b/examples/linking/Program.cs
@@ -10,7 +10,7 @@ namespace Example
             using var engine = new EngineBuilder().WithModuleLinking(true).Build();
             using var module = Module.FromTextFile(engine, "name.wat");
             using var program = Module.FromTextFile(engine, "program.wat");
-            
+
             using var store = new Store(engine);
             using var host = new Host(store);
 
@@ -18,12 +18,13 @@ namespace Example
 
             host.DefineInstance("", "inst", module.Instantiate(store, memory));
 
-            host.DefineFunction("", "print", (Caller caller, int addr, int len) => {
+            host.DefineFunction("", "print", (Caller caller, int addr, int len) =>
+            {
                 Console.WriteLine(caller.GetMemory("mem").ReadString(addr, len));
             });
 
             using dynamic instance = host.Instantiate(program);
-            
+
             instance.run();
         }
     }

--- a/examples/linking/linking.csproj
+++ b/examples/linking/linking.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wasmtime.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/linking/name.wat
+++ b/examples/linking/name.wat
@@ -1,0 +1,21 @@
+(module
+  (import "" "mem" (memory 1))
+  (func $name (export "write") (param i32) (result i32)
+    local.get 0
+    i32.const 119 ;;; w
+    i32.store offset=0 align=1
+    local.get 0
+    i32.const 111 ;;; o
+    i32.store offset=1 align=1
+    local.get 0
+    i32.const 114 ;;; r
+    i32.store offset=2 align=1
+    local.get 0
+    i32.const 108 ;;; l
+    i32.store offset=3 align=1
+    local.get 0
+    i32.const 100 ;;; d
+    i32.store offset=4 align=1
+    i32.const 5
+  )
+)

--- a/examples/linking/program.wat
+++ b/examples/linking/program.wat
@@ -1,0 +1,21 @@
+(module
+  (import "" "print" (func $print (param i32 i32)))
+  (import "" "inst" (instance $inst (export "write" (func $write (param i32) (result i32)))))
+  (import "" "mem" (memory 1))
+  (export "mem" (memory 0))
+  (func (export "run") (local i32)
+    i32.const 6
+    call $inst.$write
+    i32.const 6
+    i32.add
+    local.tee 0
+    i32.const 33 ;;; !
+    i32.store align=1
+    i32.const 0
+    local.get 0
+    i32.const 1
+    i32.add
+    call $print
+  )
+  (data (i32.const 0) "Hello ")
+)

--- a/examples/memory/Program.cs
+++ b/examples/memory/Program.cs
@@ -14,7 +14,8 @@ namespace Example
             using var function = host.DefineFunction(
                 "",
                 "log",
-                (Caller caller, int address, int length) => {
+                (Caller caller, int address, int length) =>
+                {
                     var message = caller.GetMemory("mem").ReadString(address, length);
                     Console.WriteLine($"Message from WebAssembly: {message}");
                 }

--- a/examples/memory/memory.csproj
+++ b/examples/memory/memory.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/table/table.csproj
+++ b/examples/table/table.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EngineBuilder.cs
+++ b/src/EngineBuilder.cs
@@ -178,6 +178,12 @@ namespace Wasmtime
             return this;
         }
 
+        public EngineBuilder WithModuleLinking(bool enable)
+        {
+            _enableModuleLinking = enable;
+            return this;
+        }
+
         /// <summary>
         /// Builds the <see cref="Engine" /> instance.
         /// </summary>
@@ -216,6 +222,11 @@ namespace Wasmtime
                 Interop.wasmtime_config_wasm_multi_value_set(config, _enableMultiValue.Value);
             }
 
+            if (_enableModuleLinking.HasValue)
+            {
+                Interop.wasmtime_config_wasm_module_linking_set(config, _enableModuleLinking.Value);
+            }
+
             if (_strategy.HasValue)
             {
                 Interop.wasmtime_config_strategy_set(config, _strategy.Value);
@@ -240,6 +251,7 @@ namespace Wasmtime
         private bool? _enableSIMD;
         private bool? _enableBulkMemory;
         private bool? _enableMultiValue;
+        private bool? _enableModuleLinking;
         private Interop.wasmtime_strategy_t? _strategy;
         private bool? _enableCraneliftDebugVerifier;
         private Interop.wasmtime_opt_level_t? _optLevel;

--- a/src/Exports/Export.cs
+++ b/src/Exports/Export.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Wasmtime.Exports
 {
     /// <summary>
-    /// Represents an export of a WebAssembly module.
+    /// Represents an export of a WebAssembly module or instance.
     /// </summary>
     public abstract class Export
     {

--- a/src/Exports/Export.cs
+++ b/src/Exports/Export.cs
@@ -13,7 +13,14 @@ namespace Wasmtime.Exports
             unsafe
             {
                 var name = Interop.wasm_exporttype_name(exportType);
-                Name = Marshal.PtrToStringUTF8((IntPtr)name->data, (int)name->size);
+                if (name->size == UIntPtr.Zero)
+                {
+                    Name = String.Empty;
+                }
+                else
+                {
+                    Name = Marshal.PtrToStringUTF8((IntPtr)name->data, (int)name->size);
+                }
             }
         }
 

--- a/src/Exports/Exports.cs
+++ b/src/Exports/Exports.cs
@@ -4,93 +4,109 @@ using System.Collections.Generic;
 namespace Wasmtime.Exports
 {
     /// <summary>
-    /// Represents the exports of a WebAssembly module.
+    /// Represents the exports of a WebAssembly module or instance.
     /// </summary>
     public class Exports
     {
-        internal Exports(Module module)
+        internal Exports(Interop.wasm_exporttype_vec_t exports)
         {
-            Interop.wasm_exporttype_vec_t exports;
-            Interop.wasm_module_exports(module.Handle, out exports);
+            var all = new List<Export>((int)exports.size);
+            var functions = new List<FunctionExport>();
+            var globals = new List<GlobalExport>();
+            var tables = new List<TableExport>();
+            var memories = new List<MemoryExport>();
+            var instances = new List<InstanceExport>();
+            var modules = new List<ModuleExport>();
 
-            try
+            for (int i = 0; i < (int)exports.size; ++i)
             {
-                var all = new List<Export>((int)exports.size);
-                var functions = new List<FunctionExport>();
-                var globals = new List<GlobalExport>();
-                var tables = new List<TableExport>();
-                var memories = new List<MemoryExport>();
-
-                for (int i = 0; i < (int)exports.size; ++i)
+                unsafe
                 {
-                    unsafe
+                    var exportType = exports.data[i];
+                    var externType = Interop.wasm_exporttype_type(exportType);
+
+                    switch (Interop.wasm_externtype_kind(externType))
                     {
-                        var exportType = exports.data[i];
-                        var externType = Interop.wasm_exporttype_type(exportType);
+                        case Interop.wasm_externkind_t.WASM_EXTERN_FUNC:
+                            var function = new FunctionExport(exportType, externType);
+                            functions.Add(function);
+                            all.Add(function);
+                            break;
 
-                        switch (Interop.wasm_externtype_kind(externType))
-                        {
-                            case Interop.wasm_externkind_t.WASM_EXTERN_FUNC:
-                                var function = new FunctionExport(exportType, externType);
-                                functions.Add(function);
-                                all.Add(function);
-                                break;
+                        case Interop.wasm_externkind_t.WASM_EXTERN_GLOBAL:
+                            var global = new GlobalExport(exportType, externType);
+                            globals.Add(global);
+                            all.Add(global);
+                            break;
 
-                            case Interop.wasm_externkind_t.WASM_EXTERN_GLOBAL:
-                                var global = new GlobalExport(exportType, externType);
-                                globals.Add(global);
-                                all.Add(global);
-                                break;
+                        case Interop.wasm_externkind_t.WASM_EXTERN_TABLE:
+                            var table = new TableExport(exportType, externType);
+                            tables.Add(table);
+                            all.Add(table);
+                            break;
 
-                            case Interop.wasm_externkind_t.WASM_EXTERN_TABLE:
-                                var table = new TableExport(exportType, externType);
-                                tables.Add(table);
-                                all.Add(table);
-                                break;
+                        case Interop.wasm_externkind_t.WASM_EXTERN_MEMORY:
+                            var memory = new MemoryExport(exportType, externType);
+                            memories.Add(memory);
+                            all.Add(memory);
+                            break;
 
-                            case Interop.wasm_externkind_t.WASM_EXTERN_MEMORY:
-                                var memory = new MemoryExport(exportType, externType);
-                                memories.Add(memory);
-                                all.Add(memory);
-                                break;
+                        case Interop.wasm_externkind_t.WASM_EXTERN_INSTANCE:
+                            var instance = new InstanceExport(exportType, externType);
+                            instances.Add(instance);
+                            all.Add(instance);
+                            break;
 
-                            default:
-                                throw new NotSupportedException("Unsupported export extern type.");
-                        }
+                        case Interop.wasm_externkind_t.WASM_EXTERN_MODULE:
+                            var module = new ModuleExport(exportType, externType);
+                            modules.Add(module);
+                            all.Add(module);
+                            break;
+
+                        default:
+                            throw new NotSupportedException("Unsupported export extern type.");
                     }
                 }
+            }
 
-                Functions = functions;
-                Globals = globals;
-                Tables = tables;
-                Memories = memories;
-                All = all;
-            }
-            finally
-            {
-                Interop.wasm_exporttype_vec_delete(ref exports);
-            }
+            Functions = functions;
+            Globals = globals;
+            Tables = tables;
+            Memories = memories;
+            Instances = instances;
+            Modules = modules;
+            All = all;
         }
 
         /// <summary>
-        /// The exported functions of a WebAssembly module.
+        /// The exported functions of a WebAssembly module or instance.
         /// </summary>
         public IReadOnlyList<FunctionExport> Functions { get; private set; }
 
         /// <summary>
-        /// The exported globals of a WebAssembly module.
+        /// The exported globals of a WebAssembly module or instance.
         /// </summary>
         public IReadOnlyList<GlobalExport> Globals { get; private set; }
 
         /// <summary>
-        /// The exported tables of a WebAssembly module.
+        /// The exported tables of a WebAssembly module or instance.
         /// </summary>
         public IReadOnlyList<TableExport> Tables { get; private set; }
 
         /// <summary>
-        /// The exported memories of a WebAssembly module.
+        /// The exported memories of a WebAssembly module or instance.
         /// </summary>
         public IReadOnlyList<MemoryExport> Memories { get; private set; }
+
+        /// <summary>
+        /// The exported instances of a WebAssembly module or instance.
+        /// </summary>
+        public IReadOnlyList<InstanceExport> Instances { get; private set; }
+
+        /// <summary>
+        /// The exported modules of a WebAssembly module or instance.
+        /// </summary>
+        public IReadOnlyList<ModuleExport> Modules { get; private set; }
 
         internal List<Export> All { get; private set; }
     }

--- a/src/Exports/FunctionExport.cs
+++ b/src/Exports/FunctionExport.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 namespace Wasmtime.Exports
 {
     /// <summary>
-    /// Represents a function exported from a WebAssembly module.
+    /// Represents a function exported from a WebAssembly module or instance.
     /// </summary>
     public class FunctionExport : Export
     {

--- a/src/Exports/GlobalExport.cs
+++ b/src/Exports/GlobalExport.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 namespace Wasmtime.Exports
 {
     /// <summary>
-    /// Represents a global variable exported from a WebAssembly module.
+    /// Represents a global variable exported from a WebAssembly module or instance.
     /// </summary>
     public class GlobalExport : Export
     {

--- a/src/Exports/InstanceExport.cs
+++ b/src/Exports/InstanceExport.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Diagnostics;
+
+namespace Wasmtime.Exports
+{
+    /// <summary>
+    /// Represents an instance exported from a WebAssembly module or instance.
+    /// </summary>
+    public class InstanceExport : Export
+    {
+        internal InstanceExport(IntPtr exportType, IntPtr externType) : base(exportType)
+        {
+            Debug.Assert(Interop.wasm_externtype_kind(externType) == Interop.wasm_externkind_t.WASM_EXTERN_INSTANCE);
+
+            var instanceType = Interop.wasm_externtype_as_instancetype_const(externType);
+
+            Interop.wasm_exporttype_vec_t exports;
+            Interop.wasm_instancetype_exports(instanceType, out exports);
+
+            try
+            {
+                Exports = new Exports(exports);
+            }
+            finally
+            {
+                Interop.wasm_exporttype_vec_delete(ref exports);
+            }
+        }
+
+        /// <summary>
+        /// The exports of the instance.
+        /// </summary>
+        public Exports Exports { get; private set; }
+    }
+}

--- a/src/Exports/MemoryExport.cs
+++ b/src/Exports/MemoryExport.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 namespace Wasmtime.Exports
 {
     /// <summary>
-    /// Represents a memory exported from a WebAssembly module.
+    /// Represents a memory exported from a WebAssembly module or instance.
     /// </summary>
     public class MemoryExport : Export
     {

--- a/src/Exports/ModuleExport.cs
+++ b/src/Exports/ModuleExport.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Diagnostics;
+
+namespace Wasmtime.Exports
+{
+    /// <summary>
+    /// Represents a module exported from a WebAssembly module or instance.
+    /// </summary>
+    public class ModuleExport : Export
+    {
+        internal ModuleExport(IntPtr exportType, IntPtr externType) : base(exportType)
+        {
+            Debug.Assert(Interop.wasm_externtype_kind(externType) == Interop.wasm_externkind_t.WASM_EXTERN_MODULE);
+
+            var moduleType = Interop.wasm_externtype_as_moduletype_const(externType);
+
+            Interop.wasm_importtype_vec_t imports;
+            Interop.wasm_moduletype_imports(moduleType, out imports);
+
+            try
+            {
+                Imports = new Imports.Imports(imports);
+            }
+            finally
+            {
+                Interop.wasm_importtype_vec_delete(ref imports);
+            }
+
+            Interop.wasm_exporttype_vec_t exports;
+            Interop.wasm_moduletype_exports(moduleType, out exports);
+
+            try
+            {
+                Exports = new Exports(exports);
+            }
+            finally
+            {
+                Interop.wasm_exporttype_vec_delete(ref exports);
+            }
+        }
+
+        /// <summary>
+        /// The imports of the module.
+        /// </summary>
+        public Imports.Imports Imports { get; private set; }
+
+        /// <summary>
+        /// The exports of the module.
+        /// </summary>
+        public Exports Exports { get; private set; }
+    }
+}

--- a/src/Exports/TableExport.cs
+++ b/src/Exports/TableExport.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 namespace Wasmtime.Exports
 {
     /// <summary>
-    /// Represents a table exported from a WebAssembly module.
+    /// Represents a table exported from a WebAssembly module or instance.
     /// </summary>
     public class TableExport : Export
     {

--- a/src/Externs/ExternFunction.cs
+++ b/src/Externs/ExternFunction.cs
@@ -5,9 +5,9 @@ using Wasmtime.Exports;
 namespace Wasmtime.Externs
 {
     /// <summary>
-    /// Represents an external (instantiated) WebAssembly function.
+    /// Represents an external WebAssembly function.
     /// </summary>
-    public class ExternFunction
+    public class ExternFunction : IImportable
     {
         internal ExternFunction(FunctionExport export, IntPtr func)
         {
@@ -57,6 +57,11 @@ namespace Wasmtime.Externs
         public object? Invoke(ReadOnlySpan<object?> arguments)
         {
             return Function.Invoke(_func, Parameters, Results, arguments);
+        }
+
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_func_as_extern(_func);
         }
 
         private FunctionExport _export;

--- a/src/Externs/ExternGlobal.cs
+++ b/src/Externs/ExternGlobal.cs
@@ -4,9 +4,9 @@ using Wasmtime.Exports;
 namespace Wasmtime.Externs
 {
     /// <summary>
-    /// Represents an external (instantiated) WebAssembly global.
+    /// Represents an external WebAssembly global.
     /// </summary>
-    public class ExternGlobal
+    public class ExternGlobal : IImportable
     {
         internal ExternGlobal(GlobalExport export, IntPtr global)
         {
@@ -54,6 +54,11 @@ namespace Wasmtime.Externs
                     Interop.DeleteValue(&v);
                 }
             }
+        }
+
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_global_as_extern(_global);
         }
 
         private GlobalExport _export;

--- a/src/Externs/ExternMemory.cs
+++ b/src/Externs/ExternMemory.cs
@@ -4,14 +4,19 @@ using Wasmtime.Exports;
 namespace Wasmtime.Externs
 {
     /// <summary>
-    /// Represents an external (instantiated) WebAssembly memory.
+    /// Represents an external WebAssembly memory.
     /// </summary>
-    public class ExternMemory : MemoryBase
+    public class ExternMemory : MemoryBase, IImportable
     {
         internal ExternMemory(MemoryExport export, IntPtr memory)
         {
             _export = export;
             _memory = memory;
+        }
+
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_memory_as_extern(_memory);
         }
 
         /// <summary>

--- a/src/Externs/ExternModule.cs
+++ b/src/Externs/ExternModule.cs
@@ -1,0 +1,110 @@
+using System;
+using Wasmtime.Exports;
+
+namespace Wasmtime.Externs
+{
+    /// <summary>
+    /// Represents an external WebAssembly module.
+    /// </summary>
+    public class ExternModule : IImportable
+    {
+        /// <summary>
+        /// The imports of the module.
+        /// </summary>
+        public Wasmtime.Imports.Imports Imports { get; private set; }
+
+        /// <summary>
+        /// The exports of the module.
+        /// </summary>
+        /// <value></value>
+        public Wasmtime.Exports.Exports Exports { get; private set; }
+
+        /// <summary>
+        /// Instantiates the module given a set of imports.
+        /// </summary>
+        /// <param name="store">The store to associate with the instance.</param>
+        /// <param name="imports">The imports to use for the instantiations.</param>
+        /// <returns>Returns a new <see cref="Instance"/>.</returns>
+        public Instance Instantiate(Store store, params IImportable[] imports)
+        {
+            if (store is null)
+            {
+                throw new ArgumentNullException(nameof(store));
+            }
+
+            if (imports is null)
+            {
+                throw new ArgumentNullException(nameof(imports));
+            }
+
+            unsafe
+            {
+                IntPtr* handles = stackalloc IntPtr[imports.Length];
+
+                for (int i = 0; i < imports.Length; ++i)
+                {
+                    unsafe
+                    {
+                        handles[i] = imports[i].GetHandle();
+                    }
+                }
+
+                var error = Interop.wasmtime_instance_new(store.Handle, _module, handles, (UIntPtr)imports.Length, out var instance, out var trap);
+
+                if (error != IntPtr.Zero)
+                {
+                    throw WasmtimeException.FromOwnedError(error);
+                }
+                if (trap != IntPtr.Zero)
+                {
+                    throw TrapException.FromOwnedTrap(trap);
+                }
+
+                return new Instance(instance, _module);
+            }
+        }
+
+        internal ExternModule(ModuleExport export, IntPtr module)
+        {
+            _export = export;
+            _module = module;
+
+            Interop.wasm_importtype_vec_t imports;
+            Interop.wasm_module_imports(_module, out imports);
+
+            try
+            {
+                Imports = new Wasmtime.Imports.Imports(imports);
+            }
+            finally
+            {
+                Interop.wasm_importtype_vec_delete(ref imports);
+            }
+
+            Interop.wasm_exporttype_vec_t exports;
+            Interop.wasm_module_exports(_module, out exports);
+
+            try
+            {
+                Exports = new Wasmtime.Exports.Exports(exports);
+            }
+            finally
+            {
+                Interop.wasm_exporttype_vec_delete(ref exports);
+            }
+        }
+
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_module_as_extern(_module);
+        }
+
+        /// <summary>
+        /// The name of the WebAssembly module.
+        /// </summary>
+        public string Name => _export.Name;
+
+        private ModuleExport _export;
+        private IntPtr _module;
+    }
+}

--- a/src/Externs/ExternTable.cs
+++ b/src/Externs/ExternTable.cs
@@ -4,14 +4,19 @@ using Wasmtime.Exports;
 namespace Wasmtime.Externs
 {
     /// <summary>
-    /// Represents an external (instantiated) WebAssembly table.
+    /// Represents an external WebAssembly table.
     /// </summary>
-    public class ExternTable
+    public class ExternTable : IImportable
     {
         internal ExternTable(TableExport export, IntPtr table)
         {
             _export = export;
             _table = table;
+        }
+
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_table_as_extern(_table);
         }
 
         /// <summary>

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -11,7 +11,7 @@ namespace Wasmtime
     /// <summary>
     /// Represents a WebAsssembly function.
     /// </summary>
-    public class Function : IDisposable
+    public class Function : IDisposable, IImportable
     {
         /// <summary>
         /// Creates a function given a callback.
@@ -592,6 +592,11 @@ namespace Wasmtime
                 Handle.Dispose();
                 Handle.SetHandleAsInvalid();
             }
+        }
+
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_func_as_extern(Handle.DangerousGetHandle());
         }
 
         internal static object? Invoke(IntPtr func, IReadOnlyList<ValueKind> funcParameters, IReadOnlyList<ValueKind> funcResults, ReadOnlySpan<object?> arguments)

--- a/src/Global.cs
+++ b/src/Global.cs
@@ -6,7 +6,7 @@ namespace Wasmtime
     /// <summary>
     /// Represents a constant WebAssembly global value.
     /// </summary>
-    public class Global<T> : IDisposable
+    public class Global<T> : IDisposable, IImportable
     {
         /// <summary>
         /// The value of the global.
@@ -41,6 +41,11 @@ namespace Wasmtime
                 Handle.Dispose();
                 Handle.SetHandleAsInvalid();
             }
+        }
+
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_global_as_extern(Handle.DangerousGetHandle());
         }
 
         internal Global(Interop.StoreHandle store, T initialValue)

--- a/src/Imports/Import.cs
+++ b/src/Imports/Import.cs
@@ -15,10 +15,24 @@ namespace Wasmtime.Imports
                 Handle = importType;
 
                 var moduleName = Interop.wasm_importtype_module(Handle);
-                ModuleName = Marshal.PtrToStringUTF8((IntPtr)moduleName->data, (int)moduleName->size);
+                if (moduleName->size == UIntPtr.Zero)
+                {
+                    ModuleName = String.Empty;
+                }
+                else
+                {
+                    ModuleName = Marshal.PtrToStringUTF8((IntPtr)moduleName->data, (int)moduleName->size);
+                }
 
                 var name = Interop.wasm_importtype_name(Handle);
-                Name = Marshal.PtrToStringUTF8((IntPtr)name->data, (int)name->size);
+                if (name is null || name->size == UIntPtr.Zero)
+                {
+                    Name = String.Empty;
+                }
+                else
+                {
+                    Name = Marshal.PtrToStringUTF8((IntPtr)name->data, (int)name->size);
+                }
             }
         }
 

--- a/src/Imports/InstanceImport.cs
+++ b/src/Imports/InstanceImport.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Diagnostics;
+
+namespace Wasmtime.Imports
+{
+    /// <summary>
+    /// Represents an instance imported to a WebAssembly module.
+    /// </summary>
+    public class InstanceImport : Import
+    {
+        internal InstanceImport(IntPtr importType, IntPtr externType) : base(importType)
+        {
+            Debug.Assert(Interop.wasm_externtype_kind(externType) == Interop.wasm_externkind_t.WASM_EXTERN_INSTANCE);
+
+            var instanceType = Interop.wasm_externtype_as_instancetype_const(externType);
+
+            Interop.wasm_exporttype_vec_t exports;
+            Interop.wasm_instancetype_exports(instanceType, out exports);
+
+            try
+            {
+                Exports = new Exports.Exports(exports);
+            }
+            finally
+            {
+                Interop.wasm_exporttype_vec_delete(ref exports);
+            }
+        }
+
+        /// <summary>
+        /// The exports of the instance.
+        /// </summary>
+        public Exports.Exports Exports { get; private set; }
+    }
+}

--- a/src/Imports/ModuleImport.cs
+++ b/src/Imports/ModuleImport.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Diagnostics;
+
+namespace Wasmtime.Imports
+{
+    /// <summary>
+    /// Represents a module imported to a WebAssembly module.
+    /// </summary>
+    public class ModuleImport : Import
+    {
+        internal ModuleImport(IntPtr importType, IntPtr externType) : base(importType)
+        {
+            Debug.Assert(Interop.wasm_externtype_kind(externType) == Interop.wasm_externkind_t.WASM_EXTERN_MODULE);
+
+            var moduleType = Interop.wasm_externtype_as_moduletype_const(externType);
+
+            Interop.wasm_importtype_vec_t imports;
+            Interop.wasm_moduletype_imports(moduleType, out imports);
+
+            try
+            {
+                Imports = new Imports(imports);
+            }
+            finally
+            {
+                Interop.wasm_importtype_vec_delete(ref imports);
+            }
+
+            Interop.wasm_exporttype_vec_t exports;
+            Interop.wasm_moduletype_exports(moduleType, out exports);
+
+            try
+            {
+                Exports = new Exports.Exports(exports);
+            }
+            finally
+            {
+                Interop.wasm_exporttype_vec_delete(ref exports);
+            }
+        }
+
+        /// <summary>
+        /// The imports of the module.
+        /// </summary>
+        public Imports Imports { get; private set; }
+
+        /// <summary>
+        /// The exports of the module.
+        /// </summary>
+        public Exports.Exports Exports { get; private set; }
+    }
+}

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -5,7 +5,7 @@ namespace Wasmtime
     /// <summary>
     /// Represents a WebAssembly memory.
     /// </summary>
-    public class Memory : MemoryBase, IDisposable
+    public class Memory : MemoryBase, IDisposable, IImportable
     {
         /// <summary>
         /// The size, in bytes, of a WebAssembly memory page.
@@ -30,6 +30,11 @@ namespace Wasmtime
                 Handle.Dispose();
                 Handle.SetHandleAsInvalid();
             }
+        }
+
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_memory_as_extern(Handle.DangerousGetHandle());
         }
 
         internal Memory(Interop.StoreHandle store, uint minimum = 1, uint maximum = uint.MaxValue)

--- a/src/MemoryBase.cs
+++ b/src/MemoryBase.cs
@@ -7,6 +7,11 @@ namespace Wasmtime
     public abstract class MemoryBase
     {
         /// <summary>
+        /// The current size, in WebAssembly page units, of the memory.
+        /// </summary>
+        public uint Size => Interop.wasm_memory_size(MemoryHandle);
+
+        /// <summary>
         /// The span of the memory.
         /// </summary>
         /// <remarks>
@@ -229,6 +234,16 @@ namespace Wasmtime
             {
                 WriteInt64(address, *(long*)&value);
             }
+        }
+
+        /// <summary>
+        /// Grows the memory by the specified number of pages.
+        /// </summary>
+        /// <param name="delta">The number of WebAssembly pages to grow the memory by.</param>
+        /// <returns>Returns true if the memory grew or false if it would exceed the maximum size.</returns>
+        public bool Grow(uint delta)
+        {
+            return Interop.wasm_memory_grow(MemoryHandle, delta);
         }
 
         protected abstract IntPtr MemoryHandle { get; }

--- a/src/Module.cs
+++ b/src/Module.cs
@@ -15,6 +15,7 @@ namespace Wasmtime
         /// </summary>
         /// <remarks>
         /// This interface is internal to Wasmtime and not intended to be implemented by users.
+        /// </remarks>
         /// <returns>Returns the extern handle for the importable.</returns>
         IntPtr GetHandle();
     }

--- a/src/Module.cs
+++ b/src/Module.cs
@@ -6,9 +6,23 @@ using System.Text;
 namespace Wasmtime
 {
     /// <summary>
+    /// Implemented by types that can be imported by WebAssembly modules.
+    /// </summary>
+    public interface IImportable
+    {
+        /// <summary>
+        /// Gets the extern handle for the importable.
+        /// </summary>
+        /// <remarks>
+        /// This interface is internal to Wasmtime and not intended to be implemented by users.
+        /// <returns>Returns the extern handle for the importable.</returns>
+        IntPtr GetHandle();
+    }
+
+    /// <summary>
     /// Represents a WebAssembly module.
     /// </summary>
-    public class Module : IDisposable
+    public class Module : IDisposable, IImportable
     {
         /// <summary>
         /// The name of the module.
@@ -168,6 +182,51 @@ namespace Wasmtime
             return FromText(engine, name, reader.ReadToEnd());
         }
 
+        /// <summary>
+        /// Instantiates a <see cref="Module"/> given a set of imports.
+        /// </summary>
+        /// <param name="store">The store to associate with the instance.</param>
+        /// <param name="imports">The imports to use for the instantiations.</param>
+        /// <returns>Returns a new <see cref="Instance"/>.</returns>
+        public Instance Instantiate(Store store, params IImportable[] imports)
+        {
+            if (store is null)
+            {
+                throw new ArgumentNullException(nameof(store));
+            }
+
+            if (imports is null)
+            {
+                throw new ArgumentNullException(nameof(imports));
+            }
+
+            unsafe
+            {
+                IntPtr* handles = stackalloc IntPtr[imports.Length];
+
+                for (int i = 0; i < imports.Length; ++i)
+                {
+                    unsafe
+                    {
+                        handles[i] = imports[i].GetHandle();
+                    }
+                }
+
+                var error = Interop.wasmtime_instance_new(store.Handle, Handle.DangerousGetHandle(), handles, (UIntPtr)imports.Length, out var instance, out var trap);
+
+                if (error != IntPtr.Zero)
+                {
+                    throw WasmtimeException.FromOwnedError(error);
+                }
+                if (trap != IntPtr.Zero)
+                {
+                    throw TrapException.FromOwnedTrap(trap);
+                }
+
+                return new Instance(instance, Handle.DangerousGetHandle());
+            }
+        }
+
         /// <inheritdoc/>
         public void Dispose()
         {
@@ -176,15 +235,11 @@ namespace Wasmtime
                 Handle.Dispose();
                 Handle.SetHandleAsInvalid();
             }
+        }
 
-            if (!(Imports is null))
-            {
-                Imports.Dispose();
-
-                // once Module is disposed, nothing in Module should be used anyways.
-                // keeping `Imports` to appear as a non-nullable makes things simpler for developers.
-                Imports = null!;
-            }
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_module_as_extern(Handle.DangerousGetHandle());
         }
 
         internal Module(Interop.EngineHandle engine, string name, ReadOnlySpan<byte> bytes)
@@ -208,8 +263,30 @@ namespace Wasmtime
             }
 
             Name = name;
-            Imports = new Wasmtime.Imports.Imports(this);
-            Exports = new Wasmtime.Exports.Exports(this);
+
+            Interop.wasm_importtype_vec_t imports;
+            Interop.wasm_module_imports(Handle.DangerousGetHandle(), out imports);
+
+            try
+            {
+                Imports = new Wasmtime.Imports.Imports(imports);
+            }
+            finally
+            {
+                Interop.wasm_importtype_vec_delete(ref imports);
+            }
+
+            Interop.wasm_exporttype_vec_t exports;
+            Interop.wasm_module_exports(Handle.DangerousGetHandle(), out exports);
+
+            try
+            {
+                Exports = new Wasmtime.Exports.Exports(exports);
+            }
+            finally
+            {
+                Interop.wasm_exporttype_vec_delete(ref exports);
+            }
         }
 
         internal Interop.ModuleHandle Handle { get; private set; }

--- a/src/MutableGlobal.cs
+++ b/src/MutableGlobal.cs
@@ -6,7 +6,7 @@ namespace Wasmtime
     /// <summary>
     /// Represents a mutable WebAssembly global value.
     /// </summary>
-    public class MutableGlobal<T> : IDisposable
+    public class MutableGlobal<T> : IDisposable, IImportable
     {
         /// <summary>
         /// The value of the global.
@@ -52,6 +52,11 @@ namespace Wasmtime
                 Handle.Dispose();
                 Handle.SetHandleAsInvalid();
             }
+        }
+
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_global_as_extern(Handle.DangerousGetHandle());
         }
 
         internal MutableGlobal(Interop.StoreHandle store, T initialValue)

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -6,7 +6,7 @@ namespace Wasmtime
     /// <summary>
     /// Represents a WebAssembly table.
     /// </summary>
-    public class Table<T> : IDisposable where T : class
+    public class Table<T> : IDisposable, IImportable where T : class
     {
         /// <summary>
         /// Gets the value kind of the table.
@@ -100,6 +100,11 @@ namespace Wasmtime
                 Handle.Dispose();
                 Handle.SetHandleAsInvalid();
             }
+        }
+
+        IntPtr IImportable.GetHandle()
+        {
+            return Interop.wasm_table_as_extern(Handle.DangerousGetHandle());
         }
 
         internal Table(Interop.StoreHandle store, T? initialValue, uint initial, uint maximum)

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -20,7 +20,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RepositoryUrl>https://github.com/bytecodealliance/wasmtime-dotnet</RepositoryUrl>
-    <PackageReleaseNotes>Update Wasmtime to 0.21.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>Update Wasmtime to 0.22.0.</PackageReleaseNotes>
     <Summary>A .NET API for Wasmtime, a standalone WebAssembly runtime</Summary>
     <PackageTags>webassembly, .net, wasm, wasmtime</PackageTags>
     <Title>Wasmtime</Title>

--- a/tests/GlobalExportsTests.cs
+++ b/tests/GlobalExportsTests.cs
@@ -46,7 +46,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
 
             dynamic dyn = instance;
-            var globals = instance.Externs.Globals;
+            var globals = instance.Globals;
             globals.Count.Should().Be(8);
 
             var i32 = globals[0];

--- a/tests/MemoryExportsTests.cs
+++ b/tests/MemoryExportsTests.cs
@@ -44,9 +44,9 @@ namespace Wasmtime.Tests
         {
             using var instance = Host.Instantiate(Fixture.Module);
 
-            instance.Externs.Memories.Count.Should().Be(1);
+            instance.Memories.Count.Should().Be(1);
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
             memory.ReadString(0, 11).Should().Be("Hello World");
             int written = memory.WriteString(0, "WebAssembly Rocks!");
             memory.ReadString(0, written).Should().Be("WebAssembly Rocks!");

--- a/tests/ModuleLinkingTests.cs
+++ b/tests/ModuleLinkingTests.cs
@@ -12,7 +12,6 @@ namespace Wasmtime.Tests
         public ModuleLinkingTests()
         {
             Engine = new EngineBuilder()
-                .WithReferenceTypes(true)
                 .WithModuleLinking(true)
                 .Build();
             Store = new Store(Engine);

--- a/tests/ModuleLinkingTests.cs
+++ b/tests/ModuleLinkingTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+using Wasmtime;
+
+namespace Wasmtime.Tests
+{
+    public class ModuleLinkingTests : IDisposable
+    {
+        public ModuleLinkingTests()
+        {
+            Engine = new EngineBuilder()
+                .WithReferenceTypes(true)
+                .WithModuleLinking(true)
+                .Build();
+            Store = new Store(Engine);
+            Host = new Host(Store);
+        }
+
+        private Engine Engine { get; set; }
+
+        private Store Store { get; set; }
+
+        private Host Host { get; set; }
+
+        [Fact]
+        public void ItExposesModuleImports()
+        {
+            using var module = Module.FromText(Engine, "test", @"(module (import ""a"" ""b"" (module)))");
+
+            module.Imports.Modules.Count.Should().Be(1);
+            module.Imports.Modules[0].ModuleName.Should().Be("a");
+            module.Imports.Modules[0].Name.Should().Be("b");
+        }
+
+        [Fact]
+        public void ItExposesModuleExports()
+        {
+            using var module = Module.FromText(Engine, "test", @"(module (module (export ""a"")))");
+
+            module.Exports.Modules.Count.Should().Be(1);
+            module.Exports.Modules[0].Name.Should().Be("a");
+        }
+
+        [Fact]
+        public void ItExposesInstanceImports()
+        {
+            using var module = Module.FromText(Engine, "test", @"(module (import ""a"" ""b"" (instance (export ""c"" (memory 1)))))");
+
+            module.Imports.Instances.Count.Should().Be(1);
+            module.Imports.Instances[0].ModuleName.Should().Be("a");
+            module.Imports.Instances[0].Name.Should().Be("b");
+            module.Imports.Instances[0].Exports.Memories.Count.Should().Be(1);
+            module.Imports.Instances[0].Exports.Memories[0].Name.Should().Be("c");
+        }
+
+        [Fact]
+        public void ItExposesInstanceExports()
+        {
+            using var module = Module.FromText(Engine, "test", @"(module (module (table (export ""b"") 1 10 funcref)) (instance (export ""a"") (instantiate 0)))");
+
+            module.Exports.Instances.Count.Should().Be(1);
+            module.Exports.Instances[0].Name.Should().Be("a");
+            module.Exports.Instances[0].Exports.Tables.Count.Should().Be(1);
+            module.Exports.Instances[0].Exports.Tables[0].Name.Should().Be("b");
+        }
+
+        [Fact]
+        public void ItInstantiatesAModule()
+        {
+            using var importModule = Module.FromText(Engine, "other", @"(module (import ""a"" (func)) (export ""b"" (func 0)) (memory 1))");
+            using var module = Module.FromText(Engine, "test", @"(module (import ""a"" (module (import ""b"" (func)))) (export ""c"" (module 0)))");
+
+            var called = false;
+            using var instance = module.Instantiate(Store, importModule);
+            instance.Modules.Count.Should().Be(1);
+            using var other = instance.Modules[0].Instantiate(Store, Function.FromCallback(Store, () => { called = true; }));
+            other.Functions.Count.Should().Be(1);
+            other.Functions[0].Invoke();
+            called.Should().BeTrue();
+        }
+
+        public void Dispose()
+        {
+            Engine.Dispose();
+            Store.Dispose();
+            Host.Dispose();
+        }
+    }
+}

--- a/tests/TableExportsTests.cs
+++ b/tests/TableExportsTests.cs
@@ -45,7 +45,7 @@ namespace Wasmtime.Tests
         {
             using var instance = Host.Instantiate(Fixture.Module);
 
-            var tables = instance.Externs.Tables;
+            var tables = instance.Tables;
             tables.Count.Should().Be(3);
 
             var table1 = tables[0];

--- a/tests/WasiSnapshot0Tests.cs
+++ b/tests/WasiSnapshot0Tests.cs
@@ -31,7 +31,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_environ_sizes_get(0, 4));
             Assert.Equal(0, memory.ReadInt32(0));
@@ -55,7 +55,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_environ_sizes_get(0, 4));
             Assert.Equal(env.Count, memory.ReadInt32(0));
@@ -80,7 +80,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_environ_sizes_get(0, 4));
             Assert.Equal(Environment.GetEnvironmentVariables().Keys.Count, memory.ReadInt32(0));
@@ -94,7 +94,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_args_sizes_get(0, 4));
             Assert.Equal(0, memory.ReadInt32(0));
@@ -119,7 +119,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_args_sizes_get(0, 4));
             Assert.Equal(args.Count, memory.ReadInt32(0));
@@ -144,7 +144,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_args_sizes_get(0, 4));
             Assert.Equal(Environment.GetCommandLineArgs().Length, memory.ReadInt32(0));
@@ -166,7 +166,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
             memory.WriteInt32(0, 8);
             memory.WriteInt32(4, MESSAGE.Length);
 
@@ -199,7 +199,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
             memory.WriteInt32(0, 8);
             memory.WriteInt32(4, MESSAGE.Length);
             memory.WriteString(8, MESSAGE);
@@ -225,7 +225,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
             var fileName = Path.GetFileName(file.Path);
             memory.WriteString(0, fileName);
 

--- a/tests/WasiTests.cs
+++ b/tests/WasiTests.cs
@@ -32,7 +32,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_environ_sizes_get(0, 4));
             Assert.Equal(0, memory.ReadInt32(0));
@@ -56,7 +56,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_environ_sizes_get(0, 4));
             Assert.Equal(env.Count, memory.ReadInt32(0));
@@ -81,7 +81,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_environ_sizes_get(0, 4));
             Assert.Equal(Environment.GetEnvironmentVariables().Keys.Count, memory.ReadInt32(0));
@@ -95,7 +95,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_args_sizes_get(0, 4));
             Assert.Equal(0, memory.ReadInt32(0));
@@ -120,7 +120,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_args_sizes_get(0, 4));
             Assert.Equal(args.Count, memory.ReadInt32(0));
@@ -145,7 +145,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
 
             Assert.Equal(0, inst.call_args_sizes_get(0, 4));
             Assert.Equal(Environment.GetCommandLineArgs().Length, memory.ReadInt32(0));
@@ -167,7 +167,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
             memory.WriteInt32(0, 8);
             memory.WriteInt32(4, MESSAGE.Length);
 
@@ -200,7 +200,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
             memory.WriteInt32(0, 8);
             memory.WriteInt32(4, MESSAGE.Length);
             memory.WriteString(8, MESSAGE);
@@ -226,7 +226,7 @@ namespace Wasmtime.Tests
             using var instance = Host.Instantiate(Fixture.Module);
             dynamic inst = instance;
 
-            var memory = instance.Externs.Memories[0];
+            var memory = instance.Memories[0];
             var fileName = Path.GetFileName(file.Path);
             memory.WriteString(0, fileName);
 

--- a/tests/Wasmtime.Tests.csproj
+++ b/tests/Wasmtime.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR implements the changes to support the module linking proposal.

Modules and instances are now supported import types for module instantiation.

Modules can now also be instantiated via `Module.Instantiate` and
`ModuleExtern.Instantiate`.

There is a breaking change to the API:

* `Instance.Externs` has been removed in favor of individual properties that
  forward to the inner `Externs` instance.  Thus `Instance.Externs.Functions`
  becomes `Instance.Functions`, etc.

Additionally, the examples and the test project have been migrated to .NET 5.

Closes #45.
Fixes #40.