### PR TITLE
Add linux-arm64 and osx-arm64 runtimes to package.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,4 +68,4 @@ jobs:
     - name: Create package
       run: |
         cd src
-        dotnet pack -c ${{ matrix.config }}
+        dotnet pack -c ${{ matrix.config }} /p:Packing=true

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Use `dotnet` to create a NuGet package:
 
 ```
 $ cd src
-$ dotnet pack Wasmtime.sln -c Release
+$ dotnet pack Wasmtime.sln -c Release /p:Packing=true
 ```
 
 This will create a `.nupkg` file in `src/bin/Release`.

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -32,77 +32,95 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
     </PackageDescription>
     <PackageLicenseExpression>Apache-2.0 WITH LLVM-exception</PackageLicenseExpression>
   </PropertyGroup>
-	
+
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="DownloadWasmtime" BeforeTargets="BeforeBuild">
     <PropertyGroup>
-      <WasmtimeArchitecture>x86_64</WasmtimeArchitecture>
-      <ReleaseURLBase Condition="'$(DevBuild)'=='true'">https://github.com/bytecodealliance/wasmtime/releases/download/dev/</ReleaseURLBase>
-      <ReleaseURLBase Condition="'$(ReleaseURLBase)'==''">https://github.com/bytecodealliance/wasmtime/releases/download/v$(WasmtimeVersion)/</ReleaseURLBase>
-      <ReleaseFileNameBase Condition="'$(DevBuild)'=='true'">wasmtime-dev-$(WasmtimeArchitecture)</ReleaseFileNameBase>
-      <ReleaseFileNameBase Condition="'$(ReleaseFileNameBase)'==''">wasmtime-v$(WasmtimeVersion)-$(WasmtimeArchitecture)</ReleaseFileNameBase>
+      <BaseURL>https://github.com/bytecodealliance/wasmtime/releases/download</BaseURL>
+      <ReleaseURLBase Condition="'$(DevBuild)'=='true'">$(BaseURL)/dev</ReleaseURLBase>
+      <ReleaseURLBase Condition="'$(ReleaseURLBase)'==''">$(BaseURL)/v$(WasmtimeVersion)</ReleaseURLBase>
+      <ReleaseFileNameBase Condition="'$(DevBuild)'=='true'">wasmtime-dev</ReleaseFileNameBase>
+      <ReleaseFileNameBase Condition="'$(ReleaseFileNameBase)'==''">wasmtime-v$(WasmtimeVersion)</ReleaseFileNameBase>
     </PropertyGroup>
 
-    <ItemGroup>
-      <WasmtimeDownload Include="Linux" Condition="'$(DevBuild)' != 'true' Or $([MSBuild]::IsOsPlatform('Linux'))">
-        <ReleaseFileExtension>.tar.xz</ReleaseFileExtension>
-        <ReleaseDirectory>$(ReleaseFileNameBase)-linux-c-api</ReleaseDirectory>
-        <ReleaseFileName>%(ReleaseDirectory)%(ReleaseFileExtension)</ReleaseFileName>
-        <URL>$(ReleaseURLBase)%(ReleaseFileName)</URL>
-        <WasmtimeLibraryFilename>libwasmtime.so</WasmtimeLibraryFilename>
-        <PackagePath>runtimes/linux-x64/native/lib/libwasmtime.so</PackagePath>
+    <ItemGroup Condition="'$(Packing)' == 'true' Or $([MSBuild]::IsOsPlatform('Linux'))">
+      <WasmtimeDownload Include="linux-x86_64" Condition="'$(Packing)' == 'true' Or '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">
+        <OS>linux</OS>
+        <Arch>x86_64</Arch>
+        <RID>linux-x64</RID>
+        <FileExtension>tar.xz</FileExtension>
+        <LibraryFilename>libwasmtime.so</LibraryFilename>
       </WasmtimeDownload>
