### PR TITLE
Pull aarch64 for macOS

### DIFF
--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -63,6 +63,15 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
         <WasmtimeLibraryFilename>libwasmtime.dylib</WasmtimeLibraryFilename>
         <PackagePath>runtimes/osx-x64/native/lib/libwasmtime.dylib</PackagePath>
       </WasmtimeDownload>
+      <WasmtimeDownload Include="macOS" Condition="'$(DevBuild)' != 'true' Or $([MSBuild]::IsOsPlatform('OSX'))">
+        <ReleaseFileExtension>.tar.xz</ReleaseFileExtension>
+        <ReleaseDirectory Condition="'$(DevBuild)'=='true'">wasmtime-dev-aarch64-macos-c-api</ReleaseDirectory>
+        <ReleaseDirectory Condition="'$(ReleaseDirectory)'==''">wasmtime-v$(WasmtimeVersion)-aarch64-macos-c-api</ReleaseDirectory>
+        <ReleaseFileName>%(ReleaseDirectory)%(ReleaseFileExtension)</ReleaseFileName>
+        <URL>$(ReleaseURLBase)%(ReleaseFileName)</URL>
+        <WasmtimeLibraryFilename>libwasmtime.dylib</WasmtimeLibraryFilename>
+        <PackagePath>runtimes/osx-aarch64/native/lib/libwasmtime.dylib</PackagePath>
+      </WasmtimeDownload>
       <WasmtimeDownload Include="Windows" Condition="'$(DevBuild)' != 'true' Or $([MSBuild]::IsOsPlatform('Windows'))">
         <ReleaseFileExtension>.zip</ReleaseFileExtension>
         <ReleaseDirectory>$(ReleaseFileNameBase)-windows-c-api</ReleaseDirectory>


### PR DESCRIPTION
@peterhuene I can setup an additional item to publish, but the output lib is identical for aarch64-macos and x86_64-macos, `libwasmtime.dylib`.  This results in one overriding the other in the test bin.

I tried changing the `<Content Include="..."><Link>%(WasmtimeDownload.WasmtimeLibraryFilename)</Link></Content>` to be `<Link>%(WasmtimeDownload.PackagePath)</Link>` so that the lib would be unique when copied to the output. That correctly gave me 4 libs, separated into their own runtime folders, but the tests could no longer pass. They all say the lib couldn't be found.

Have any thoughts?