### PR TITLE
Add fuel consumption tests and consume fuel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Run examples
       shell: bash
       env:
-        EXAMPLES: externref funcref global hello memory table
+        EXAMPLES: externref funcref global hello memory table consumefuel
       run: |
         for e in $EXAMPLES; do cd examples/$e && dotnet run -c ${{ matrix.config }} && cd ../..; done
     - name: Create package

--- a/Examples.sln
+++ b/Examples.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "table", "examples\table\tab
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wasmtime", "src\Wasmtime.csproj", "{82B01E4A-1CAD-44BB-B923-11FA37173BD7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "consumefuel", "examples\consumefuel\consumefuel.csproj", "{F79FAA27-3CA6-4CC3-BB50-CE27191770F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,10 +41,6 @@ Global
 		{D3D124D2-AE6F-49F5-81F4-8FE41451856B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3D124D2-AE6F-49F5-81F4-8FE41451856B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3D124D2-AE6F-49F5-81F4-8FE41451856B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5C690486-153E-4221-A3FD-BE6B8B4FE579}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5C690486-153E-4221-A3FD-BE6B8B4FE579}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5C690486-153E-4221-A3FD-BE6B8B4FE579}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5C690486-153E-4221-A3FD-BE6B8B4FE579}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9F2BF53D-F96F-4E74-82D1-DC1F940B7B54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9F2BF53D-F96F-4E74-82D1-DC1F940B7B54}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9F2BF53D-F96F-4E74-82D1-DC1F940B7B54}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -55,6 +53,10 @@ Global
 		{82B01E4A-1CAD-44BB-B923-11FA37173BD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82B01E4A-1CAD-44BB-B923-11FA37173BD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82B01E4A-1CAD-44BB-B923-11FA37173BD7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F79FAA27-3CA6-4CC3-BB50-CE27191770F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F79FAA27-3CA6-4CC3-BB50-CE27191770F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F79FAA27-3CA6-4CC3-BB50-CE27191770F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F79FAA27-3CA6-4CC3-BB50-CE27191770F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/consumefuel/Program.cs
+++ b/examples/consumefuel/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Wasmtime;
 
 namespace Example
@@ -41,7 +41,15 @@ namespace Example
             }
 
             Console.WriteLine("Calling the expensive function one more time, which will throw an exception.");
-            expensive.Invoke(store);
+            try
+            {
+                expensive.Invoke(store);
+            }
+            catch (TrapException ex)
+            {
+                Console.WriteLine("Exception caught with the following message:");
+                Console.WriteLine(ex.Message);
+            }
         }
     }
 }

--- a/examples/consumefuel/Program.cs
+++ b/examples/consumefuel/Program.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Wasmtime;
+
+namespace Example
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            using var engine = new Engine(new Config()
+                .WithFuelConsumption(true));
+            using var module = Module.FromTextFile(engine, "consumefuel.wat");
+            using var linker = new Linker(engine);
+            using var store = new Store(engine);
+
+            linker.Define(
+                "",
+                "expensive",
+                Function.FromCallback(store, (Caller caller) =>
+                {
+                    var remaining = store.ConsumeFuel(1000UL);
+                    Console.WriteLine($"Called an expensive function which consumed 1000 fuel. {remaining} units of fuel remaining.");
+                }
+            ));
+
+            var instance = linker.Instantiate(store, module);
+
+            var expensive = instance.GetFunction(store, "expensive");
+            if (expensive is null)
+            {
+                Console.WriteLine("error: expensive export is missing");
+                return;
+            }
+
+            store.AddFuel(5000UL);
+            Console.WriteLine("Added 5000 units of fuel");
+
+            for (var i = 0; i < 4; i++)
+            {
+                expensive.Invoke(store);
+            }
+
+            Console.WriteLine("Calling the expensive function one more time, which will throw an exception.");
+            expensive.Invoke(store);
+        }
+    }
+}

--- a/examples/consumefuel/Program.cs
+++ b/examples/consumefuel/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Wasmtime;
 
 namespace Example
@@ -18,7 +18,7 @@ namespace Example
                 "expensive",
                 Function.FromCallback(store, (Caller caller) =>
                 {
-                    var remaining = store.ConsumeFuel(1000UL);
+                    var remaining = caller.ConsumeFuel(1000UL);
                     Console.WriteLine($"Called an expensive function which consumed 1000 fuel. {remaining} units of fuel remaining.");
                 }
             ));

--- a/examples/consumefuel/consumefuel.csproj
+++ b/examples/consumefuel/consumefuel.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wasmtime.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/consumefuel/consumefuel.wat
+++ b/examples/consumefuel/consumefuel.wat
@@ -1,0 +1,7 @@
+﻿(module
+  (import "" "expensive" (func $.expensive))
+  (func $expensive
+    call $.expensive
+  )
+  (export "expensive" (func $expensive))
+)

--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -69,6 +69,35 @@ namespace Wasmtime
 
         StoreContext IStore.Context => new StoreContext(Native.wasmtime_caller_context(NativeHandle));
 
