### PR TITLE
Global Store Reference

### DIFF
--- a/examples/global/Program.cs
+++ b/examples/global/Program.cs
@@ -21,7 +21,7 @@ namespace Example
                 "print_global",
                 Function.FromCallback(store, (Caller caller) =>
                 {
-                    Console.WriteLine($"The value of the global is: {global.GetValue(caller)}.");
+                    Console.WriteLine($"The value of the global is: {global.GetValue()}.");
                 }
             ));
 

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -614,7 +614,7 @@ namespace Wasmtime
                 return null;
             }
 
-            return new Global(context, ext.of.global);
+            return new Global(store, ext.of.global);
         }
 
         private bool TryGetExtern(StoreContext context, string name, out Extern ext)

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -727,7 +727,7 @@ namespace Wasmtime
                 return null;
             }
 
-            return new Global(context, ext.of.global);
+            return new Global(store, ext.of.global);
         }
 
         /// <inheritdoc/>

--- a/tests/GlobalExportsTests.cs
+++ b/tests/GlobalExportsTests.cs
@@ -50,70 +50,70 @@ namespace Wasmtime.Tests
             var i32 = instance.GetGlobal(Store, "global_i32");
             i32.Kind.Should().Be(ValueKind.Int32);
             i32.Mutability.Should().Be(Mutability.Immutable);
-            i32.GetValue(Store).Should().Be(0);
+            i32.GetValue().Should().Be(0);
 
             var i32Mut = instance.GetGlobal(Store, "global_i32_mut");
             i32Mut.Kind.Should().Be(ValueKind.Int32);
             i32Mut.Mutability.Should().Be(Mutability.Mutable);
-            i32Mut.GetValue(Store).Should().Be(1);
-            i32Mut.SetValue(Store, 11);
-            i32Mut.GetValue(Store).Should().Be(11);
+            i32Mut.GetValue().Should().Be(1);
+            i32Mut.SetValue(11);
+            i32Mut.GetValue().Should().Be(11);
 
             var i64 = instance.GetGlobal(Store, "global_i64");
             i64.Kind.Should().Be(ValueKind.Int64);
             i64.Mutability.Should().Be(Mutability.Immutable);
-            i64.GetValue(Store).Should().Be(2);
+            i64.GetValue().Should().Be(2);
 
             var i64Mut = instance.GetGlobal(Store, "global_i64_mut");
             i64Mut.Kind.Should().Be(ValueKind.Int64);
             i64Mut.Mutability.Should().Be(Mutability.Mutable);
-            i64Mut.GetValue(Store).Should().Be(3);
-            i64Mut.SetValue(Store, 13);
-            i64Mut.GetValue(Store).Should().Be(13);
+            i64Mut.GetValue().Should().Be(3);
+            i64Mut.SetValue(13);
+            i64Mut.GetValue().Should().Be(13);
 
             var f32 = instance.GetGlobal(Store, "global_f32");
             f32.Kind.Should().Be(ValueKind.Float32);
             f32.Mutability.Should().Be(Mutability.Immutable);
-            f32.GetValue(Store).Should().Be(4);
+            f32.GetValue().Should().Be(4);
 
             var f32Mut = instance.GetGlobal(Store, "global_f32_mut");
             f32Mut.Kind.Should().Be(ValueKind.Float32);
             f32Mut.Mutability.Should().Be(Mutability.Mutable);
-            f32Mut.GetValue(Store).Should().Be(5);
-            f32Mut.SetValue(Store, 15);
-            f32Mut.GetValue(Store).Should().Be(15);
+            f32Mut.GetValue().Should().Be(5);
+            f32Mut.SetValue(15);
+            f32Mut.GetValue().Should().Be(15);
 
             var f64 = instance.GetGlobal(Store, "global_f64");
             f64.Kind.Should().Be(ValueKind.Float64);
             f64.Mutability.Should().Be(Mutability.Immutable);
