### PR TITLE
Generic Memory Methods

### DIFF
--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -108,7 +108,7 @@ namespace Wasmtime
         /// Gets the span of the memory viewed as a specific type, starting at a given address.
         /// </summary>
         /// <param name="store">The store that owns the memory.</param>
-        /// /// <param name="address">The zero-based address of the start of the span.</param>
+        /// <param name="address">The zero-based address of the start of the span.</param>
         /// <returns>Returns the span of the memory.</returns>
         /// <remarks>
         /// The span may become invalid if the memory grows.

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -105,6 +105,53 @@ namespace Wasmtime
         }
 
         /// <summary>
+        /// Gets the span of the memory viewed as a specific type, starting at a given address.
+        /// </summary>
+        /// <param name="store">The store that owns the memory.</param>
+        /// /// <param name="address">The zero-based address of the start of the span.</param>
+        /// <returns>Returns the span of the memory.</returns>
+        /// <remarks>
+        /// The span may become invalid if the memory grows.
+        /// 
+        /// This may happen if the memory is explicitly requested to grow or
+        /// grows as a result of WebAssembly execution.
+        /// 
+        /// Therefore, the returned span should not be used after calling the grow method or
+        /// after calling into WebAssembly code.
+        /// </remarks>
+        public unsafe Span<T> GetSpan<T>(IStore store, int address)
+            where T : unmanaged
+        {
+            return MemoryMarshal.Cast<byte, T>(GetSpan(store)[address..]);
+        }
+
+        /// <summary>
+        /// Read a struct from memory.
+        /// </summary>
+        /// <typeparam name="T">Type of the struct to read. Ensure layout in C# is identical to layout in WASM.</typeparam>
+        /// <param name="store">The store that owns the memory.</param>
+        /// <param name="address">The zero-based address to read from.</param>
+        /// <returns>Returns the struct read from memory.</returns>
+        public T Read<T>(IStore store, int address)
+            where T : unmanaged
+        {
+            return GetSpan<T>(store, address)[0];
+        }
+
+        /// <summary>
+        /// Write a struct to memory.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="store">The store that owns the memory.</param>
+        /// <param name="address">The zero-based address to read from.</param>
+        /// <param name="value">The struct to write.</param>
+        public void Write<T>(IStore store, int address, T value)
+            where T : unmanaged
+        {
+            GetSpan<T>(store, address)[0] = value;
+        }
+
+        /// <summary>
         /// Reads a UTF-8 string from memory.
         /// </summary>
         /// <param name="store">The store that owns the memory.</param>

--- a/tests/MemoryExportsTests.cs
+++ b/tests/MemoryExportsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using FluentAssertions;
 using Xunit;
 
@@ -40,6 +41,27 @@ namespace Wasmtime.Tests
         public void ItHasTheExpectedNumberOfExportedTables()
         {
             GetMemoryExports().Count().Should().Be(Fixture.Module.Exports.Count(e => e is MemoryExport));
+        }
+
+        [Fact]
+        public void ItReadsAndWritesGenericTypes()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var memory = instance.GetMemory(Store, "mem");
+
+            memory.Should().NotBeNull();
+
+            memory.Write(Store, 11, new TestStruct { A = 17, B = -34346});
+            var result = memory.Read<TestStruct>(Store, 11);
+
+            result.A.Should().Be(17);
+            result.B.Should().Be(-34346);
+        }
+
+        struct TestStruct
+        {
+            public byte A;
+            public int B;
         }
 
         [Fact]


### PR DESCRIPTION
In my use of wasmtime I've often found myself doing something like this:

```csharp
var ptr = MemoryMarshal.Cast<byte, T>(_memory.GetSpan(Store!)[addr..]);
var v = ptr[0]; // Read
ptr[0] = new T(); // Write
```

to access a single value at an address.

I've added `Read<T>`, `Write<T>` and `GetSpan<T>` methods to `Memory` to make this pattern cleaner:

```csharp
var v = _memory.Read<T>(Store, addr);
_memory.Write<T>(Store, addr);
```