### PR TITLE
Small bug fixes for `Config`.

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -7,7 +7,7 @@ namespace Wasmtime
     /// <summary>
     /// Represents the Wasmtime compiler strategy.
     /// </summary>
-    public enum CompilerStrategy
+    public enum CompilerStrategy : byte
     {
         /// <summary>
         /// Automatically pick the compiler strategy.
@@ -26,7 +26,7 @@ namespace Wasmtime
     /// <summary>
     /// Represents the Wasmtime optimization level.
     /// </summary>
-    public enum OptimizationLevel
+    public enum OptimizationLevel : byte
     {
         /// <summary>
         /// Disable optimizations.
@@ -45,7 +45,7 @@ namespace Wasmtime
     /// <summary>
     /// Represents the Wasmtime code profiling strategy.
     /// </summary>
-    public enum ProfilingStrategy
+    public enum ProfilingStrategy : byte
     {
         /// <summary>
         /// Disable code profiling.
@@ -253,7 +253,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="strategy">The profiling strategy to use.</param>
         /// <returns>Returns the current config.</returns>
-        public Config WithOptimizationLevel(ProfilingStrategy strategy)
+        public Config WithProfilingStrategy(ProfilingStrategy strategy)
         {
             if (!Enum.IsDefined(typeof(ProfilingStrategy), (byte)strategy))
             {

--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -1,0 +1,39 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Wasmtime.Tests
+{
+    public class ConfigTests
+    {
+        [Fact]
+        public void ItSetsCompilerStrategy()
+        {
+            var config = new Config();
+
+            config.WithCompilerStrategy(CompilerStrategy.Cranelift);
+
+            using var engine = new Engine(config);
+        }
+
+        [Fact]
+        public void ItSetsProfilingStrategy()
+        {
+            var config = new Config();
+
+            config.WithProfilingStrategy(ProfilingStrategy.None);
+
+            using var engine = new Engine(config);
+        }
+
+        [Fact]
+        public void ItSetsOptimizationLevel()
+        {
+            var config = new Config();
+
+            config.WithOptimizationLevel(OptimizationLevel.Speed);
+
+            using var engine = new Engine(config);
+        }
+    }
+}


### PR DESCRIPTION
* The config-related enums should use `byte` as the underlying type as that is
  what we're using in the P/Invoke signatures.
* Cut-and-paste error where `WithProfilingStrategy` was named as an overload to
  `WithOptimizationLevel`.
* Added tests for setting the enums.

Fixes #72.