### PR TITLE
Memory IStore Reference

### DIFF
--- a/examples/memory/Program.cs
+++ b/examples/memory/Program.cs
@@ -17,7 +17,7 @@ namespace Example
                 "log",
                 Function.FromCallback(store, (Caller caller, int address, int length) =>
                 {
-                    var message = caller.GetMemory("mem").ReadString(caller, address, length);
+                    var message = caller.GetMemory("mem").ReadString(address, length);
                     Console.WriteLine($"Message from WebAssembly: {message}");
                 }
             ));

--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -43,7 +43,7 @@ namespace Wasmtime
                         return null;
                     }
 
-                    return new Memory(((IStore)this).Context, item.of.memory);
+                    return new Memory(this, item.of.memory);
                 }
             }
         }

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -587,13 +587,12 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            var context = store.Context;
-            if (!TryGetExtern(context, name, out var ext) || ext.kind != ExternKind.Memory)
+            if (!TryGetExtern(store.Context, name, out var ext) || ext.kind != ExternKind.Memory)
             {
                 return null;
             }
 
-            return new Memory(context, ext.of.memory);
+            return new Memory(store, ext.of.memory);
         }
 
         /// <summary>

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -704,7 +704,7 @@ namespace Wasmtime
                 return null;
             }
 
-            return new Memory(context, ext.of.memory);
+            return new Memory(store, ext.of.memory);
         }
 
         /// <summary>

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -29,7 +29,7 @@ namespace Wasmtime.Tests
             Linker.Define("env", "do_throw", Function.FromCallback(Store, () => throw new Exception(THROW_MESSAGE)));
             Linker.Define("env", "check_string", Function.FromCallback(Store, (Caller caller, int address, int length) =>
             {
-                caller.GetMemory("mem").ReadString(caller, address, length).Should().Be("Hello World");
+                caller.GetMemory("mem").ReadString(address, length).Should().Be("Hello World");
             }));
         }
 

--- a/tests/LinkerFunctionsTests.cs
+++ b/tests/LinkerFunctionsTests.cs
@@ -28,7 +28,7 @@ namespace Wasmtime.Tests
             Linker.DefineFunction("env", "do_throw", () => throw new Exception(THROW_MESSAGE));
             Linker.DefineFunction("env", "check_string", (Caller caller, int address, int length) =>
             {
-                caller.GetMemory("mem").ReadString(caller, address, length).Should().Be("Hello World");
+                caller.GetMemory("mem").ReadString(address, length).Should().Be("Hello World");
             });
         }
 

--- a/tests/MemoryExportsTests.cs
+++ b/tests/MemoryExportsTests.cs
@@ -51,8 +51,8 @@ namespace Wasmtime.Tests
 
             memory.Should().NotBeNull();
 
-            memory.Write(Store, 11, new TestStruct { A = 17, B = -34346});
-            var result = memory.Read<TestStruct>(Store, 11);
+            memory.Write(11, new TestStruct { A = 17, B = -34346});
+            var result = memory.Read<TestStruct>(11);
 
             result.A.Should().Be(17);
             result.B.Should().Be(-34346);
@@ -72,37 +72,37 @@ namespace Wasmtime.Tests
 
             memory.Should().NotBeNull();
 
-            memory.ReadString(Store, 0, 11).Should().Be("Hello World");
-            int written = memory.WriteString(Store, 0, "WebAssembly Rocks!");
-            memory.ReadString(Store, 0, written).Should().Be("WebAssembly Rocks!");
+            memory.ReadString(0, 11).Should().Be("Hello World");
+            int written = memory.WriteString(0, "WebAssembly Rocks!");
+            memory.ReadString(0, written).Should().Be("WebAssembly Rocks!");
 
-            memory.ReadByte(Store, 20).Should().Be(1);
-            memory.WriteByte(Store, 20, 11);
-            memory.ReadByte(Store, 20).Should().Be(11);
+            memory.ReadByte(20).Should().Be(1);
+            memory.WriteByte(20, 11);
+            memory.ReadByte(20).Should().Be(11);
 
-            memory.ReadInt16(Store, 21).Should().Be(2);
-            memory.WriteInt16(Store, 21, 12);
-            memory.ReadInt16(Store, 21).Should().Be(12);
+            memory.ReadInt16(21).Should().Be(2);
+            memory.WriteInt16(21, 12);
+            memory.ReadInt16(21).Should().Be(12);
 
