### PR TITLE
ValueBox

### DIFF
--- a/src/Function.cs
+++ b/src/Function.cs
@@ -14,6 +14,7 @@ namespace Wasmtime
     /// </summary>
     public class Function : IExternal
     {
+        #region FromCallback
         /// <summary>
         /// Creates a function given a callback.
         /// </summary>
@@ -523,6 +524,7 @@ namespace Wasmtime
 
             return new Function(store.Context, callback, true);
         }
+        #endregion
 
         /// <summary>
         /// The parameters of the WebAssembly function.
@@ -545,6 +547,25 @@ namespace Wasmtime
         public static Function Null => _null;
 
         /// <summary>
+        /// Invokes the Wasmtime function with no arguments.
+        /// </summary>
+        /// <param name="store">The store that owns this function.</param>
+        /// <returns>
+        ///   Returns null if the function has no return value.
+        ///   Returns the value if the function returns a single value.
+        ///   Returns an array of values if the function returns more than one value.
+        /// </returns>
+        public object? Invoke(IStore store)
+        {
+            if (store is null)
+            {
+                throw new ArgumentNullException(nameof(store));
+            }
+
+            return Invoke(store, new ReadOnlySpan<ValueBox>());
+        }
+
+        /// <summary>
         /// Invokes the Wasmtime function.
         /// </summary>
         /// <param name="store">The store that owns this function.</param>
@@ -554,80 +575,74 @@ namespace Wasmtime
         ///   Returns the value if the function returns a single value.
         ///   Returns an array of values if the function returns more than one value.
         /// </returns>
