### PR TITLE
Fix CI by updating an expected error message.

### DIFF
--- a/tests/InvalidModuleTests.cs
+++ b/tests/InvalidModuleTests.cs
@@ -23,7 +23,7 @@ namespace Wasmtime.Tests
         public void ItReturnsAnErrorWhenValidatingAnInvalidModule()
         {
             using var engine = new Engine();
-            Module.Validate(engine, Array.Empty<byte>()).Should().Be("unexpected end-of-file (at offset 0)");
+            Module.Validate(engine, Array.Empty<byte>()).Should().Be("unexpected end-of-file (at offset 0x0)");
         }
     }
 }


### PR DESCRIPTION
Wasmtime upstream updated wasm-tools, which includes a tweaked error message
that caused a test failure.

This commit updates the message to fix the failing test.