-            memory.ReadInt32(Store, 23).Should().Be(3);
-            memory.WriteInt32(Store, 23, 13);
-            memory.ReadInt32(Store, 23).Should().Be(13);
+            memory.ReadInt32(23).Should().Be(3);
+            memory.WriteInt32(23, 13);
+            memory.ReadInt32(23).Should().Be(13);
 
-            memory.ReadInt64(Store, 27).Should().Be(4);
-            memory.WriteInt64(Store, 27, 14);
-            memory.ReadInt64(Store, 27).Should().Be(14);
+            memory.ReadInt64(27).Should().Be(4);
+            memory.WriteInt64(27, 14);
+            memory.ReadInt64(27).Should().Be(14);
 
-            memory.ReadSingle(Store, 35).Should().Be(5);
-            memory.WriteSingle(Store, 35, 15);
-            memory.ReadSingle(Store, 35).Should().Be(15);
+            memory.ReadSingle(35).Should().Be(5);
+            memory.WriteSingle(35, 15);
+            memory.ReadSingle(35).Should().Be(15);
 
-            memory.ReadDouble(Store, 39).Should().Be(6);
-            memory.WriteDouble(Store, 39, 16);
-            memory.ReadDouble(Store, 39).Should().Be(16);
+            memory.ReadDouble(39).Should().Be(6);
+            memory.WriteDouble(39, 16);
+            memory.ReadDouble(39).Should().Be(16);
 
-            memory.ReadIntPtr(Store, 48).Should().Be((IntPtr)7);
-            memory.WriteIntPtr(Store, 48, (IntPtr)17);
-            memory.ReadIntPtr(Store, 48).Should().Be((IntPtr)17);
+            memory.ReadIntPtr(48).Should().Be((IntPtr)7);
+            memory.WriteIntPtr(48, (IntPtr)17);
+            memory.ReadIntPtr(48).Should().Be((IntPtr)17);
         }
 
         public static IEnumerable<object[]> GetMemoryExports()

--- a/tests/MemoryImportBindingTests.cs
+++ b/tests/MemoryImportBindingTests.cs
@@ -49,43 +49,43 @@ namespace Wasmtime.Tests
             var readFloat64 = instance.GetFunction(Store, "ReadFloat64");
             var readIntPtr = instance.GetFunction(Store, "ReadIntPtr");
 
-            mem.ReadString(Store, 0, 11).Should().Be("Hello World");
-            int written = mem.WriteString(Store, 0, "WebAssembly Rocks!");
-            mem.ReadString(Store, 0, written).Should().Be("WebAssembly Rocks!");
+            mem.ReadString(0, 11).Should().Be("Hello World");
+            int written = mem.WriteString(0, "WebAssembly Rocks!");
+            mem.ReadString(0, written).Should().Be("WebAssembly Rocks!");
 
-            mem.ReadByte(Store, 20).Should().Be(1);
-            mem.WriteByte(Store, 20, 11);
-            mem.ReadByte(Store, 20).Should().Be(11);
+            mem.ReadByte(20).Should().Be(1);
+            mem.WriteByte(20, 11);
+            mem.ReadByte(20).Should().Be(11);
             readByte.Invoke(Store).Should().Be(11);
 
-            mem.ReadInt16(Store, 21).Should().Be(2);
-            mem.WriteInt16(Store, 21, 12);
-            mem.ReadInt16(Store, 21).Should().Be(12);
+            mem.ReadInt16(21).Should().Be(2);
+            mem.WriteInt16(21, 12);
+            mem.ReadInt16(21).Should().Be(12);
             readInt16.Invoke(Store).Should().Be(12);
 
-            mem.ReadInt32(Store, 23).Should().Be(3);
-            mem.WriteInt32(Store, 23, 13);
-            mem.ReadInt32(Store, 23).Should().Be(13);
+            mem.ReadInt32(23).Should().Be(3);
+            mem.WriteInt32(23, 13);
+            mem.ReadInt32(23).Should().Be(13);
             readInt32.Invoke(Store).Should().Be(13);
 
-            mem.ReadInt64(Store, 27).Should().Be(4);
-            mem.WriteInt64(Store, 27, 14);
-            mem.ReadInt64(Store, 27).Should().Be(14);
+            mem.ReadInt64(27).Should().Be(4);
+            mem.WriteInt64(27, 14);
+            mem.ReadInt64(27).Should().Be(14);
             readInt64.Invoke(Store).Should().Be(14);
 
