### PR TITLE
Add `WithMultiMemory` to `Config`.

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -179,6 +179,17 @@ namespace Wasmtime
         }
 
         /// <summary>
+        /// Sets whether or not enable WebAssembly multi-memory support.
+        /// </summary>
+        /// <param name="enable">True to enable WebAssembly multi-memory support or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithMultiMemory(bool enable)
+        {
+            Native.wasmtime_config_wasm_multi_memory_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
         /// Sets whether or not enable WebAssembly module linking support.
         /// </summary>
         /// <param name="enable">True to enable WebAssembly module linking support or false to disable.</param>
@@ -378,6 +389,9 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_wasm_multi_value_set(Handle config, bool enable);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_multi_memory_set(Handle config, bool enable);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_wasm_module_linking_set(Handle config, bool enable);

--- a/tests/MultiMemoryTests.cs
+++ b/tests/MultiMemoryTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Wasmtime.Tests
+{
+    public class MultiMemoryTests
+    {
+        [Fact]
+        public void ItFailsWithoutMultiMemoryEnabled()
+        {
+            using var engine = new Engine();
+            Action action = () =>
+            {
+                using var module = Module.FromText(engine, "test", @"(module (memory 0 1) (memory 0 1))");
+            };
+
+            action
+                .Should()
+                .Throw<WasmtimeException>()
+                .WithMessage("WebAssembly module 'test' is not valid: WebAssembly failed to compile*");
+        }
+
+        [Fact]
+        public void ItSucceedsWithMultiMemoryEnabled()
+        {
+            using var engine = new Engine(new Config().WithMultiMemory(true));
+            using var module = Module.FromText(engine, "test", @"(module (memory 0 1) (memory 0 1))");
+        }
+    }
+}


### PR DESCRIPTION
This commit adds the `WithMultiMemory` method to `Config` to enable support for
the multi-memory feature.

Fixes #65.