### PR TITLE
Table Store Reference

### DIFF
--- a/examples/table/Program.cs
+++ b/examples/table/Program.cs
@@ -14,10 +14,10 @@ namespace Example
 
             var table = new Table(store, ValueKind.FuncRef, null, 4);
 
-            table.SetElement(store, 0, Function.FromCallback(store, (int a, int b) => a + b));
-            table.SetElement(store, 1, Function.FromCallback(store, (int a, int b) => a - b));
-            table.SetElement(store, 2, Function.FromCallback(store, (int a, int b) => a * b));
-            table.SetElement(store, 3, Function.FromCallback(store, (int a, int b) => a / b));
+            table.SetElement(0, Function.FromCallback(store, (int a, int b) => a + b));
+            table.SetElement(1, Function.FromCallback(store, (int a, int b) => a - b));
+            table.SetElement(2, Function.FromCallback(store, (int a, int b) => a * b));
+            table.SetElement(3, Function.FromCallback(store, (int a, int b) => a / b));
 
             linker.Define("", "table", table);
 

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -571,7 +571,7 @@ namespace Wasmtime
                 return null;
             }
 
-            return new Table(context, ext.of.table);
+            return new Table(store, ext.of.table);
         }
 
         /// <summary>

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -681,7 +681,7 @@ namespace Wasmtime
                 return null;
             }
 
-            return new Table(context, ext.of.table);
+            return new Table(store, ext.of.table);
         }
 
         /// <summary>

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -87,11 +87,6 @@ namespace Wasmtime
         /// </remarks>
         public unsafe Span<byte> GetSpan()
         {
-            if (store is null)
-            {
-                throw new ArgumentNullException(nameof(store));
-            }
-
             var context = store.Context;
             var data = Native.wasmtime_memory_data(context.handle, this.memory);
             var size = Convert.ToInt32(Native.wasmtime_memory_data_size(context.handle, this.memory).ToUInt32());

--- a/tests/TableImportBindingTests.cs
+++ b/tests/TableImportBindingTests.cs
@@ -95,8 +95,8 @@ namespace Wasmtime.Tests
             for (int i = 0; i < 10; ++i)
             {
                 int index = i;
-                funcs.SetElement(Store, (uint)i, Function.FromCallback(Store, () => { called[index] = true; }));
-                externs.SetElement(Store, (uint)i, string.Format("string{0}", i));
+                funcs.SetElement((uint)i, Function.FromCallback(Store, () => { called[index] = true; }));
+                externs.SetElement((uint)i, string.Format("string{0}", i));
             }
 
             for (int i = 0; i < 10; ++i)
@@ -105,8 +105,8 @@ namespace Wasmtime.Tests
                 Convert.ToBoolean(is_null_extern.Invoke(Store, i)).Should().BeFalse();
                 call.Invoke(Store, i);
                 assert_extern.Invoke(Store, i, string.Format("string{0}", i));
-                funcs.SetElement(Store, (uint)i, Function.Null);
-                externs.SetElement(Store, (uint)i, null);
+                funcs.SetElement((uint)i, Function.Null);
+                externs.SetElement((uint)i, null);
             }
 
             for (int i = 0; i < 10; ++i)
@@ -130,29 +130,29 @@ namespace Wasmtime.Tests
             var grow_funcs = instance.GetFunction(Store, "grow_funcs");
             var grow_externs = instance.GetFunction(Store, "grow_externs");
 
-            funcs.GetSize(Store).Should().Be(10);
-            externs.GetSize(Store).Should().Be(10);
+            funcs.GetSize().Should().Be(10);
+            externs.GetSize().Should().Be(10);
 
             grow_funcs.Invoke(Store, 5);
             grow_externs.Invoke(Store, 3);
 
-            funcs.GetSize(Store).Should().Be(15);
-            externs.GetSize(Store).Should().Be(13);
+            funcs.GetSize().Should().Be(15);
+            externs.GetSize().Should().Be(13);
 
-            funcs.Grow(Store, 5, null).Should().Be(15);
-            externs.Grow(Store, 5, null).Should().Be(13);
+            funcs.Grow(5, null).Should().Be(15);
+            externs.Grow(5, null).Should().Be(13);
 
-            funcs.GetSize(Store).Should().Be(20);
-            externs.GetSize(Store).Should().Be(18);
+            funcs.GetSize().Should().Be(20);
+            externs.GetSize().Should().Be(18);
 
-            Action action = () => { funcs.Grow(Store, 5, null); };
+            Action action = () => { funcs.Grow(5, null); };
 
             action
                 .Should()
                 .Throw<WasmtimeException>()
                 .WithMessage("failed to grow table by `5`");
 
-            action = () => { externs.Grow(Store, 3, null); };
+            action = () => { externs.Grow(3, null); };
 
             action
                 .Should()


### PR DESCRIPTION
Modified `Table` to keep a reference to the store which owns it. Much like #143 this simplifies the API and removes the potential footgun of trying to use a `Table` with the wrong `Store`