+        /// <summary>
+        /// Adds fuel to this store for WebAssembly code to consume while executing.
+        /// </summary>
+        /// <param name="fuel">The fuel to add to the store.</param>
+        public void AddFuel(ulong fuel) => ((IStore)this).Context.AddFuel(fuel);
+
+        /// <summary>
+        /// Synthetically consumes fuel from this store.
+        ///
+        /// For this method to work fuel consumption must be enabled via <see cref="Config.WithFuelConsumption(bool)"/>.
+        ///
+        /// WebAssembly execution will automatically consume fuel but if so desired the embedder can also consume fuel manually
+        /// to account for relative costs of host functions, for example.
+        ///
+        /// This method will attempt to consume <paramref name="fuel"/> units of fuel from within this store. If the remaining
+        /// amount of fuel allows this then the amount of remaining fuel is returned. Otherwise, a <see cref="WasmtimeException"/>
+        /// is thrown and no fuel is consumed.
+        /// </summary>
+        /// <param name="fuel">The fuel to consume from the store.</param>
+        /// <returns>Returns the remaining amount of fuel.</returns>
+        /// <exception cref="WasmtimeException">Thrown if more fuel is consumed than the store currently has.</exception>
+        public ulong ConsumeFuel(ulong fuel) => ((IStore)this).Context.ConsumeFuel(fuel);
+
+        /// <summary>
+        /// Gets the fuel consumed by the executing WebAssembly code.
+        /// </summary>
+        /// <returns>Returns the fuel consumed by the executing WebAssembly code or 0 if fuel consumption was not enabled.</returns>
+        public ulong GetConsumedFuel() => ((IStore)this).Context.GetConsumedFuel();
+
         private static class Native
         {
             [DllImport(Engine.LibraryName)]

--- a/tests/FuelConsumptionTests.cs
+++ b/tests/FuelConsumptionTests.cs
@@ -33,9 +33,9 @@ namespace Wasmtime.Tests
             {
                 // do nothing
             }));
-            Linker.Define("env", "expensive", Function.FromCallback(Store, () =>
+            Linker.Define("env", "expensive", Function.FromCallback(Store, (Caller caller) =>
             {
-                Store.ConsumeFuel(100UL);
+                caller.ConsumeFuel(100UL);
             }));
         }
 

--- a/tests/FuelConsumptionTests.cs
+++ b/tests/FuelConsumptionTests.cs
@@ -1,0 +1,234 @@
+﻿using FluentAssertions;
+using System;
+using Xunit;
+
+namespace Wasmtime.Tests
+{
+    public class FuelConsumptionFixture : ModuleFixture
+    {
+        protected override string ModuleFileName => "FuelConsumption.wat";
+
+        public override Config GetEngineConfig()
+        {
+            return base.GetEngineConfig()
+                .WithFuelConsumption(true);
+        }
+    }
+
+    public class FuelConsumptionTests : IClassFixture<FuelConsumptionFixture>, IDisposable
+    {
+        private Store Store { get; set; }
+
+        private Linker Linker { get; set; }
+
+        private FuelConsumptionFixture Fixture { get; }
+
+        public FuelConsumptionTests(FuelConsumptionFixture fixture)
+        {
+            Fixture = fixture;
+            Linker = new Linker(Fixture.Engine);
+            Store = new Store(Fixture.Engine);
+
+            Linker.Define("env", "free", Function.FromCallback(Store, () =>
+            {
+                // do nothing
+            }));
+            Linker.Define("env", "expensive", Function.FromCallback(Store, () =>
+            {
+                Store.ConsumeFuel(100UL);
+            }));
+        }
+
+        [Fact]
+        public void ItConsumesNoFuelBeforeFuelIsAdded()
+        {
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(0UL);
+        }
+
+        [Fact]
+        public void ItConsumesNoFuelWhenFuelIsAdded()
+        {
+            Store.AddFuel(1000UL);
+
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(0UL);
+        }
+
+        [Fact]
+        public void ItConsumesAddedFuel()
+        {
+            Store.AddFuel(1000UL);
+            var remaining = Store.ConsumeFuel(250UL);
+            remaining.Should().Be(750UL);
+
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(250UL);
+        }
+
+        [Fact]
+        public void ItCanConsumeZeroFuel()
+        {
+            Store.AddFuel(1000UL);
+            var remaining = Store.ConsumeFuel(0UL);
+            remaining.Should().Be(1000UL);
+
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(0UL);
+        }
+
+        [Fact]
+        public void ItThrowsOnConsumingTooMuchFuel()
+        {
+            Store.AddFuel(1000UL);
+
+            Action action = () => Store.ConsumeFuel(2000UL);
+            action
+                .Should()
+                .Throw<WasmtimeException>()
+                .WithMessage("not enough fuel remaining in store");
+
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(0UL);
+        }
+
+        [Fact]
+        public void ItConsumesFuelWhenCallingImportMethods()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var free = instance.GetFunction(Store, "free");
+
+            Store.AddFuel(1000UL);
+
+            free.Invoke(Store);
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(2UL);
+
+            free.Invoke(Store);
+            consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(4UL);
+        }
+
+        [Fact]
+        public void ItConsumesFuelFromInsideAnImportMethod()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var expensive = instance.GetFunction(Store, "expensive");
+
+            Store.AddFuel(1000UL);
+
+            expensive.Invoke(Store);
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(102UL);
+        }
+
+        [Fact]
+        public void ItThrowsOnCallingImportMethodIfNoFuelAdded()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var free = instance.GetFunction(Store, "free");
+
+            Action action = () => free.Invoke(Store);
+            action
+                .Should()
+                .Throw<TrapException>()
+                .WithMessage("all fuel consumed by WebAssembly");
+
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(1UL);
+        }
+
+        [Fact]
+        public void ItThrowsOnCallingImportMethodIfNotEnoughFuelAdded()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var free = instance.GetFunction(Store, "free");
+
+            Store.AddFuel(4UL);
+
+            free.Invoke(Store);
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(2UL);
+
+            free.Invoke(Store);
+            consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(4UL);
+
+            Action action = () => free.Invoke(Store);
+            action
+                .Should()
+                .Throw<TrapException>()
+                .WithMessage("all fuel consumed by WebAssembly");
+
+            consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(5UL);
+        }
+
+        [Fact]
+        public void ItThrowsWhenConsumingTooMuchFuelFromInsideAnImportMethod()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var expensive = instance.GetFunction(Store, "expensive");
+
+            Store.AddFuel(50UL);
+
+            Action action = () => expensive.Invoke(Store);
+            action
+                .Should()
+                .Throw<TrapException>()
+                .WithMessage(
+                    "not enough fuel remaining in store\n" +
+                    "wasm backtrace:\n" +
+                    "    0:   0x4c - <unknown>!expensive\n");
+
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(2UL);
+        }
+
+        [Fact]
+        public void ItAddsAdditonalFuelAfterCallingImportMethods()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var free = instance.GetFunction(Store, "free");
+
+            Store.AddFuel(4UL);
+
+            free.Invoke(Store);
+            var consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(2UL);
+
+            free.Invoke(Store);
+            consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(4UL);
+
+            Action action = () => free.Invoke(Store);
+            action
+                .Should()
+                .Throw<TrapException>()
+                .WithMessage("all fuel consumed by WebAssembly");
+
+            consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(5UL);
+
+            Store.AddFuel(3UL);
+
+            free.Invoke(Store);
+            consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(7UL);
+
+            action
+                .Should()
+                .Throw<TrapException>()
+                .WithMessage("all fuel consumed by WebAssembly");
+
+            consumed = Store.GetConsumedFuel();
+            consumed.Should().Be(8UL);
+        }
+
+        public void Dispose()
+        {
+            Store.Dispose();
+            Linker.Dispose();
+        }
+    }
+}