-        public object? Invoke(IStore store, params object?[] arguments)
+        // TODO: remove overload when https://github.com/dotnet/csharplang/issues/1757 is resolved
+        public object? Invoke(IStore store, params ValueBox[] arguments)
         {
             if (store is null)
             {
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return Invoke(store.Context, (ReadOnlySpan<object?>)(arguments ?? NullParams));
+            return Invoke(store, (ReadOnlySpan<ValueBox>)arguments);
         }
 
-        // TODO: remove overload when https://github.com/dotnet/csharplang/issues/1757 is resolved
-        private object? Invoke(StoreContext context, ReadOnlySpan<object?> arguments)
+        /// <summary>
+        /// Invokes the Wasmtime function.
+        /// </summary>
+        /// <param name="store">The store that owns this function.</param>
+        /// <param name="arguments">The arguments to pass to the function, wrapped in `ArgBox`</param>
+        /// <returns>
+        ///   Returns null if the function has no return value.
+        ///   Returns the value if the function returns a single value.
+        ///   Returns an array of values if the function returns more than one value.
+        /// </returns>
+        public object? Invoke(IStore store, ReadOnlySpan<ValueBox> arguments)
         {
             if (IsNull)
-            {
                 throw new InvalidOperationException("Cannot invoke a null function reference.");
-            }
 
             if (arguments.Length != Parameters.Count)
-            {
                 throw new WasmtimeException($"Argument mismatch when invoking function: requires {Parameters.Count} but was given {arguments.Length}.");
-            }
 
+            if (store is null)
+                throw new ArgumentNullException(nameof(store));
+
+            var context = store.Context;
             unsafe
             {
                 Value* args = stackalloc Value[Parameters.Count];
                 Value* results = stackalloc Value[Results.Count];
 
                 for (int i = 0; i < arguments.Length; ++i)
-                {
-                    args[i] = Value.FromObject(arguments[i], Parameters[i]);
-                }
+                    args[i] = arguments[i].ToValue(Parameters[i]);
 
-                var error = Native.wasmtime_func_call(context.handle, this.func, args, (UIntPtr)Parameters.Count, results, (UIntPtr)Results.Count, out var trap);
+                var error = Native.wasmtime_func_call(context.handle, func, args, (UIntPtr)Parameters.Count, results, (UIntPtr)Results.Count, out var trap);
                 if (error != IntPtr.Zero)
-                {
                     throw WasmtimeException.FromOwnedError(error);
-                }
 
                 for (int i = 0; i < arguments.Length; ++i)
-                {
                     args[i].Dispose();
-                }
 
                 if (trap != IntPtr.Zero)
-                {
                     throw TrapException.FromOwnedTrap(trap);
-                }
 
                 if (Results.Count == 0)
-                {
                     return null;
-                }
 
                 try
                 {
                     if (Results.Count == 1)
-                    {
                         return results[0].ToObject(context);
-                    }
 
                     var ret = new object?[Results.Count];
                     for (int i = 0; i < Results.Count; ++i)
-                    {
                         ret[i] = results[i].ToObject(context);
-                    }
                     return ret;
                 }
                 finally
                 {
                     for (int i = 0; i < Results.Count; ++i)
-                    {
                         results[i].Dispose();
-                    }
                 }
             }
         }

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -590,7 +590,7 @@ namespace Wasmtime
         /// Invokes the Wasmtime function.
         /// </summary>
         /// <param name="store">The store that owns this function.</param>
-        /// <param name="arguments">The arguments to pass to the function, wrapped in `ArgBox`</param>
+        /// <param name="arguments">The arguments to pass to the function, wrapped in `ValueBox`</param>
         /// <returns>
         ///   Returns null if the function has no return value.
         ///   Returns the value if the function returns a single value.

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -599,13 +599,19 @@ namespace Wasmtime
         public object? Invoke(IStore store, ReadOnlySpan<ValueBox> arguments)
         {
             if (IsNull)
+            {
                 throw new InvalidOperationException("Cannot invoke a null function reference.");
+            }
 
             if (arguments.Length != Parameters.Count)
+            {
                 throw new WasmtimeException($"Argument mismatch when invoking function: requires {Parameters.Count} but was given {arguments.Length}.");
+            }
 
             if (store is null)
+            {
                 throw new ArgumentNullException(nameof(store));
+            }
 
             var context = store.Context;
             unsafe
@@ -618,31 +624,46 @@ namespace Wasmtime
 
                 var error = Native.wasmtime_func_call(context.handle, func, args, (UIntPtr)Parameters.Count, results, (UIntPtr)Results.Count, out var trap);
                 if (error != IntPtr.Zero)
+                {
                     throw WasmtimeException.FromOwnedError(error);
+                }
 
                 for (int i = 0; i < arguments.Length; ++i)
+                {
                     args[i].Dispose();
+                }
 
                 if (trap != IntPtr.Zero)
+                {
                     throw TrapException.FromOwnedTrap(trap);
+                }
 
                 if (Results.Count == 0)
+                {
                     return null;
+                }
 
                 try
                 {
                     if (Results.Count == 1)
+                    {
                         return results[0].ToObject(context);
+                    }
 
                     var ret = new object?[Results.Count];
                     for (int i = 0; i < Results.Count; ++i)
+                    {
                         ret[i] = results[i].ToObject(context);
+                    }
+
                     return ret;
                 }
                 finally
                 {
                     for (int i = 0; i < Results.Count; ++i)
+                    {
                         results[i].Dispose();
+                    }
                 }
             }
         }

--- a/src/V128.cs
+++ b/src/V128.cs
@@ -18,7 +18,7 @@ namespace Wasmtime
             byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue
         );
 
-        private unsafe fixed byte Value[16];
+        private unsafe fixed byte bytes[16];
 
         /// <summary>
         /// Construct a new V128 from a 16 element byte span
@@ -28,70 +28,81 @@ namespace Wasmtime
         public V128(ReadOnlySpan<byte> bytes)
         {
             if (bytes.Length != 16)
+            {
                 throw new ArgumentException("Must supply exactly 16 bytes to construct V128");
+            }
 
             unsafe
             {
-                fixed (byte* value = Value)
-                    bytes.CopyTo(new Span<byte>(value, 16));
+                fixed (byte* bytesPtr = this.bytes)
+                {
+                    bytes.CopyTo(new Span<byte>(bytesPtr, 16));
+                }
             }
         }
 
         /// <summary>
         /// Construct a new V128 from 16 bytes
         /// </summary>