-            f64.GetValue(Store).Should().Be(6);
+            f64.GetValue().Should().Be(6);
 
             var f64Mut = instance.GetGlobal(Store, "global_f64_mut");
             f64Mut.Kind.Should().Be(ValueKind.Float64);
             f64Mut.Mutability.Should().Be(Mutability.Mutable);
-            f64Mut.GetValue(Store).Should().Be(7);
-            f64Mut.SetValue(Store, 17);
-            f64Mut.GetValue(Store).Should().Be(17);
+            f64Mut.GetValue().Should().Be(7);
+            f64Mut.SetValue(17);
+            f64Mut.GetValue().Should().Be(17);
 
-            Action action = () => i32.SetValue(Store, 0);
+            Action action = () => i32.SetValue(0);
             action
                 .Should()
                 .Throw<InvalidOperationException>()
                 .WithMessage("The global is immutable and cannot be changed.");
 
-            action = () => i64.SetValue(Store, 0);
+            action = () => i64.SetValue(0);
             action
                 .Should()
                 .Throw<InvalidOperationException>()
                 .WithMessage("The global is immutable and cannot be changed.");
 
-            action = () => f32.SetValue(Store, 0);
+            action = () => f32.SetValue(0);
             action
                 .Should()
                 .Throw<InvalidOperationException>()
                 .WithMessage("The global is immutable and cannot be changed.");
 
-            action = () => f64.SetValue(Store, 0);
+            action = () => f64.SetValue(0);
             action
                 .Should()
                 .Throw<InvalidOperationException>()

--- a/tests/GlobalImportBindingTests.cs
+++ b/tests/GlobalImportBindingTests.cs
@@ -109,14 +109,14 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItBindsTheGlobalsCorrectly()
         {
-            var global_i32_mut = new Global(Store, ValueKind.Int32, 0, Mutability.Mutable).Wrap<int>(Store);
-            var global_i32 = new Global(Store, ValueKind.Int32, 1, Mutability.Immutable).Wrap<int>(Store);
-            var global_i64_mut = new Global(Store, ValueKind.Int64, 2, Mutability.Mutable).Wrap<long>(Store);
-            var global_i64 = new Global(Store, ValueKind.Int64, 3, Mutability.Immutable).Wrap<long>(Store);
-            var global_f32_mut = new Global(Store, ValueKind.Float32, 4, Mutability.Mutable).Wrap<float>(Store);
-            var global_f32 = new Global(Store, ValueKind.Float32, 5, Mutability.Immutable).Wrap<float>(Store);
-            var global_f64_mut = new Global(Store, ValueKind.Float64, 6, Mutability.Mutable).Wrap<double>(Store);
-            var global_f64 = new Global(Store, ValueKind.Float64, 7, Mutability.Immutable).Wrap<double>(Store);
+            var global_i32_mut = new Global(Store, ValueKind.Int32, 0, Mutability.Mutable).Wrap<int>();
+            var global_i32 = new Global(Store, ValueKind.Int32, 1, Mutability.Immutable).Wrap<int>();
+            var global_i64_mut = new Global(Store, ValueKind.Int64, 2, Mutability.Mutable).Wrap<long>();
+            var global_i64 = new Global(Store, ValueKind.Int64, 3, Mutability.Immutable).Wrap<long>();
+            var global_f32_mut = new Global(Store, ValueKind.Float32, 4, Mutability.Mutable).Wrap<float>();
+            var global_f32 = new Global(Store, ValueKind.Float32, 5, Mutability.Immutable).Wrap<float>();
+            var global_f64_mut = new Global(Store, ValueKind.Float64, 6, Mutability.Mutable).Wrap<double>();
+            var global_f64 = new Global(Store, ValueKind.Float64, 7, Mutability.Immutable).Wrap<double>();
 
             Linker.Define("", "global_i32_mut", global_i32_mut);
             Linker.Define("", "global_i32", global_i32);


### PR DESCRIPTION
Modified `Global` to keep a reference to the store which owns it. Much like #143 this simplifies the API and removes the potential footgun of trying to use a Global with the wrong Store