### PR TITLE
Upgrade to Dotnet 6.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.2'
+        dotnet-version: '6.0.x'
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
       run: dotnet clean && dotnet nuget locals all --clear

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.102'
+        dotnet-version: '6.0.2'
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
       run: dotnet clean && dotnet nuget locals all --clear

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,13 +42,13 @@ jobs:
         dotnet-version: '6.0.x'
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
-      run: dotnet clean && dotnet nuget locals all --clear
+      run: dotnet clean Wasmtime.sln && dotnet nuget locals all --clear
     - name: Restore packages
-      run: dotnet restore
+      run: dotnet restore Wasmtime.sln
     - name: Build
-      run: dotnet build -c ${{ matrix.config }} --no-restore
+      run: dotnet build Wasmtime.sln -c ${{ matrix.config }} --no-restore
     - name: Test
-      run: dotnet test -c ${{ matrix.config }}
+      run: dotnet test Wasmtime.sln -c ${{ matrix.config }}
     - name: Benchmark
       if: matrix.config == 'release'
       run: dotnet run -c ${{ matrix.config }} --project benchmarks/simple/simple.csproj

--- a/Benchmarks.sln
+++ b/Benchmarks.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wasmtime", "src\Wasmtime.csproj", "{5EB63C51-5286-4DDF-BF7F-4110CC6D80B8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "simple", "benchmarks\simple\simple.csproj", "{9264D423-A3AA-4765-9EBF-7A62BCE58CD8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5EB63C51-5286-4DDF-BF7F-4110CC6D80B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5EB63C51-5286-4DDF-BF7F-4110CC6D80B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5EB63C51-5286-4DDF-BF7F-4110CC6D80B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5EB63C51-5286-4DDF-BF7F-4110CC6D80B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9264D423-A3AA-4765-9EBF-7A62BCE58CD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9264D423-A3AA-4765-9EBF-7A62BCE58CD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9264D423-A3AA-4765-9EBF-7A62BCE58CD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9264D423-A3AA-4765-9EBF-7A62BCE58CD8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F5AC35E5-1373-49E6-97DC-68CB5E0369E0}
+	EndGlobalSection
+EndGlobal

--- a/Examples.sln
+++ b/Examples.sln
@@ -1,0 +1,67 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "externref", "examples\externref\externref.csproj", "{080F8792-A298-4BF4-BC5E-46BD305ACE70}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "funcref", "examples\funcref\funcref.csproj", "{E984109E-9068-4617-85D8-A2FF75490198}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "global", "examples\global\global.csproj", "{26FE6450-FCAE-471D-AA6C-6510248602E9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "hello", "examples\hello\hello.csproj", "{D3D124D2-AE6F-49F5-81F4-8FE41451856B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "linking", "examples\linking\linking.csproj", "{5C690486-153E-4221-A3FD-BE6B8B4FE579}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "memory", "examples\memory\memory.csproj", "{9F2BF53D-F96F-4E74-82D1-DC1F940B7B54}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "table", "examples\table\table.csproj", "{14C0359D-E39E-4CD6-BD25-486B37079E1C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wasmtime", "src\Wasmtime.csproj", "{82B01E4A-1CAD-44BB-B923-11FA37173BD7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{080F8792-A298-4BF4-BC5E-46BD305ACE70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{080F8792-A298-4BF4-BC5E-46BD305ACE70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{080F8792-A298-4BF4-BC5E-46BD305ACE70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{080F8792-A298-4BF4-BC5E-46BD305ACE70}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E984109E-9068-4617-85D8-A2FF75490198}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E984109E-9068-4617-85D8-A2FF75490198}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E984109E-9068-4617-85D8-A2FF75490198}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E984109E-9068-4617-85D8-A2FF75490198}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26FE6450-FCAE-471D-AA6C-6510248602E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26FE6450-FCAE-471D-AA6C-6510248602E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26FE6450-FCAE-471D-AA6C-6510248602E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26FE6450-FCAE-471D-AA6C-6510248602E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3D124D2-AE6F-49F5-81F4-8FE41451856B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3D124D2-AE6F-49F5-81F4-8FE41451856B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3D124D2-AE6F-49F5-81F4-8FE41451856B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3D124D2-AE6F-49F5-81F4-8FE41451856B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C690486-153E-4221-A3FD-BE6B8B4FE579}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C690486-153E-4221-A3FD-BE6B8B4FE579}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C690486-153E-4221-A3FD-BE6B8B4FE579}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C690486-153E-4221-A3FD-BE6B8B4FE579}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F2BF53D-F96F-4E74-82D1-DC1F940B7B54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F2BF53D-F96F-4E74-82D1-DC1F940B7B54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F2BF53D-F96F-4E74-82D1-DC1F940B7B54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F2BF53D-F96F-4E74-82D1-DC1F940B7B54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14C0359D-E39E-4CD6-BD25-486B37079E1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14C0359D-E39E-4CD6-BD25-486B37079E1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14C0359D-E39E-4CD6-BD25-486B37079E1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14C0359D-E39E-4CD6-BD25-486B37079E1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82B01E4A-1CAD-44BB-B923-11FA37173BD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82B01E4A-1CAD-44BB-B923-11FA37173BD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82B01E4A-1CAD-44BB-B923-11FA37173BD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82B01E4A-1CAD-44BB-B923-11FA37173BD7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F5AC35E5-1373-49E6-97DC-68CB5E0369E0}
+	EndGlobalSection
+EndGlobal

--- a/benchmarks/simple/simple.csproj
+++ b/benchmarks/simple/simple.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/externref/externref.csproj
+++ b/examples/externref/externref.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/funcref/funcref.csproj
+++ b/examples/funcref/funcref.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/global/global.csproj
+++ b/examples/global/global.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/hello/hello.csproj
+++ b/examples/hello/hello.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/examples/linking/linking.csproj
+++ b/examples/linking/linking.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/memory/memory.csproj
+++ b/examples/memory/memory.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/table/table.csproj
+++ b/examples/table/table.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -210,25 +210,25 @@ namespace Wasmtime
                 {
                     case ValueKind.Int32:
                         if (o is null)
-                            throw new WasmtimeException($"The value `{o ?? "null"}` is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"The value 'null' is not valid for WebAssembly type {kind}.");
                         value.of.i32 = (int)Convert.ChangeType(o, TypeCode.Int32);
                         break;
 
                     case ValueKind.Int64:
                         if (o is null)
-                            throw new WasmtimeException($"The value `{o ?? "null"}` is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"The value 'null' is not valid for WebAssembly type {kind}.");
                         value.of.i64 = (long)Convert.ChangeType(o, TypeCode.Int64);
                         break;
 
                     case ValueKind.Float32:
                         if (o is null)
-                            throw new WasmtimeException($"The value `{o ?? "null"}` is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"The value 'null' is not valid for WebAssembly type {kind}.");
                         value.of.f32 = (float)Convert.ChangeType(o, TypeCode.Single);
                         break;
 
                     case ValueKind.Float64:
                         if (o is null)
-                            throw new WasmtimeException($"The value `{o ?? "null"}` is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"The value 'null' is not valid for WebAssembly type {kind}.");
                         value.of.f64 = (double)Convert.ChangeType(o, TypeCode.Double);
                         break;
 

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -210,25 +210,25 @@ namespace Wasmtime
                 {
                     case ValueKind.Int32:
                         if (o is null)
-                            throw new WasmtimeException($"A null value is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"A `null` value is not valid for WebAssembly type {kind}.");
                         value.of.i32 = (int)Convert.ChangeType(o, TypeCode.Int32);
                         break;
 
                     case ValueKind.Int64:
                         if (o is null)
-                            throw new WasmtimeException($"A null value is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"A `null` value is not valid for WebAssembly type {kind}.");
                         value.of.i64 = (long)Convert.ChangeType(o, TypeCode.Int64);
                         break;
 
                     case ValueKind.Float32:
                         if (o is null)
-                            throw new WasmtimeException($"A null value is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"A `null` value is not valid for WebAssembly type {kind}.");
                         value.of.f32 = (float)Convert.ChangeType(o, TypeCode.Single);
                         break;
 
                     case ValueKind.Float64:
                         if (o is null)
-                            throw new WasmtimeException($"A null value is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"A `null` value is not valid for WebAssembly type {kind}.");
                         value.of.f64 = (double)Convert.ChangeType(o, TypeCode.Double);
                         break;
 

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -210,25 +210,25 @@ namespace Wasmtime
                 {
                     case ValueKind.Int32:
                         if (o is null)
-                            throw new WasmtimeException($"The value 'null' is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"A null value is not valid for WebAssembly type {kind}.");
                         value.of.i32 = (int)Convert.ChangeType(o, TypeCode.Int32);
                         break;
 
                     case ValueKind.Int64:
                         if (o is null)
-                            throw new WasmtimeException($"The value 'null' is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"A null value is not valid for WebAssembly type {kind}.");
                         value.of.i64 = (long)Convert.ChangeType(o, TypeCode.Int64);
                         break;
 
                     case ValueKind.Float32:
                         if (o is null)
-                            throw new WasmtimeException($"The value 'null' is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"A null value is not valid for WebAssembly type {kind}.");
                         value.of.f32 = (float)Convert.ChangeType(o, TypeCode.Single);
                         break;
 
                     case ValueKind.Float64:
                         if (o is null)
-                            throw new WasmtimeException($"The value 'null' is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"A null value is not valid for WebAssembly type {kind}.");
                         value.of.f64 = (double)Convert.ChangeType(o, TypeCode.Double);
                         break;
 

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -210,25 +210,25 @@ namespace Wasmtime
                 {
                     case ValueKind.Int32:
                         if (o is null)
-                            throw new WasmtimeException($"A `null` value is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"The value `null` is not valid for WebAssembly type {kind}.");
                         value.of.i32 = (int)Convert.ChangeType(o, TypeCode.Int32);
                         break;
 
                     case ValueKind.Int64:
                         if (o is null)
-                            throw new WasmtimeException($"A `null` value is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"The value `null` is not valid for WebAssembly type {kind}.");
                         value.of.i64 = (long)Convert.ChangeType(o, TypeCode.Int64);
                         break;
 
                     case ValueKind.Float32:
                         if (o is null)
-                            throw new WasmtimeException($"A `null` value is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"The value `null` is not valid for WebAssembly type {kind}.");
                         value.of.f32 = (float)Convert.ChangeType(o, TypeCode.Single);
                         break;
 
                     case ValueKind.Float64:
                         if (o is null)
-                            throw new WasmtimeException($"A `null` value is not valid for WebAssembly type {kind}.");
+                            throw new WasmtimeException($"The value `null` is not valid for WebAssembly type {kind}.");
                         value.of.f64 = (double)Convert.ChangeType(o, TypeCode.Double);
                         break;
 

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -209,18 +209,26 @@ namespace Wasmtime
                 switch (kind)
                 {
                     case ValueKind.Int32:
+                        if (o is null)
+                            throw new WasmtimeException($"The value `{o ?? "null"}` is not valid for WebAssembly type {kind}.");
                         value.of.i32 = (int)Convert.ChangeType(o, TypeCode.Int32);
                         break;
 
                     case ValueKind.Int64:
+                        if (o is null)
+                            throw new WasmtimeException($"The value `{o ?? "null"}` is not valid for WebAssembly type {kind}.");
                         value.of.i64 = (long)Convert.ChangeType(o, TypeCode.Int64);
                         break;
 
                     case ValueKind.Float32:
+                        if (o is null)
+                            throw new WasmtimeException($"The value `{o ?? "null"}` is not valid for WebAssembly type {kind}.");
                         value.of.f32 = (float)Convert.ChangeType(o, TypeCode.Single);
                         break;
 
                     case ValueKind.Float64:
+                        if (o is null)
+                            throw new WasmtimeException($"The value `{o ?? "null"}` is not valid for WebAssembly type {kind}.");
                         value.of.f64 = (double)Convert.ChangeType(o, TypeCode.Double);
                         break;
 

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
-  </ItemGroup>
 
   <PropertyGroup>
     <AssemblyName>Wasmtime.Dotnet</AssemblyName>
@@ -38,7 +34,7 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
   </PropertyGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="DownloadWasmtime" BeforeTargets="BeforeBuild">
@@ -75,21 +71,11 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       </WasmtimeDownload>
     </ItemGroup>
 
-    <DownloadFile Condition="!Exists('%(WasmtimeDownload.DownloadFolder)/%(WasmtimeDownload.DownloadFilename)')" 
-                  SourceUrl="%(WasmtimeDownload.URL)" 
-                  DestinationFolder="%(WasmtimeDownload.DownloadFolder)" 
-                  DestinationFileName="%(WasmtimeDownload.DownloadFilename)" 
-                  SkipUnchangedFiles="true" />
+    <DownloadFile Condition="!Exists('%(WasmtimeDownload.DownloadFolder)/%(WasmtimeDownload.DownloadFilename)')" SourceUrl="%(WasmtimeDownload.URL)" DestinationFolder="%(WasmtimeDownload.DownloadFolder)" DestinationFileName="%(WasmtimeDownload.DownloadFilename)" SkipUnchangedFiles="true" />
 
     <!-- Workaround for https://github.com/msys2/MSYS2-packages/issues/1548 -->
-    <Exec Condition="!%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')" 
-          Command="xz --decompress --stdout %(WasmtimeDownload.DownloadFilename) | tar --strip-components 1 -vxf -" 
-          WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" 
-          StandardOutputImportance="Low" StandardErrorImportance="Low" />
-    <Exec Condition="%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')" 
-          Command="tar --strip-components 1 -vxzf %(WasmtimeDownload.DownloadFilename)" 
-          WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" 
-          StandardOutputImportance="Low" StandardErrorImportance="Low" />
+    <Exec Condition="!%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')" Command="xz --decompress --stdout %(WasmtimeDownload.DownloadFilename) | tar --strip-components 1 -vxf -" WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" StandardOutputImportance="Low" StandardErrorImportance="Low" />
+    <Exec Condition="%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')" Command="tar --strip-components 1 -vxzf %(WasmtimeDownload.DownloadFilename)" WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" StandardOutputImportance="Low" StandardErrorImportance="Low" />
 
     <ItemGroup>
       <Content Include="%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)">

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -71,12 +71,22 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       </WasmtimeDownload>
     </ItemGroup>
 
-    <DownloadFile Condition="!Exists('%(WasmtimeDownload.DownloadFolder)/%(WasmtimeDownload.DownloadFilename)')" SourceUrl="%(WasmtimeDownload.URL)" DestinationFolder="%(WasmtimeDownload.DownloadFolder)" DestinationFileName="%(WasmtimeDownload.DownloadFilename)" SkipUnchangedFiles="true" />
-
+	<DownloadFile Condition="!Exists('%(WasmtimeDownload.DownloadFolder)/%(WasmtimeDownload.DownloadFilename)')"
+					  SourceUrl="%(WasmtimeDownload.URL)"
+					  DestinationFolder="%(WasmtimeDownload.DownloadFolder)"
+					  DestinationFileName="%(WasmtimeDownload.DownloadFilename)"
+					  SkipUnchangedFiles="true" />
+	  
     <!-- Workaround for https://github.com/msys2/MSYS2-packages/issues/1548 -->
-    <Exec Condition="!%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')" Command="xz --decompress --stdout %(WasmtimeDownload.DownloadFilename) | tar --strip-components 1 -vxf -" WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" StandardOutputImportance="Low" StandardErrorImportance="Low" />
-    <Exec Condition="%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')" Command="tar --strip-components 1 -vxzf %(WasmtimeDownload.DownloadFilename)" WorkingDirectory="%(WasmtimeDownload.DownloadFolder)" StandardOutputImportance="Low" StandardErrorImportance="Low" />
-
+	<Exec Condition="!%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')"
+		Command="xz --decompress --stdout %(WasmtimeDownload.DownloadFilename) | tar --strip-components 1 -vxf -"
+		WorkingDirectory="%(WasmtimeDownload.DownloadFolder)"
+		StandardOutputImportance="Low" StandardErrorImportance="Low" />
+	<Exec Condition="%(WasmtimeDownload.IsZip) And !Exists('%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)')"
+		Command="tar --strip-components 1 -vxzf %(WasmtimeDownload.DownloadFilename)"
+		WorkingDirectory="%(WasmtimeDownload.DownloadFolder)"
+		StandardOutputImportance="Low" StandardErrorImportance="Low" />
+	  
     <ItemGroup>
       <Content Include="%(WasmtimeDownload.DownloadFolder)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)">
         <PackagePath>%(WasmtimeDownload.PackagePath)</PackagePath>

--- a/tests/Wasmtime.Tests.csproj
+++ b/tests/Wasmtime.Tests.csproj
@@ -1,16 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The current build targets [ .Net Standard 2.1](https://github.com/bytecodealliance/wasmtime-dotnet/blob/19b3bccf841805481d2b657b0eb1b83a0a01b11f/src/Wasmtime.csproj#L4) in the main library and [.Net 5.0](https://github.com/bytecodealliance/wasmtime-dotnet/blob/19b3bccf841805481d2b657b0eb1b83a0a01b11f/tests/Wasmtime.Tests.csproj#L4) in the unit test library.

Microsoft announced [September 15th, 2020]( https://devblogs.microsoft.com/dotnet/the-future-of-net-standard/) that .Net 5.0 replaced  .Net Standard 2.1 and with .Net 6.0, which is now the current LTS channel, replacing .Net 5.0 for which support officially ends in less than 3 months on [May 8, 2022](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).

Additionally, the current build configuration also has a dependency on at least 2 .Net 4.X framework DLL's - `Microsoft.Csharp (4.6.0)` and `System.Configuration.ConfigurationManager(4.4.0)` 

![image](https://user-images.githubusercontent.com/2246388/155439356-d95c06e2-5d70-41eb-b458-3631204fee78.png)

Upgrading both the main library and the unit tests to  .Net 6, and upgrading packages to their latest versions removes the legacy 4.x DLL dependencies and moves Wasmtime-dotnet onto the current LTS version of dotnet.


Additionally, the Unit tests for `Wasmtime.ValueType` were updated to perform `null` checks to allow compiling on .Net 6.