-        /// <param name="e0"></param>
-        /// <param name="e1"></param>
-        /// <param name="e2"></param>
-        /// <param name="e3"></param>
-        /// <param name="e4"></param>
-        /// <param name="e5"></param>
-        /// <param name="e6"></param>
-        /// <param name="e7"></param>
-        /// <param name="e8"></param>
-        /// <param name="e9"></param>
-        /// <param name="e10"></param>
-        /// <param name="e11"></param>
-        /// <param name="e12"></param>
-        /// <param name="e13"></param>
-        /// <param name="e14"></param>
-        /// <param name="e15"></param>
-        public V128(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15)
+        /// <param name="b0">First byte.</param>
+        /// <param name="b1">Second byte.</param>
+        /// <param name="b2">Third byte.</param>
+        /// <param name="b3">Fourth byte.</param>
+        /// <param name="b4">Fifth byte.</param>
+        /// <param name="b5">Sixth byte.</param>
+        /// <param name="b6">Seventh byte.</param>
+        /// <param name="b7">Eighth byte.</param>
+        /// <param name="b8">Ninth byte.</param>
+        /// <param name="b9">Tenth byte.</param>
+        /// <param name="b10">Eleventh byte.</param>
+        /// <param name="b11">Twelfth byte.</param>
+        /// <param name="b12">Thirteenth byte.</param>
+        /// <param name="b13">Fourteenth byte.</param>
+        /// <param name="b14">Fifteenth byte.</param>
+        /// <param name="b15">Sixteenth byte.</param>
+        public V128(byte b0, byte b1, byte b2, byte b3, byte b4, byte b5, byte b6, byte b7, byte b8, byte b9, byte b10, byte b11, byte b12, byte b13, byte b14, byte b15)
         {
             unsafe
             {
-                Value[0] = e0;
-                Value[1] = e1;
-                Value[2] = e2;
-                Value[3] = e3;
-                Value[4] = e4;
-                Value[5] = e5;
-                Value[6] = e6;
-                Value[7] = e7;
-                Value[8] = e8;
-                Value[9] = e9;
-                Value[10] = e10;
-                Value[11] = e11;
-                Value[12] = e12;
-                Value[13] = e13;
-                Value[14] = e14;
-                Value[15] = e15;
+                bytes[0] = b0;
+                bytes[1] = b1;
+                bytes[2] = b2;
+                bytes[3] = b3;
+                bytes[4] = b4;
+                bytes[5] = b5;
+                bytes[6] = b6;
+                bytes[7] = b7;
+                bytes[8] = b8;
+                bytes[9] = b9;
+                bytes[10] = b10;
+                bytes[11] = b11;
+                bytes[12] = b12;
+                bytes[13] = b13;
+                bytes[14] = b14;
+                bytes[15] = b15;
             }
         }
 
         internal unsafe V128(byte* src)
         {
-            fixed (byte* value = Value)
+            fixed (byte* dest = bytes)
             {
-                Unsafe.CopyBlock(value, src, 16);
+                Unsafe.CopyBlock(dest, src, 16);
             }
         }
 
         internal unsafe void CopyTo(byte* dest)
         {
-            for (int i = 0; i < 16; i++)
+            var dst = new Span<byte>(dest, 16);
+            CopyTo(dst);
+        }
+
+        internal unsafe void CopyTo(Span<byte> dest)
+        {
+            fixed (byte* bytesPtr = bytes)
             {
-                dest[i] = Value[i];
+                var src = new Span<byte>(bytesPtr, 16);
+                src.CopyTo(dest);
             }
         }
     }