-      <WasmtimeDownload Include="macOS" Condition="'$(DevBuild)' != 'true' Or $([MSBuild]::IsOsPlatform('OSX'))">
-        <ReleaseFileExtension>.tar.xz</ReleaseFileExtension>
-        <ReleaseDirectory>$(ReleaseFileNameBase)-macos-c-api</ReleaseDirectory>
-        <ReleaseFileName>%(ReleaseDirectory)%(ReleaseFileExtension)</ReleaseFileName>
-        <URL>$(ReleaseURLBase)%(ReleaseFileName)</URL>
-        <WasmtimeLibraryFilename>libwasmtime.dylib</WasmtimeLibraryFilename>
-        <PackagePath>runtimes/osx-x64/native/lib/libwasmtime.dylib</PackagePath>
-      </WasmtimeDownload>
-      <WasmtimeDownload Include="Windows" Condition="'$(DevBuild)' != 'true' Or $([MSBuild]::IsOsPlatform('Windows'))">
-        <ReleaseFileExtension>.zip</ReleaseFileExtension>
-        <ReleaseDirectory>$(ReleaseFileNameBase)-windows-c-api</ReleaseDirectory>
-        <ReleaseFileName>%(ReleaseDirectory)%(ReleaseFileExtension)</ReleaseFileName>
-        <URL>$(ReleaseURLBase)%(ReleaseFileName)</URL>
-        <WasmtimeLibraryFilename>wasmtime.dll</WasmtimeLibraryFilename>
-        <PackagePath>runtimes/win-x64/native/lib/wasmtime.dll</PackagePath>
+      <WasmtimeDownload Include="linux-aarch64" Condition="'$(Packing)' == 'true' Or '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">
+        <OS>linux</OS>
+        <Arch>aarch64</Arch>
+        <RID>linux-arm64</RID>
+        <FileExtension>tar.xz</FileExtension>
+        <LibraryFilename>libwasmtime.so</LibraryFilename>
       </WasmtimeDownload>
     </ItemGroup>
 
-	  <DownloadFile
-      Condition="!Exists('$(IntermediateOutputPath)/%(WasmtimeDownload.ReleaseFileName)')"
-      SourceUrl="%(WasmtimeDownload.URL)"
+    <ItemGroup Condition="'$(Packing)' == 'true' Or $([MSBuild]::IsOsPlatform('OSX'))">
+      <WasmtimeDownload Include="macos-x86_64" Condition="'$(Packing)' == 'true' Or '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">
+        <OS>macos</OS>
+        <Arch>x86_64</Arch>
+        <RID>osx-x64</RID>
+        <FileExtension>tar.xz</FileExtension>
+        <LibraryFilename>libwasmtime.dylib</LibraryFilename>
+      </WasmtimeDownload>
+      <WasmtimeDownload Include="macos-aarch64" Condition="'$(Packing)' == 'true' Or '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">
+        <OS>macos</OS>
+        <Arch>aarch64</Arch>
+        <RID>osx-arm64</RID>
+        <FileExtension>tar.xz</FileExtension>
+        <LibraryFilename>libwasmtime.dylib</LibraryFilename>
+      </WasmtimeDownload>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Packing)' == 'true' Or $([MSBuild]::IsOsPlatform('Windows'))">
+      <WasmtimeDownload Include="windows-x86_64" Condition="'$(Packing)' == 'true' Or '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">
+        <OS>windows</OS>
+        <Arch>x86_64</Arch>
+        <RID>win-x64</RID>
+        <FileExtension>zip</FileExtension>
+        <LibraryFilename>wasmtime.dll</LibraryFilename>
+      </WasmtimeDownload>
+    </ItemGroup>
+
+    <DownloadFile
+      Condition="!Exists('$(IntermediateOutputPath)/$(ReleaseFileNameBase)-%(WasmtimeDownload.Arch)-%(WasmtimeDownload.OS)-c-api.%(WasmtimeDownload.FileExtension)')"
+      SourceUrl="$(ReleaseURLBase)/$(ReleaseFileNameBase)-%(WasmtimeDownload.Arch)-%(WasmtimeDownload.OS)-c-api.%(WasmtimeDownload.FileExtension)"
       DestinationFolder="$(IntermediateOutputPath)"
       SkipUnchangedFiles="true"
     />
-	  
+
     <!-- Workaround for https://github.com/msys2/MSYS2-packages/issues/1548 -->
     <Exec
