### PR TITLE
Update Wasmtime to 0.22.1.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">true</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">0.22.0</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">0.22.1</WasmtimeVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)-preview1-dev</WasmtimePackageVersion>
     <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">$(WasmtimeVersion)-preview1</WasmtimePackageVersion>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 You can add a package reference with the [.NET SDK](https://dotnet.microsoft.com/):
 
 ```text
-$ dotnet add package --version 0.22.0-preview1 wasmtime
+$ dotnet add package --version 0.22.1-preview1 wasmtime
 ```
 
 _Note that the `--version` option is required because the package is currently prerelease._
@@ -54,7 +54,7 @@ $ dotnet new console
 Next, add a reference to the [Wasmtime package](https://www.nuget.org/packages/Wasmtime):
 
 ```
-$ dotnet add package --version 0.22.0-preview1 wasmtime
+$ dotnet add package --version 0.22.1-preview1 wasmtime
 ```
 
 Replace the contents of `Program.cs` with the following code:

--- a/docs/articles/intro.md
+++ b/docs/articles/intro.md
@@ -44,7 +44,7 @@ dotnet new console
 To use the .NET embedding of Wasmtime from the project, we need to add a reference to the [Wasmtime NuGet package](https://www.nuget.org/packages/Wasmtime):
 
 ```text
-dotnet add package --version 0.22.0-preview1 wasmtime
+dotnet add package --version 0.22.1-preview1 wasmtime
 ```
 
 _Note that the `--version` option is required because the package is currently prerelease._

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -20,7 +20,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RepositoryUrl>https://github.com/bytecodealliance/wasmtime-dotnet</RepositoryUrl>
-    <PackageReleaseNotes>Update Wasmtime to 0.22.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>Update Wasmtime to 0.22.1.</PackageReleaseNotes>
     <Summary>A .NET API for Wasmtime, a standalone WebAssembly runtime</Summary>
     <PackageTags>webassembly, .net, wasm, wasmtime</PackageTags>
     <Title>Wasmtime</Title>


### PR DESCRIPTION
This updates Wasmtime to 0.22.1 for a security fix for an upstream dependency
(smallvec).