--- a/src/V128.cs
+++ b/src/V128.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Windows.Markup;
+
+namespace Wasmtime
+{
+    /// <summary>
+    /// A 128 bit value
+    /// </summary>
+    public struct V128
+    {
+        /// <summary>
+        /// Get a V128 with all bits set to 1
+        /// </summary>
+        public static readonly V128 AllBitsSet = new V128(
+            byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue,
+            byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue,
+            byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue,
+            byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue
+        );
+
+        private unsafe fixed byte Value[16];
+
+        /// <summary>
+        /// Construct a new V128 from a 16 element byte span
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <exception cref="ArgumentException"></exception>
+        public V128(ReadOnlySpan<byte> bytes)
+        {
+            if (bytes.Length != 16)
+                throw new ArgumentException("Must supply exactly 16 bytes to construct V128");
+
+            unsafe
+            {
+                fixed (byte* value = Value)
+                    bytes.CopyTo(new Span<byte>(value, 16));
+            }
+        }
+
+        /// <summary>
+        /// Construct a new V128 from 16 bytes
+        /// </summary>
+        /// <param name="e0"></param>
+        /// <param name="e1"></param>
+        /// <param name="e2"></param>
+        /// <param name="e3"></param>
+        /// <param name="e4"></param>
+        /// <param name="e5"></param>
+        /// <param name="e6"></param>
+        /// <param name="e7"></param>
+        /// <param name="e8"></param>
+        /// <param name="e9"></param>
+        /// <param name="e10"></param>
+        /// <param name="e11"></param>
+        /// <param name="e12"></param>
+        /// <param name="e13"></param>
+        /// <param name="e14"></param>
+        /// <param name="e15"></param>
+        public V128(byte e0, byte e1, byte e2, byte e3, byte e4, byte e5, byte e6, byte e7, byte e8, byte e9, byte e10, byte e11, byte e12, byte e13, byte e14, byte e15)
+        {
+            unsafe
+            {
+                Value[0] = e0;
+                Value[1] = e1;
+                Value[2] = e2;
+                Value[3] = e3;
+                Value[4] = e4;
+                Value[5] = e5;
+                Value[6] = e6;
+                Value[7] = e7;
+                Value[8] = e8;
+                Value[9] = e9;
+                Value[10] = e10;
+                Value[11] = e11;
+                Value[12] = e12;
+                Value[13] = e13;
+                Value[14] = e14;
+                Value[15] = e15;
+            }
+        }
+
+        internal unsafe V128(byte* src)
+        {
+            fixed (byte* value = Value)
+            {
+                Unsafe.CopyBlock(value, src, 16);
+            }
+        }
+
+        internal unsafe void CopyTo(byte* dest)
+        {
+            for (int i = 0; i < 16; i++)
+            {
+                dest[i] = Value[i];
+            }
+        }
+    }
+}

--- a/src/V128.cs
+++ b/src/V128.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-using System.Windows.Markup;
 
 namespace Wasmtime
 {

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -325,7 +325,9 @@ namespace Wasmtime
                     unsafe
                     {
                         fixed (byte* v128 = of.v128)
+                        {
                             return new V128(v128);
+                        }
                     }
 
                 case ValueKind.ExternRef:

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -199,7 +199,7 @@ namespace Wasmtime
             return false;
         }
 
-        public static Value FromArgBox(ValueBox box)
+        public static Value FromValueBox(ValueBox box)
         {
             var value = new Value();
             value.kind = box.Kind;

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -178,7 +178,7 @@ namespace Wasmtime
                 return true;
             }
 