-      Condition="%(WasmtimeDownload.ReleaseFileExtension) == '.tar.xz' And !Exists('$(IntermediateOutputPath)/%(WasmtimeDownload.ReleaseDirectory)')"
-      Command="xz --decompress --stdout %(WasmtimeDownload.ReleaseFileName) | tar xf -"
+      Condition="%(WasmtimeDownload.FileExtension) == 'tar.xz' And !Exists('$(IntermediateOutputPath)$(ReleaseFileNameBase)-%(WasmtimeDownload.OS)-c-api')"
+      Command="xz --decompress --stdout $(ReleaseFileNameBase)-%(WasmtimeDownload.Arch)-%(WasmtimeDownload.OS)-c-api.%(WasmtimeDownload.FileExtension) | tar xf -"
       WorkingDirectory="$(IntermediateOutputPath)"
       StandardOutputImportance="Low"
       StandardErrorImportance="Low"
     />
     <Exec
-      Condition="%(WasmtimeDownload.ReleaseFileExtension) == '.zip' And !Exists('$(IntermediateOutputPath)/%(WasmtimeDownload.ReleaseDirectory)')"
-      Command="unzip %(WasmtimeDownload.ReleaseFileName)"
+      Condition="%(WasmtimeDownload.FileExtension) == 'zip' And !Exists('$(IntermediateOutputPath)$(ReleaseFileNameBase)-%(WasmtimeDownload.OS)-c-api')"
+      Command="unzip $(ReleaseFileNameBase)-%(WasmtimeDownload.Arch)-%(WasmtimeDownload.OS)-c-api.%(WasmtimeDownload.FileExtension)"
       WorkingDirectory="$(IntermediateOutputPath)"
       StandardOutputImportance="Low"
       StandardErrorImportance="Low"
     />
-    
+
     <ItemGroup>
-      <Content Include="$(IntermediateOutputPath)/%(WasmtimeDownload.ReleaseDirectory)/lib/%(WasmtimeDownload.WasmtimeLibraryFilename)">
-        <PackagePath>%(WasmtimeDownload.PackagePath)</PackagePath>
+      <Content Include="$(IntermediateOutputPath)$(ReleaseFileNameBase)-%(WasmtimeDownload.Arch)-%(WasmtimeDownload.OS)-c-api/lib/%(WasmtimeDownload.LibraryFilename)">
+        <PackagePath>runtimes/%(WasmtimeDownload.RID)/native/lib/%(WasmtimeDownload.LibraryFilename)</PackagePath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <Link>%(WasmtimeDownload.WasmtimeLibraryFilename)</Link>
+        <Link>%(WasmtimeDownload.LibraryFilename)</Link>
       </Content>
     </ItemGroup>
+
   </Target>
 
 </Project>

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -99,14 +99,14 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
 
     <!-- Workaround for https://github.com/msys2/MSYS2-packages/issues/1548 -->
     <Exec
-      Condition="%(WasmtimeDownload.FileExtension) == 'tar.xz' And !Exists('$(IntermediateOutputPath)$(ReleaseFileNameBase)-%(WasmtimeDownload.OS)-c-api')"
+      Condition="%(WasmtimeDownload.FileExtension) == 'tar.xz' And !Exists('$(IntermediateOutputPath)$(ReleaseFileNameBase)-%(WasmtimeDownload.Arch)-%(WasmtimeDownload.OS)-c-api')"
       Command="xz --decompress --stdout $(ReleaseFileNameBase)-%(WasmtimeDownload.Arch)-%(WasmtimeDownload.OS)-c-api.%(WasmtimeDownload.FileExtension) | tar xf -"
       WorkingDirectory="$(IntermediateOutputPath)"
       StandardOutputImportance="Low"
       StandardErrorImportance="Low"
     />
     <Exec
-      Condition="%(WasmtimeDownload.FileExtension) == 'zip' And !Exists('$(IntermediateOutputPath)$(ReleaseFileNameBase)-%(WasmtimeDownload.OS)-c-api')"
+      Condition="%(WasmtimeDownload.FileExtension) == 'zip' And !Exists('$(IntermediateOutputPath)$(ReleaseFileNameBase)-%(WasmtimeDownload.Arch)-%(WasmtimeDownload.OS)-c-api')"
       Command="unzip $(ReleaseFileNameBase)-%(WasmtimeDownload.Arch)-%(WasmtimeDownload.OS)-c-api.%(WasmtimeDownload.FileExtension)"
       WorkingDirectory="$(IntermediateOutputPath)"
       StandardOutputImportance="Low"


### PR DESCRIPTION
This PR adds the wasmtime libraries for the following RIDs to the
`Wasmtime` package:

* linux-arm64
* osx-arm64

Fixes #135.