### PR TITLE
Removed Unnecessary Import

### DIFF
--- a/src/Value.cs
+++ b/src/Value.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 
 namespace Wasmtime
 {


### PR DESCRIPTION
Removed a reference to `using System.Runtime.Intrinsics;` which I accidentally left in after experimenting with Vector128<byte>`. This is not needed and including it breaks source compatibility with Unity.