--- a/tests/FuelConsumptionTests.cs
+++ b/tests/FuelConsumptionTests.cs
@@ -176,10 +176,7 @@ namespace Wasmtime.Tests
             action
                 .Should()
                 .Throw<TrapException>()
-                .WithMessage(
-                    "not enough fuel remaining in store\n" +
-                    "wasm backtrace:\n" +
-                    "    0:   0x4c - <unknown>!expensive\n");
+                .WithMessage("not enough fuel remaining in store*");
 
             var consumed = Store.GetConsumedFuel();
             consumed.Should().Be(2UL);

--- a/tests/ModuleFixture.cs
+++ b/tests/ModuleFixture.cs
@@ -8,9 +8,15 @@ namespace Wasmtime.Tests
     {
         public ModuleFixture()
         {
-            Engine = new Engine(new Config().WithReferenceTypes(true));
+            Engine = new Engine(GetEngineConfig());
 
             Module = Wasmtime.Module.FromTextFile(Engine, Path.Combine("Modules", ModuleFileName));
+        }
+
+        public virtual Config GetEngineConfig()
+        {
+            return new Config()
+                .WithReferenceTypes(true);
         }
 
         public void Dispose()

--- a/tests/Modules/FuelConsumption.wat
+++ b/tests/Modules/FuelConsumption.wat
@@ -1,0 +1,12 @@
+(module
+  (import "env" "expensive" (func $env.expensive))
+  (import "env" "free" (func $env.free))
+  (func $expensive
+    call $env.expensive
+  )
+  (func $free
+    call $env.free
+  )
+  (export "expensive" (func $expensive))
+  (export "free" (func $free))
+)


### PR DESCRIPTION
Here's a PR for https://github.com/bytecodealliance/wasmtime-dotnet/issues/106

* Added tests for existing Store fuel functionality, specifically AddFuel and GetConsumedFuel.
* Added a virtual method GetEngineConfig to the ModuleFixture class to add customized Engine configs.
* Added a pinvoke call to wasmtime_context_consume_fuel and wired that up through the Store.
* Added tests for the above.
* Added an example for consuming fuel.