-            mem.ReadSingle(Store, 35).Should().Be(5);
-            mem.WriteSingle(Store, 35, 15);
-            mem.ReadSingle(Store, 35).Should().Be(15);
+            mem.ReadSingle(35).Should().Be(5);
+            mem.WriteSingle(35, 15);
+            mem.ReadSingle(35).Should().Be(15);
             readFloat32.Invoke(Store).Should().Be(15);
 
-            mem.ReadDouble(Store, 39).Should().Be(6);
-            mem.WriteDouble(Store, 39, 16);
-            mem.ReadDouble(Store, 39).Should().Be(16);
+            mem.ReadDouble(39).Should().Be(6);
+            mem.WriteDouble(39, 16);
+            mem.ReadDouble(39).Should().Be(16);
             readFloat64.Invoke(Store).Should().Be(16);
 
-            mem.ReadIntPtr(Store, 48).Should().Be((IntPtr)7);
-            mem.WriteIntPtr(Store, 48, (IntPtr)17);
-            mem.ReadIntPtr(Store, 48).Should().Be((IntPtr)17);
+            mem.ReadIntPtr(48).Should().Be((IntPtr)7);
+            mem.WriteIntPtr(48, (IntPtr)17);
+            mem.ReadIntPtr(48).Should().Be((IntPtr)17);
             readIntPtr.Invoke(Store).Should().Be(17);
         }
 

--- a/tests/WasiTests.cs
+++ b/tests/WasiTests.cs
@@ -30,8 +30,8 @@ namespace Wasmtime.Tests
             call_environ_sizes_get.Should().NotBeNull();
 
             Assert.Equal(0, call_environ_sizes_get.Invoke(store, 0, 4));
-            Assert.Equal(0, memory.ReadInt32(store, 0));
-            Assert.Equal(0, memory.ReadInt32(store, 4));
+            Assert.Equal(0, memory.ReadInt32(0));
+            Assert.Equal(0, memory.ReadInt32(4));
         }
 
         [Theory]
@@ -66,13 +66,13 @@ namespace Wasmtime.Tests
             call_environ_sizes_get.Should().NotBeNull();
 
             Assert.Equal(0, call_environ_sizes_get.Invoke(store, 0, 4));
-            Assert.Equal(env.Count, memory.ReadInt32(store, 0));
-            Assert.Equal(env.Sum(kvp => kvp.Key.Length + kvp.Value.Length + 2), memory.ReadInt32(store, 4));
+            Assert.Equal(env.Count, memory.ReadInt32(0));
+            Assert.Equal(env.Sum(kvp => kvp.Key.Length + kvp.Value.Length + 2), memory.ReadInt32(4));
             Assert.Equal(0, call_environ_get.Invoke(store, 0, 4 * env.Count));
 
             for (int i = 0; i < env.Count; ++i)
             {
-                var kvp = memory.ReadNullTerminatedString(store, memory.ReadInt32(store, i * 4)).Split("=");
+                var kvp = memory.ReadNullTerminatedString(memory.ReadInt32(i * 4)).Split("=");
                 Assert.Equal(env[kvp[0]], kvp[1]);
             }
         }
@@ -101,7 +101,7 @@ namespace Wasmtime.Tests
             call_environ_sizes_get.Should().NotBeNull();
 
             Assert.Equal(0, call_environ_sizes_get.Invoke(store, 0, 4));
-            Assert.Equal(Environment.GetEnvironmentVariables().Keys.Count, memory.ReadInt32(store, 0));
+            Assert.Equal(Environment.GetEnvironmentVariables().Keys.Count, memory.ReadInt32(0));
         }
 
         [Theory]
@@ -125,8 +125,8 @@ namespace Wasmtime.Tests
             call_args_sizes_get.Should().NotBeNull();
 
             Assert.Equal(0, call_args_sizes_get.Invoke(store, 0, 4));
-            Assert.Equal(0, memory.ReadInt32(store, 0));
-            Assert.Equal(0, memory.ReadInt32(store, 4));
+            Assert.Equal(0, memory.ReadInt32(0));
+            Assert.Equal(0, memory.ReadInt32(4));
         }
 
         [Theory]
@@ -162,13 +162,13 @@ namespace Wasmtime.Tests
             call_args_get.Should().NotBeNull();
 
             Assert.Equal(0, call_args_sizes_get.Invoke(store, 0, 4));
