### PR TITLE
add epoch interruption support

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -86,13 +86,13 @@ namespace Wasmtime
         }
 
         /// <summary>
-        /// Sets whether or not to enable interruptability of WebAssembly code.
+        /// Sets whether or not to enable epoch-based interruption of WebAssembly code.
         /// </summary>
-        /// <param name="enable">True to enable interruptability or false to disable.</param>
+        /// <param name="enable">True to enable epoch-based interruption or false to disable.</param>
         /// <returns>Returns the current config.</returns>
-        public Config WithInterruptability(bool enable)
+        public Config WithEpochInterruption(bool enable)
         {
-            Native.wasmtime_config_interruptable_set(handle, enable);
+            Native.wasmtime_config_epoch_interruption_set(handle, enable);
             return this;
         }
 
@@ -365,7 +365,7 @@ namespace Wasmtime
             public static extern void wasmtime_config_debug_info_set(Handle config, bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_interruptable_set(Handle config, bool enable);
+            public static extern void wasmtime_config_epoch_interruption_set(Handle config, bool enable);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_consume_fuel_set(Handle config, bool enable);

--- a/src/Engine.cs
+++ b/src/Engine.cs
@@ -35,11 +35,12 @@ namespace Wasmtime
         {
             handle.Dispose();
         }
-        
+
         /// <summary>
         /// Increments the epoch for epoch-based interruption
         /// </summary>
-        public void IncrementEpoch() {
+        public void IncrementEpoch()
+        {
             Native.wasmtime_engine_increment_epoch(handle.DangerousGetHandle());
         }
 
@@ -81,7 +82,7 @@ namespace Wasmtime
 
             [DllImport(LibraryName)]
             public static extern void wasm_engine_delete(IntPtr engine);
-            
+
             [DllImport(LibraryName)]
             public static extern IntPtr wasmtime_engine_increment_epoch(IntPtr engine);
         }

--- a/src/Engine.cs
+++ b/src/Engine.cs
@@ -35,6 +35,10 @@ namespace Wasmtime
         {
             handle.Dispose();
         }
+        
+        public void IncrementEpoch() {
+            Native.wasmtime_engine_increment_epoch(handle.DangerousGetHandle());
+        }
 
         internal Handle NativeHandle
         {
@@ -74,6 +78,9 @@ namespace Wasmtime
 
             [DllImport(LibraryName)]
             public static extern void wasm_engine_delete(IntPtr engine);
+            
+            [DllImport(LibraryName)]
+            public static extern IntPtr wasmtime_engine_increment_epoch(IntPtr engine);
         }
 
         private readonly Handle handle;

--- a/src/Engine.cs
+++ b/src/Engine.cs
@@ -36,6 +36,9 @@ namespace Wasmtime
             handle.Dispose();
         }
         
+        /// <summary>
+        /// Increments the epoch for epoch-based interruption
+        /// </summary>
         public void IncrementEpoch() {
             Native.wasmtime_engine_increment_epoch(handle.DangerousGetHandle());
         }

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -61,12 +61,16 @@ namespace Wasmtime
             }
         }
 
+        /// <summary>
+        /// Configures the relative deadline at which point WebAssembly code will trap.
+        /// </summary>
+        /// <param name="deadline"></param>
         public void SetEpochDeadline(ulong deadline)
         {
             Native.wasmtime_context_set_epoch_deadline(handle, deadline);
         }
 
-        public static class Native
+        private static class Native
         {
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_context_gc(IntPtr handle);
@@ -85,7 +89,7 @@ namespace Wasmtime
             public static extern IntPtr wasmtime_context_set_wasi(IntPtr handle, IntPtr config);
             
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_context_set_epoch_deadline(IntPtr handle, ulong ticks_beyond_current);
+            public static extern void wasmtime_context_set_epoch_deadline(IntPtr handle, ulong ticksBeyondCurrent);
         }
 
         internal readonly IntPtr handle;
@@ -244,8 +248,8 @@ namespace Wasmtime
         /// <summary>
         /// Configures the relative deadline at which point WebAssembly code will trap.
         /// </summary>
-        /// <param name="ticks_beyond_current"></param>
-        public void SetEpochDeadline(ulong ticks_beyond_current) => ((IStore)this).Context.SetEpochDeadline(ticks_beyond_current);
+        /// <param name="ticksBeyondCurrent"></param>
+        public void SetEpochDeadline(ulong ticksBeyondCurrent) => ((IStore)this).Context.SetEpochDeadline(ticksBeyondCurrent);
 
         StoreContext IStore.Context => new StoreContext(Native.wasmtime_store_context(NativeHandle));
 

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -61,7 +61,12 @@ namespace Wasmtime
             }
         }
 
-        private static class Native
+        public void SetEpochDeadline(ulong deadline)
+        {
+            Native.wasmtime_context_set_epoch_deadline(handle, deadline);
+        }
+
+        public static class Native
         {
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_context_gc(IntPtr handle);
@@ -78,6 +83,9 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasmtime_context_set_wasi(IntPtr handle, IntPtr config);
+            
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_context_set_epoch_deadline(IntPtr handle, ulong ticks_beyond_current);
         }
 
         internal readonly IntPtr handle;
@@ -232,6 +240,12 @@ namespace Wasmtime
         /// </summary>
         /// <param name="config">The WASI configuration to use.</param>
         public void SetWasiConfiguration(WasiConfiguration config) => ((IStore)this).Context.SetWasiConfiguration(config);
