### PR TITLE
Added an ability to get function from Caller

### DIFF
--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -48,6 +48,35 @@ namespace Wasmtime
             }
         }
 
+        /// <summary>
+        /// Gets an exported function of the caller by the given name.
+        /// </summary>
+        /// <param name="name">The name of the exported function.</param>
+        /// <returns>Returns the exported function if found or null if a function of the requested name is not exported.</returns>
+        public Function? GetFunction(string name)
+        {
+            unsafe
+            {
+                var bytes = Encoding.UTF8.GetBytes(name);
+
+                fixed (byte* ptr = bytes)
+                {
+                    if (!Native.wasmtime_caller_export_get(NativeHandle, ptr, (UIntPtr)bytes.Length, out var item))
+                    {
+                        return null;
+                    }
+
+                    if (item.kind != ExternKind.Func)
+                    {
+                        item.Dispose();
+                        return null;
+                    }
+
+                    return new Function(((IStore)this).Context, item.of.func);
+                }
+            }
+        }
+
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/tests/CallExportFromImportTests.cs
+++ b/tests/CallExportFromImportTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Wasmtime.Tests
+{
+    public class CallExportFromImportFixture : ModuleFixture
+    {
+        protected override string ModuleFileName => "CallExportFromImport.wat";
+    }
+
+    public class CallExportFromImportTests : IClassFixture<CallExportFromImportFixture>, IDisposable
+    {
+        private CallExportFromImportFixture Fixture { get; }
+        private Store Store { get; }
+        private Linker Linker { get; }
+
+        public CallExportFromImportTests(CallExportFromImportFixture fixture)
+        {
+            Fixture = fixture;
+            Store = new Store(Fixture.Engine);
+            Linker = new Linker(Fixture.Engine);
+        }
+
+        [Fact]
+        public void ItCallsExportedFunctionFromImportedFunction()
+        {
+            Linker.DefineFunction("env", "getInt", (Caller caller, int arg) =>
+            {
+                var shiftLeftFunc = caller.GetFunction("shiftLeft");
+
+                return (int) shiftLeftFunc.Invoke(caller, arg);
+            });
+
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var testFunction = instance.GetFunction(Store, "testFunction");
+
+            var result = (int) testFunction.Invoke(Store, 2);
+            result.Should().Be(2 << 1);
+        }
+
+        public void Dispose()
+        {
+            Store?.Dispose();
+            Linker?.Dispose();
+        }
+    }
+}

--- a/tests/Modules/CallExportFromImport.wat
+++ b/tests/Modules/CallExportFromImport.wat
@@ -1,0 +1,17 @@
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "env" "getInt" (func $assembly/env/getInt (param i32) (result i32)))
+ (memory $0 1 1)
+ (export "testFunction" (func $assembly/index/testFunction))
+ (export "shiftLeft" (func $assembly/index/shiftLeft))
+ (export "memory" (memory $0))
+ (func $assembly/index/testFunction (param $0 i32) (result i32)
+  local.get $0
+  call $assembly/env/getInt
+ )
+ (func $assembly/index/shiftLeft (param $0 i32) (result i32)
+  local.get $0
+  i32.const 1
+  i32.shl
+ )
+)


### PR DESCRIPTION
Allows getting functions from Caller in the scope of imported function.
```csharp
         linker.Define("env", "computeSha256", Function.FromCallback(store,
                (Caller caller, int dataPtr) =>
                {
                    var memory = caller.GetMemory("memory");
                    var data = ReadBytes(dataPtr, memory, caller);
                    var hash = SHA256.Create().ComputeHash(data);

                    var allocFunc = caller.GetFunction("alloc");
                    var hashPtr = (int) allocFunc.Invoke(store, hash.Length);

                    hash.CopyTo(memory.GetSpan(store).Slice(hashPtr, hash.Length));
                }));
```