-            Assert.Equal(args.Count, memory.ReadInt32(store, 0));
-            Assert.Equal(args.Sum(a => a.Length + 1), memory.ReadInt32(store, 4));
+            Assert.Equal(args.Count, memory.ReadInt32(0));
+            Assert.Equal(args.Sum(a => a.Length + 1), memory.ReadInt32(4));
             Assert.Equal(0, call_args_get.Invoke(store, 0, 4 * args.Count));
 
             for (int i = 0; i < args.Count; ++i)
             {
-                var arg = memory.ReadNullTerminatedString(store, memory.ReadInt32(store, i * 4));
+                var arg = memory.ReadNullTerminatedString(memory.ReadInt32(i * 4));
                 Assert.Equal(args[i], arg);
             }
         }
@@ -197,7 +197,7 @@ namespace Wasmtime.Tests
             call_args_sizes_get.Should().NotBeNull();
 
             Assert.Equal(0, call_args_sizes_get.Invoke(store, 0, 4));
-            Assert.Equal(Environment.GetCommandLineArgs().Length, memory.ReadInt32(store, 0));
+            Assert.Equal(Environment.GetCommandLineArgs().Length, memory.ReadInt32(0));
         }
 
         [Theory]
@@ -228,12 +228,12 @@ namespace Wasmtime.Tests
             var call_fd_read = instance.GetFunction(store, "call_fd_read");
             call_fd_read.Should().NotBeNull();
 
-            memory.WriteInt32(store, 0, 8);
-            memory.WriteInt32(store, 4, MESSAGE.Length);
+            memory.WriteInt32(0, 8);
+            memory.WriteInt32(4, MESSAGE.Length);
 
             Assert.Equal(0, call_fd_read.Invoke(store, 0, 0, 1, 32));
-            Assert.Equal(MESSAGE.Length, memory.ReadInt32(store, 32));
-            Assert.Equal(MESSAGE, memory.ReadString(store, 8, MESSAGE.Length));
+            Assert.Equal(MESSAGE.Length, memory.ReadInt32(32));
+            Assert.Equal(MESSAGE, memory.ReadString(8, MESSAGE.Length));
         }
 
         [Theory]
@@ -274,12 +274,12 @@ namespace Wasmtime.Tests
             var call_fd_close = instance.GetFunction(store, "call_fd_close");
             call_fd_close.Should().NotBeNull();
 
-            memory.WriteInt32(store, 0, 8);
-            memory.WriteInt32(store, 4, MESSAGE.Length);
-            memory.WriteString(store, 8, MESSAGE);
+            memory.WriteInt32(0, 8);
+            memory.WriteInt32(4, MESSAGE.Length);
+            memory.WriteString(8, MESSAGE);
 
             Assert.Equal(0, call_fd_write.Invoke(store, fd, 0, 1, 32));
-            Assert.Equal(MESSAGE.Length, memory.ReadInt32(store, 32));
+            Assert.Equal(MESSAGE.Length, memory.ReadInt32(32));
             Assert.Equal(0, call_fd_close.Invoke(store, fd));
             Assert.Equal(MESSAGE, File.ReadAllText(file.Path));
         }
@@ -316,7 +316,7 @@ namespace Wasmtime.Tests
             call_fd_close.Should().NotBeNull();
 
             var fileName = Path.GetFileName(file.Path);
-            memory.WriteString(store, 0, fileName);
+            memory.WriteString(0, fileName);
 
             Assert.Equal(0, call_path_open.Invoke(
                     store,
@@ -332,15 +332,15 @@ namespace Wasmtime.Tests
                 )
             );
 
-            var fileFd = (int)memory.ReadInt32(store, 64);
+            var fileFd = (int)memory.ReadInt32(64);
             Assert.True(fileFd > 3);
 
-            memory.WriteInt32(store, 0, 8);
-            memory.WriteInt32(store, 4, MESSAGE.Length);
-            memory.WriteString(store, 8, MESSAGE);
+            memory.WriteInt32(0, 8);
+            memory.WriteInt32(4, MESSAGE.Length);
+            memory.WriteString(8, MESSAGE);
 
             Assert.Equal(0, call_fd_write.Invoke(store, fileFd, 0, 1, 64));
-            Assert.Equal(MESSAGE.Length, memory.ReadInt32(store, 64));
+            Assert.Equal(MESSAGE.Length, memory.ReadInt32(64));
             Assert.Equal(0, call_fd_close.Invoke(store, fileFd));
             Assert.Equal(MESSAGE, File.ReadAllText(file.Path));
         }


### PR DESCRIPTION
Storing a reference to the `IStore` which was used to create the `Memory` object, this simplifies the API (all instance methods no longer need to be given an `IStore` reference) and removes a potential footgun (using the wrong `IStore`).

If you accept this PR then I can make the same change to `Function`, `Global` and `Table` as well.