+        
+        /// <summary>
+        /// Configures the relative deadline at which point WebAssembly code will trap.
+        /// </summary>
+        /// <param name="ticks_beyond_current"></param>
+        public void SetEpochDeadline(ulong ticks_beyond_current) => ((IStore)this).Context.SetEpochDeadline(ticks_beyond_current);
 
         StoreContext IStore.Context => new StoreContext(Native.wasmtime_store_context(NativeHandle));
 

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -87,7 +87,7 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasmtime_context_set_wasi(IntPtr handle, IntPtr config);
-            
+
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_context_set_epoch_deadline(IntPtr handle, ulong ticksBeyondCurrent);
         }
@@ -244,7 +244,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="config">The WASI configuration to use.</param>
         public void SetWasiConfiguration(WasiConfiguration config) => ((IStore)this).Context.SetWasiConfiguration(config);
-        
+
         /// <summary>
         /// Configures the relative deadline at which point WebAssembly code will trap.
         /// </summary>

--- a/tests/CallExportFromImportTests.cs
+++ b/tests/CallExportFromImportTests.cs
@@ -29,13 +29,13 @@ namespace Wasmtime.Tests
             {
                 var shiftLeftFunc = caller.GetFunction("shiftLeft");
 
-                return (int) shiftLeftFunc.Invoke(caller, arg);
+                return (int)shiftLeftFunc.Invoke(caller, arg);
             });
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var testFunction = instance.GetFunction(Store, "testFunction");
 
-            var result = (int) testFunction.Invoke(Store, 2);
+            var result = (int)testFunction.Invoke(Store, 2);
             result.Should().Be(2 << 1);
         }
 

--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -35,7 +35,7 @@ namespace Wasmtime.Tests
 
             using var engine = new Engine(config);
         }
-        
+
         [Fact]
         public void ItSetsNanCanonicalization()
         {
@@ -52,7 +52,7 @@ namespace Wasmtime.Tests
             var config = new Config();
 
             config.WithEpochInterruption(true);
-            
+
             using var engine = new Engine(config);
         }
     }

--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -45,5 +45,15 @@ namespace Wasmtime.Tests
 
             using var engine = new Engine(config);
         }
+
+        [Fact]
+        public void ItSetsEpochInterruption()
+        {
+            var config = new Config();
+
+            config.WithEpochInterruption(true);
+            
+            using var engine = new Engine(config);
+        }
     }
 }

--- a/tests/EpochInterruptionTests.cs
+++ b/tests/EpochInterruptionTests.cs
@@ -38,18 +38,14 @@ public class EpochInterruptionTests : IClassFixture<EpochInterruptionFixture>, I
 
         var action = () => {
             using (var timer = new Timer(state => Fixture.Engine.IncrementEpoch())) {
-                try {
-                    timer.Change(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(Timeout.Infinite));
-                    run.Invoke(Store);
-                }
-                catch (TrapException trap) {
-                    throw new TimeoutException("Invocation timed out", trap);
-                }
+                timer.Change(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(Timeout.Infinite));
+                run.Invoke(Store);
             }
         };
 
         action.Should()
-            .Throw<TimeoutException>();
+            .Throw<TrapException>()
+            .WithMessage("epoch deadline reached during execution*");
     }
         
     public void Dispose()

--- a/tests/EpochInterruptionTests.cs
+++ b/tests/EpochInterruptionTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using FluentAssertions;
+using Xunit;
+
+namespace Wasmtime.Tests; 
+
+public class EpochInterruptionFixture : ModuleFixture
+{
+    protected override string ModuleFileName => "Interrupt.wat";
+
+    public override Config GetEngineConfig() {
+        return base.GetEngineConfig()
+            .WithEpochInterruption(true);
+    }
+}
+
+public class EpochInterruptionTests : IClassFixture<EpochInterruptionFixture>, IDisposable {
+    public Store Store { get; set; }
+
+    public Linker Linker { get; set; }
+
+    public EpochInterruptionFixture Fixture { get; }
+
+    public EpochInterruptionTests(EpochInterruptionFixture fixture)
+    {
+        Fixture = fixture;
+        Linker = new Linker(Fixture.Engine);
+        Store = new Store(Fixture.Engine);
+    }
+    
+    [Fact]
+    public void ItCanInterruptInfiniteLoop() {
+        Store.SetEpochDeadline(1);
+        
+        var instance = Linker.Instantiate(Store, Fixture.Module);
+        var run = instance.GetFunction(Store, "run");
+
+        var action = () => {
+            using (var timer = new Timer(state => Fixture.Engine.IncrementEpoch())) {
+                try {
+                    timer.Change(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(Timeout.Infinite));
+                    run.Invoke(Store);
+                }
+                catch (TrapException trap) {
+                    throw new TimeoutException("Invocation timed out", trap);
+                }
+            }
+        };
+
+        action.Should()
+            .Throw<TimeoutException>();
+    }
+        
+    public void Dispose()
+    {
+        Store.Dispose();
+        Linker.Dispose();
+    }
+}

--- a/tests/Modules/Interrupt.wat
+++ b/tests/Modules/Interrupt.wat
@@ -1,0 +1,6 @@
+(module
+  (func (export "run")
+    (loop
+      br 0)
+  )
+)


### PR DESCRIPTION
fixes: https://github.com/bytecodealliance/wasmtime-dotnet/issues/117

wasmtime removed and replaced old interruptability: https://github.com/bytecodealliance/wasmtime/commit/c22033bf9397e9bec3704ff10ca897598e3dcd08

also add a working unit test and features for this example: https://github.com/bytecodealliance/wasmtime/blob/main/examples/interrupt.c