-            if (type == typeof(Vector128<byte>))
+            if (type == typeof(V128))
             {
                 kind = ValueKind.V128;
                 return true;
@@ -258,14 +258,10 @@ namespace Wasmtime
                     case ValueKind.V128:
                         if (o is null)
                             throw new WasmtimeException($"The value `null` is not valid for WebAssembly type {kind}.");
-                        var bytes = (Vector128<byte>)o;
-
+                        var bytes = (V128)o;
                         unsafe
                         {
-                            for (int i = 0; i < 16; ++i)
-                            {
-                                value.of.v128[i] = bytes.GetElement(i);
-                            }
+                            bytes.CopyTo(value.of.v128);
                         }
                         break;
 
@@ -328,24 +324,8 @@ namespace Wasmtime
                 case ValueKind.V128:
                     unsafe
                     {
-                        return Vector128.Create(
-                            of.v128[0],
-                            of.v128[1],
-                            of.v128[2],
-                            of.v128[3],
-                            of.v128[4],
-                            of.v128[5],
-                            of.v128[6],
-                            of.v128[7],
-                            of.v128[8],
-                            of.v128[9],
-                            of.v128[10],
-                            of.v128[11],
-                            of.v128[12],
-                            of.v128[13],
-                            of.v128[14],
-                            of.v128[15]
-                        );
+                        fixed (byte* v128 = of.v128)
+                            return new V128(v128);
                     }
 
                 case ValueKind.ExternRef:

--- a/src/ValueBox.cs
+++ b/src/ValueBox.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Intrinsics;
 
 namespace Wasmtime
 {
@@ -95,6 +96,24 @@ namespace Wasmtime
         public static implicit operator ValueBox(double value)
         {
             return new ValueBox(ValueKind.Float64, new ValueUnion { f64 = value });
+        }
+
+        /// <summary>
+        /// "Box" a 16 element vector of bytes without any heap allocations
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ValueBox(Vector128<byte> value)
+        {
+            var union = new ValueUnion();
+            unsafe
+            {
+                for (int i = 0; i < 16; i++)
+                {
+                    union.v128[i] = value.GetElement(i);
+                }
+            }
+
+            return new ValueBox(ValueKind.V128, union);
         }
 
         /// <summary>

--- a/src/ValueBox.cs
+++ b/src/ValueBox.cs
@@ -102,15 +102,12 @@ namespace Wasmtime
         /// "Box" a 16 element vector of bytes without any heap allocations
         /// </summary>
         /// <param name="value"></param>
-        public static implicit operator ValueBox(Vector128<byte> value)
+        public static implicit operator ValueBox(V128 value)
         {
             var union = new ValueUnion();
             unsafe
             {
-                for (int i = 0; i < 16; i++)
-                {
-                    union.v128[i] = value.GetElement(i);
-                }
+                value.CopyTo(union.v128);
             }
 
             return new ValueBox(ValueKind.V128, union);

--- a/src/ValueBox.cs
+++ b/src/ValueBox.cs
@@ -18,7 +18,7 @@ namespace Wasmtime
             ExternRefObject = null;
         }
 
-        internal ValueBox(object externref)
+        internal ValueBox(object? externref)
         {
             Kind = ValueKind.ExternRef;
             Union = default;
@@ -28,9 +28,9 @@ namespace Wasmtime
         internal Value ToValue(ValueKind convertTo)
         {
             if (convertTo != Kind)
-                return Value.FromArgBox(ConvertTo(convertTo));
+                return Value.FromValueBox(ConvertTo(convertTo));
 
-            return Value.FromArgBox(this);
+            return Value.FromValueBox(this);
         }
 
         internal ValueBox ConvertTo(ValueKind convertTo)
@@ -148,7 +148,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static ValueBox AsBox<T>(T value)
+        public static ValueBox AsBox<T>(T? value)
             where T : class
         {
             return new ValueBox(value);

--- a/src/ValueBox.cs
+++ b/src/ValueBox.cs
@@ -148,7 +148,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static ValueBox AsArg<T>(T value)
+        public static ValueBox AsBox<T>(T value)
             where T : class
         {
             return new ValueBox(value);

--- a/src/ValueBox.cs
+++ b/src/ValueBox.cs
@@ -1,0 +1,157 @@
+﻿using System;
+
+namespace Wasmtime
+{
+    /// <summary>
+    /// Allocation free container for a single value
+    /// </summary>
+    public readonly struct ValueBox
+    {
+        internal readonly ValueKind Kind;
+        internal readonly ValueUnion Union;
+        internal readonly object? ExternRefObject;
+
+        internal ValueBox(ValueKind kind, ValueUnion of)
+        {
+            Kind = kind;
+            Union = of;
+            ExternRefObject = null;
+        }
+
+        internal ValueBox(object externref)
+        {
+            Kind = ValueKind.ExternRef;
+            Union = default;
+            ExternRefObject = externref;
+        }
+
+        internal Value ToValue(ValueKind convertTo)
+        {
+            if (convertTo != Kind)
+                return Value.FromArgBox(ConvertTo(convertTo));
+
+            return Value.FromArgBox(this);
+        }
+
+        internal ValueBox ConvertTo(ValueKind convertTo)
+        {
+            return (Kind, convertTo) switch
+            {
+                (ValueKind.Int32, ValueKind.Int32) => this,
+                (ValueKind.Int32, ValueKind.Int64) => Convert.ToInt64(Union.i32),
+                (ValueKind.Int32, ValueKind.Float32) => Convert.ToSingle(Union.i32),
+                (ValueKind.Int32, ValueKind.Float64) => Convert.ToDouble(Union.i32),
+
+                (ValueKind.Int64, ValueKind.Int32) => Convert.ToInt32(Union.i64),
+                (ValueKind.Int64, ValueKind.Int64) => Convert.ToInt64(Union.i64),
+                (ValueKind.Int64, ValueKind.Float32) => Convert.ToSingle(Union.i64),
+                (ValueKind.Int64, ValueKind.Float64) => Convert.ToDouble(Union.i64),
+
+                (ValueKind.Float32, ValueKind.Int32) => Convert.ToInt32(Union.f32),
+                (ValueKind.Float32, ValueKind.Int64) => Convert.ToInt64(Union.f32),
+                (ValueKind.Float32, ValueKind.Float32) => Convert.ToSingle(Union.f32),
+                (ValueKind.Float32, ValueKind.Float64) => Convert.ToDouble(Union.f32),
+
+                (ValueKind.Float64, ValueKind.Int32) => Convert.ToInt32(Union.f64),
+                (ValueKind.Float64, ValueKind.Int64) => Convert.ToInt64(Union.f64),
+                (ValueKind.Float64, ValueKind.Float32) => Convert.ToSingle(Union.f64),
+                (ValueKind.Float64, ValueKind.Float64) => Convert.ToDouble(Union.f64),
+
+                _ => throw new InvalidCastException($"Cannot convert from `{Kind}` to `{convertTo}`")
+            };
+        }
+
+        /// <summary>
+        /// "Box" an int without any heap allocations
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ValueBox(int value)
+        {
+            return new ValueBox(ValueKind.Int32, new ValueUnion { i32 = value });
+        }
+
+        /// <summary>
+        /// "Box" a long without any heap allocations
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ValueBox(long value)
+        {
+            return new ValueBox(ValueKind.Int64, new ValueUnion { i64 = value });
+        }
+
+        /// <summary>
+        /// "Box" a float without any heap allocations
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ValueBox(float value)
+        {
+            return new ValueBox(ValueKind.Float32, new ValueUnion { f32 = value });
+        }
+
+        /// <summary>
+        /// "Box" a double without any heap allocations
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ValueBox(double value)
+        {
+            return new ValueBox(ValueKind.Float64, new ValueUnion { f64 = value });
+        }
+
+        /// <summary>
+        /// "Box" a 16 element byte array without any heap allocations
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator ValueBox(byte[] value)
+        {
+            return (ValueBox)(ReadOnlySpan<byte>)value;
+        }
+
+        /// <summary>
+        /// "Box" a 16 element byte span without any heap allocations
+        /// </summary>
+        /// <param name="value"></param>
+        public static explicit operator ValueBox(ReadOnlySpan<byte> value)
+        {
+            if (value.Length != 16)
+                throw new ArgumentException("expected a 16 byte array for a v128 value", nameof(value));
+
+            var union = new ValueUnion();
+            unsafe
+            {
+                value.CopyTo(new Span<byte>(union.v128, 16));
+            }
+
+            return new ValueBox(ValueKind.V128, union);
+        }
+
+        /// <summary>
+        /// "Box" a function without any heap allocations
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ValueBox(Function? value)
+        {
+            var func = value?.func ?? Function.Null.func;
+            return new ValueBox(ValueKind.FuncRef, new ValueUnion { funcref = func });
+        }
+
+        /// <summary>
+        /// "Box" a string without any heap allocations
+        /// </summary>
+        /// <param name="value"></param>
+        public static implicit operator ValueBox(string value)
+        {
+            return new ValueBox(value);
+        }
+
+        /// <summary>
+        /// "Box" an arbitrary reference type without any heap allocations
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ValueBox AsArg<T>(T value)
+            where T : class
+        {
+            return new ValueBox(value);
+        }
+    }
+}

--- a/tests/ExternRefTests.cs
+++ b/tests/ExternRefTests.cs
@@ -49,7 +49,7 @@ namespace Wasmtime.Tests
             var nullref = instance.GetFunction(Store, "nullref");
             inout.Should().NotBeNull();
 
-            (inout.Invoke(Store, ValueBox.AsArg((object?)null))).Should().BeNull();
+            (inout.Invoke(Store, ValueBox.AsBox((object?)null))).Should().BeNull();
             (nullref.Invoke(Store)).Should().BeNull();
         }
 
@@ -90,7 +90,7 @@ namespace Wasmtime.Tests
                 inout.Should().NotBeNull();
                 for (int i = 0; i < 100; ++i)
                 {
-                    inout.Invoke(Store, ValueBox.AsArg(new Value(counter)));
+                    inout.Invoke(Store, ValueBox.AsBox(new Value(counter)));
                 }
 
                 Store.Dispose();
@@ -109,7 +109,7 @@ namespace Wasmtime.Tests
             var inout = instance.GetFunction(Store, "inout");
             inout.Should().NotBeNull();
 
-            Action action = () => inout.Invoke(Store, ValueBox.AsArg((object)5));
+            Action action = () => inout.Invoke(Store, ValueBox.AsBox((object)5));
 
             action
                 .Should()

--- a/tests/ExternRefTests.cs
+++ b/tests/ExternRefTests.cs
@@ -49,7 +49,7 @@ namespace Wasmtime.Tests
             var nullref = instance.GetFunction(Store, "nullref");
             inout.Should().NotBeNull();
 
-            (inout.Invoke(Store, null)).Should().BeNull();
+            (inout.Invoke(Store, ValueBox.AsArg((object?)null))).Should().BeNull();
             (nullref.Invoke(Store)).Should().BeNull();
         }
 
@@ -90,7 +90,7 @@ namespace Wasmtime.Tests
                 inout.Should().NotBeNull();
                 for (int i = 0; i < 100; ++i)
                 {
-                    inout.Invoke(Store, new Value(counter));
+                    inout.Invoke(Store, ValueBox.AsArg(new Value(counter)));
                 }
 
                 Store.Dispose();
@@ -109,7 +109,7 @@ namespace Wasmtime.Tests
             var inout = instance.GetFunction(Store, "inout");
             inout.Should().NotBeNull();
 
-            Action action = () => inout.Invoke(Store, (object)5);
+            Action action = () => inout.Invoke(Store, ValueBox.AsArg((object)5));
 
             action
                 .Should()

--- a/tests/ExternRefTests.cs
+++ b/tests/ExternRefTests.cs
@@ -49,7 +49,7 @@ namespace Wasmtime.Tests
             var nullref = instance.GetFunction(Store, "nullref");
             inout.Should().NotBeNull();
 
-            (inout.Invoke(Store, ValueBox.AsBox((object?)null))).Should().BeNull();
+            (inout.Invoke(Store, ValueBox.AsBox((object)null))).Should().BeNull();
             (nullref.Invoke(Store)).Should().BeNull();
         }
 

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -66,7 +66,7 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
-        public void ItWrapsArgumentsInArgbox()
+        public void ItWrapsArgumentsInValueBox()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var add = instance.GetFunction(Store, "add");

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using System;
+using System.Runtime.Intrinsics;
 using Xunit;
 
 namespace Wasmtime.Tests
@@ -90,6 +91,19 @@ namespace Wasmtime.Tests
                 // Ideally this should contain a check for the backtrace
                 // See: https://github.com/bytecodealliance/wasmtime/issues/1845
                 .WithMessage(THROW_MESSAGE + "*");
+        }
+
+        [Fact]
+        public void ItEchoesV128()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var echo = instance.GetFunction(Store, "$echo_v128");
+
+            var result = (Vector128<byte>)echo.Invoke(Store, Vector128<byte>.AllBitsSet);
+
+            result
+                .Should()
+                .Be(Vector128<byte>.AllBitsSet);
         }
 
         public void Dispose()

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -99,11 +99,11 @@ namespace Wasmtime.Tests
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var echo = instance.GetFunction(Store, "$echo_v128");
 
