### PR TITLE
Add Nuget Licence Expression

### DIFF
--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -68,19 +68,21 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       </WasmtimeDownload>
     </ItemGroup>
 
-    <DownloadFile Condition="!Exists('%(WasmtimeDownload.DownloadFolder)/%(WasmtimeDownload.DownloadFilename)')" SourceUrl="%(WasmtimeDownload.URL)" DestinationFolder="%(WasmtimeDownload.DownloadFolder)" DestinationFileName="%(WasmtimeDownload.DownloadFilename)" SkipUnchangedFiles="true" />
+    <DownloadFile Condition="!Exists('%(WasmtimeDownload.DownloadFolder)/%(WasmtimeDownload.DownloadFilename)')" 
+                  SourceUrl="%(WasmtimeDownload.URL)" 
+                  DestinationFolder="%(WasmtimeDownload.DownloadFolder)" 
+                  DestinationFileName="%(WasmtimeDownload.DownloadFilename)" 
+                  SkipUnchangedFiles="true" />
 
     <!-- Workaround for https://github.com/msys2/MSYS2-packages/issues/1548 -->
     <Exec Condition="!%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')" 
           Command="xz --decompress --stdout %(WasmtimeDownload.DownloadFilename) | tar --strip-components 1 -vxf -" 
           WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" 
-          StandardOutputImportance="Low" 
-          StandardErrorImportance="Low" />
+          StandardOutputImportance="Low" StandardErrorImportance="Low" />
     <Exec Condition="%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')" 
           Command="tar --strip-components 1 -vxzf %(WasmtimeDownload.DownloadFilename)" 
           WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" 
-          StandardOutputImportance="Low" 
-          StandardErrorImportance="Low" />
+          StandardOutputImportance="Low" StandardErrorImportance="Low" />
 
     <ItemGroup>
       <Content Include="%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)">

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -31,6 +31,7 @@ Wasmtime is a standalone runtime for WebAssembly, using the Cranelift JIT compil
 
 The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modules and to interact with them in-process.
     </PackageDescription>
+    <PackageLicenseExpression>Apache-2.0 WITH LLVM-exception</PackageLicenseExpression>
   </PropertyGroup>
 
   <Target Name="DownloadWasmtime" BeforeTargets="BeforeBuild">
@@ -67,20 +68,18 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       </WasmtimeDownload>
     </ItemGroup>
 
-    <DownloadFile Condition="!Exists('%(WasmtimeDownload.DownloadFolder)/%(WasmtimeDownload.DownloadFilename)')"
-                  SourceUrl="%(WasmtimeDownload.URL)"
-                  DestinationFolder="%(WasmtimeDownload.DownloadFolder)"
-                  DestinationFileName="%(WasmtimeDownload.DownloadFilename)"
-                  SkipUnchangedFiles="true" />
+    <DownloadFile Condition="!Exists('%(WasmtimeDownload.DownloadFolder)/%(WasmtimeDownload.DownloadFilename)')" SourceUrl="%(WasmtimeDownload.URL)" DestinationFolder="%(WasmtimeDownload.DownloadFolder)" DestinationFileName="%(WasmtimeDownload.DownloadFilename)" SkipUnchangedFiles="true" />
 
     <!-- Workaround for https://github.com/msys2/MSYS2-packages/issues/1548 -->
-    <Exec Condition="!%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')"
-          Command="xz --decompress --stdout %(WasmtimeDownload.DownloadFilename) | tar --strip-components 1 -vxf -"
-          WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" StandardOutputImportance="Low"
+    <Exec Condition="!%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')" 
+          Command="xz --decompress --stdout %(WasmtimeDownload.DownloadFilename) | tar --strip-components 1 -vxf -" 
+          WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" 
+          StandardOutputImportance="Low" 
           StandardErrorImportance="Low" />
-    <Exec Condition="%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')"
-          Command="tar --strip-components 1 -vxzf %(WasmtimeDownload.DownloadFilename)"
-          WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" StandardOutputImportance="Low"
+    <Exec Condition="%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')" 
+          Command="tar --strip-components 1 -vxzf %(WasmtimeDownload.DownloadFilename)" 
+          WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" 
+          StandardOutputImportance="Low" 
           StandardErrorImportance="Low" />
 
     <ItemGroup>


### PR DESCRIPTION
Some companies rely on nuget licence data to automatically ensure they properly comply with the licence each library is released under