-            var result = (Vector128<byte>)echo.Invoke(Store, Vector128<byte>.AllBitsSet);
+            var result = (V128)echo.Invoke(Store, V128.AllBitsSet);
 
             result
                 .Should()
-                .Be(Vector128<byte>.AllBitsSet);
+                .Be(V128.AllBitsSet);
         }
 
         public void Dispose()

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -66,6 +66,17 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItWrapsArgumentsInArgbox()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var add = instance.GetFunction(Store, "add");
+
+            var args = new ValueBox[] { 40, 2 };
+            int x = (int)add.Invoke(Store, args.AsSpan());
+            x.Should().Be(42);
+        }
+
+        [Fact]
         public void ItPropagatesExceptionsToCallersViaTraps()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);

--- a/tests/Modules/Functions.wat
+++ b/tests/Modules/Functions.wat
@@ -21,4 +21,9 @@
   (call $env.check_string (i32.const 0) (i32.const 11))
  )
  (data (i32.const 0) "Hello World")
+
+ (func $echo_v128 (param v128) (result v128)
+	local.get 0
+ )
+ (export "$echo_v128" (func $echo_v128))
 )


### PR DESCRIPTION
See proposal #113.

To reduce allocations for boxing on every call this PR introduces a new `ValueBox` struct which wraps up arguments without requiring any heap allocations. Currently this is only used for function arguments, but in principle it could be used anywhere else plain old `object` references are passed around (e.g. function returns values).

## Drawbacks

1. `ValueBox` is _mostly_ invisible to the end user since things convert to it with an implict conversion. However, C# does not support user defined conversions from `object` so that has to be done with an explicit conversion method - i.e. passing `my_ref_object` becomes `ValueBox.AsBox(my_ref_object)`. I've added an implict conversion for strings, since that's likely to be a fairly common case. Unfortunately I don't see a better way to handle this situation for any other references types.

2. I had to remove the old `params object[]` method, since it confliced with the new `params ValueBox[]` method, which is a breaking API change. If you'd rather not much such a big change to the external API I can instead remove `params ValueBox[]` and require that users call it explicitly with a `ReadOnlySpan<ValueBox>` instead.

3. `params ValueBox[]` still incurs a single allocation, which can be worked around by explicitly passing in a `ReadOnlySpan<ArgBox>`, but that's not very ergonomic.

4. I haven't done anything with return types at all, they still get boxed. It's not obvious how to fix them, since the caller does not supply the return type.

## Potential Improvements

We could potentially workaround a lot of the drawbacks above by introducing a new set of generic `GetFunction` overloads which return `Func<>` or `Action<>` objects. This would have quite a few benefits:
 - Compatibility of types could be checked when `GetFunction` is called, instead of when `Invoke` is called. Potentially reducing per-call overhead.
 - Fixed number of arguments, so ergonomics issues with params array/span disappear.
 - Conversion to `ValueBox` can be done inside the `Func`/`Action` which is returned, making it invisible to the end user (`ValueBox.AsBox` doesn't need to be called externally)
 - Return type unboxing can be handled easily in the same way.
 - Fits better into a normal C# workflow - wasm functions can be used just like any other `Func`/`Action` object.

If you're interested I can put together another PR which does this (don't merge this PR if so).