### PR TITLE
Function Store Reference

### DIFF
--- a/benchmarks/simple/Program.cs
+++ b/benchmarks/simple/Program.cs
@@ -51,17 +51,17 @@ namespace Simple
             linker.Define("", "memory", new Memory(store, 3));
 
             var instance = linker.Instantiate(store, _module);
-            var run = instance.GetFunction(store, "run");
+            var run = instance.GetFunction(store, "run")!.WrapAction();
             if (run == null)
             {
                 throw new InvalidOperationException();
             }
             
-            run.Invoke(store);
+            run.Invoke();
         }
 
-        private Engine _engine;
-        private Module _module;
+        private readonly Engine _engine;
+        private readonly Module _module;
     }
 
     class Program
@@ -70,7 +70,7 @@ namespace Simple
         {
             var summary = BenchmarkRunner.Run<Benchmark>();
 
-            var report = summary[summary.BenchmarksCases.Where(c => c.Descriptor.Type == typeof(Benchmark)).Single()];
+            var report = summary[summary.BenchmarksCases.Single(c => c.Descriptor.Type == typeof(Benchmark))];
             if (!(report is null))
             {
                 if (report.ExecuteResults.All(r => r.ExitCode == 0))

--- a/examples/funcref/Program.cs
+++ b/examples/funcref/Program.cs
@@ -15,7 +15,7 @@ namespace Example
             linker.Define(
                 "",
                 "g",
-                Function.FromCallback(store, (Caller caller, Function h) => { h.Invoke(caller); })
+                Function.FromCallback(store, (Caller caller, Function h) => { h.Invoke(); })
             );
 
             linker.Define(

--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -72,7 +72,7 @@ namespace Wasmtime
                         return null;
                     }
 
-                    return new Function(((IStore)this).Context, item.of.func);
+                    return new Function(this, item.of.func);
                 }
             }
         }

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -1773,7 +1773,6 @@ namespace Wasmtime
         /// <typeparam name="TL">Twelfth parameter</typeparam>
         /// <typeparam name="TM">Thirteenth parameter</typeparam>
         /// <typeparam name="TN">Fourteenth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>()
         {

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -27,7 +27,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -237,7 +237,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -267,7 +267,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, false);
+            return new Function(store, callback, false);
         }
 
         /// <summary>
@@ -282,7 +282,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -297,7 +297,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -312,7 +312,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -327,7 +327,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -342,7 +342,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -357,7 +357,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -372,7 +372,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -387,7 +387,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -402,7 +402,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -432,7 +432,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -447,7 +447,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -462,7 +462,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -477,7 +477,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -492,7 +492,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -507,7 +507,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
 
         /// <summary>
@@ -522,7 +522,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
-            return new Function(store.Context, callback, true);
+            return new Function(store, callback, true);
         }
         #endregion
 
@@ -638,10 +638,14 @@ namespace Wasmtime
         /// <summary>
         /// Attempt to wrap this function as an Action. Wrapped action is faster than a normal Invoke call.
         /// </summary>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>An action to invoke this function. Null if the type signature is incompatible</returns>
-        public Action? WrapAction(IStore store)
+        public Action? WrapAction()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature())
             {
@@ -651,7 +655,7 @@ namespace Wasmtime
             return () =>
             {
                 Span<Value> args = stackalloc Value[0];
-                InvokeWithoutReturn(store, args);
+                InvokeWithoutReturn(args);
             };
         }
 
@@ -659,10 +663,14 @@ namespace Wasmtime
         /// Attempt to wrap this function as an Action. Wrapped action is faster than a normal Invoke call.
         /// </summary>
         /// <typeparam name="TA">First parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>An action to invoke this function. Null if the type signature is incompatible</returns>
-        public Action<TA>? WrapAction<TA>(IStore store)
+        public Action<TA>? WrapAction<TA>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(null, typeof(TA)))
             {
@@ -677,7 +685,7 @@ namespace Wasmtime
                 Span<Value> args = stackalloc Value[1];
                 args[0] = Value.FromValueBox(ca.Box(a));
 
-                InvokeWithoutReturn(store, args);
+                InvokeWithoutReturn(args);
             };
         }
 
@@ -686,10 +694,14 @@ namespace Wasmtime
         /// </summary>
         /// <typeparam name="TA">First parameter</typeparam>
         /// <typeparam name="TB">Second parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>An action to invoke this function. Null if the type signature is incompatible</returns>
-        public Action<TA, TB>? WrapAction<TA, TB>(IStore store)
+        public Action<TA, TB>? WrapAction<TA, TB>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(null, typeof(TA), typeof(TB)))
             {
@@ -706,7 +718,7 @@ namespace Wasmtime
                 args[0] = Value.FromValueBox(ca.Box(a));
                 args[1] = Value.FromValueBox(cb.Box(b));
 
-                InvokeWithoutReturn(store, args);
+                InvokeWithoutReturn(args);
             };
         }
 
@@ -716,10 +728,14 @@ namespace Wasmtime
         /// <typeparam name="TA">First parameter</typeparam>
         /// <typeparam name="TB">Second parameter</typeparam>
         /// <typeparam name="TC">Third parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>An action to invoke this function. Null if the type signature is incompatible</returns>
-        public Action<TA, TB, TC>? WrapAction<TA, TB, TC>(IStore store)
+        public Action<TA, TB, TC>? WrapAction<TA, TB, TC>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(null, typeof(TA), typeof(TB), typeof(TC)))
             {
@@ -738,7 +754,7 @@ namespace Wasmtime
                 args[1] = Value.FromValueBox(cb.Box(b));
                 args[2] = Value.FromValueBox(cc.Box(c));
 
-                InvokeWithoutReturn(store, args);
+                InvokeWithoutReturn(args);
             };
         }
 
@@ -749,10 +765,14 @@ namespace Wasmtime
         /// <typeparam name="TB">Second parameter</typeparam>
         /// <typeparam name="TC">Third parameter</typeparam>
         /// <typeparam name="TD">Fourth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>An action to invoke this function. Null if the type signature is incompatible</returns>
-        public Action<TA, TB, TC, TD>? WrapAction<TA, TB, TC, TD>(IStore store)
+        public Action<TA, TB, TC, TD>? WrapAction<TA, TB, TC, TD>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(null, typeof(TA), typeof(TB), typeof(TC), typeof(TD)))
             {
@@ -773,7 +793,7 @@ namespace Wasmtime
                 args[2] = Value.FromValueBox(cc.Box(c));
                 args[3] = Value.FromValueBox(cd.Box(d));
 
-                InvokeWithoutReturn(store, args);
+                InvokeWithoutReturn(args);
             };
         }
 
@@ -785,10 +805,14 @@ namespace Wasmtime
         /// <typeparam name="TC">Third parameter</typeparam>
         /// <typeparam name="TD">Fourth parameter</typeparam>
         /// <typeparam name="TE">Fifth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>An action to invoke this function. Null if the type signature is incompatible</returns>
-        public Action<TA, TB, TC, TD, TE>? WrapAction<TA, TB, TC, TD, TE>(IStore store)
+        public Action<TA, TB, TC, TD, TE>? WrapAction<TA, TB, TC, TD, TE>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(null, typeof(TA), typeof(TB), typeof(TC), typeof(TD),
                                           typeof(TE)))
@@ -812,7 +836,7 @@ namespace Wasmtime
                 args[3] = Value.FromValueBox(cd.Box(d));
                 args[4] = Value.FromValueBox(ce.Box(e));
 
-                InvokeWithoutReturn(store, args);
+                InvokeWithoutReturn(args);
             };
         }
 
@@ -825,10 +849,14 @@ namespace Wasmtime
         /// <typeparam name="TD">Fourth parameter</typeparam>
         /// <typeparam name="TE">Fifth parameter</typeparam>
         /// <typeparam name="TF">Sixth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>An action to invoke this function. Null if the type signature is incompatible</returns>
-        public Action<TA, TB, TC, TD, TE, TF>? WrapAction<TA, TB, TC, TD, TE, TF>(IStore store)
+        public Action<TA, TB, TC, TD, TE, TF>? WrapAction<TA, TB, TC, TD, TE, TF>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(null, typeof(TA), typeof(TB), typeof(TC), typeof(TD),
                                           typeof(TE), typeof(TF)))
@@ -854,7 +882,7 @@ namespace Wasmtime
                 args[4] = Value.FromValueBox(ce.Box(e));
                 args[5] = Value.FromValueBox(cf.Box(f));
 
-                InvokeWithoutReturn(store, args);
+                InvokeWithoutReturn(args);
             };
         }
 
@@ -868,10 +896,14 @@ namespace Wasmtime
         /// <typeparam name="TE">Fifth parameter</typeparam>
         /// <typeparam name="TF">Sixth parameter</typeparam>
         /// <typeparam name="TG">Seventh parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>An action to invoke this function. Null if the type signature is incompatible</returns>
-        public Action<TA, TB, TC, TD, TE, TF, TG>? WrapAction<TA, TB, TC, TD, TE, TF, TG>(IStore store)
+        public Action<TA, TB, TC, TD, TE, TF, TG>? WrapAction<TA, TB, TC, TD, TE, TF, TG>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(null, typeof(TA), typeof(TB), typeof(TC), typeof(TD),
                                           typeof(TE), typeof(TF), typeof(TG)))
@@ -899,7 +931,7 @@ namespace Wasmtime
                 args[5] = Value.FromValueBox(cf.Box(f));
                 args[6] = Value.FromValueBox(cg.Box(g));
 
-                InvokeWithoutReturn(store, args);
+                InvokeWithoutReturn(args);
             };
         }
 
@@ -914,10 +946,14 @@ namespace Wasmtime
         /// <typeparam name="TF">Sixth parameter</typeparam>
         /// <typeparam name="TG">Seventh parameter</typeparam>
         /// <typeparam name="TH">Eighth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>An action to invoke this function. Null if the type signature is incompatible</returns>
-        public Action<TA, TB, TC, TD, TE, TF, TG, TH>? WrapAction<TA, TB, TC, TD, TE, TF, TG, TH>(IStore store)
+        public Action<TA, TB, TC, TD, TE, TF, TG, TH>? WrapAction<TA, TB, TC, TD, TE, TF, TG, TH>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(null, typeof(TA), typeof(TB), typeof(TC), typeof(TD),
                                           typeof(TE), typeof(TF), typeof(TG), typeof(TH)))
@@ -947,7 +983,7 @@ namespace Wasmtime
                 args[6] = Value.FromValueBox(cg.Box(g));
                 args[7] = Value.FromValueBox(ch.Box(h));
 
-                InvokeWithoutReturn(store, args);
+                InvokeWithoutReturn(args);
             };
         }
 
@@ -963,10 +999,14 @@ namespace Wasmtime
         /// <typeparam name="TG">Seventh parameter</typeparam>
         /// <typeparam name="TH">Eighth parameter</typeparam>
         /// <typeparam name="TI">Ninth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>An action to invoke this function. Null if the type signature is incompatible</returns>
-        public Action<TA, TB, TC, TD, TE, TF, TG, TH, TI>? WrapAction<TA, TB, TC, TD, TE, TF, TG, TH, TI>(IStore store)
+        public Action<TA, TB, TC, TD, TE, TF, TG, TH, TI>? WrapAction<TA, TB, TC, TD, TE, TF, TG, TH, TI>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(null, typeof(TA), typeof(TB), typeof(TC), typeof(TD),
                                           typeof(TE), typeof(TF), typeof(TG), typeof(TH),
@@ -999,7 +1039,7 @@ namespace Wasmtime
                 args[7] = Value.FromValueBox(ch.Box(h));
                 args[8] = Value.FromValueBox(ci.Box(i));
 
-                InvokeWithoutReturn(store, args);
+                InvokeWithoutReturn(args);
             };
         }
 
@@ -1007,10 +1047,14 @@ namespace Wasmtime
         /// Attempt to wrap this function as a Func. Wrapped func is faster than a normal Invoke call.
         /// </summary>
         /// <typeparam name="TR">Return type</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TR>? WrapFunc<TR>(IStore store)
+        public Func<TR>? WrapFunc<TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR)))
             {
@@ -1022,7 +1066,7 @@ namespace Wasmtime
 
             return () =>
             {
-                return InvokeWithReturn(store, stackalloc Value[0], factory);
+                return InvokeWithReturn(stackalloc Value[0], factory);
             };
         }
 
@@ -1031,10 +1075,14 @@ namespace Wasmtime
         /// </summary>
         /// <typeparam name="TR">Return type</typeparam>
         /// <typeparam name="TA">First parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TR>? WrapFunc<TA, TR>(IStore store)
+        public Func<TA, TR>? WrapFunc<TA, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             if (!CheckTypeSignature(typeof(TR), typeof(TA)))
             {
                 return null;
@@ -1051,7 +1099,7 @@ namespace Wasmtime
                 Span<Value> args = stackalloc Value[1];
                 args[0] = Value.FromValueBox(ca.Box(a));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1061,10 +1109,14 @@ namespace Wasmtime
         /// <typeparam name="TR">Return type</typeparam>
         /// <typeparam name="TA">First parameter</typeparam>
         /// <typeparam name="TB">First parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TR>? WrapFunc<TA, TB, TR>(IStore store)
+        public Func<TA, TB, TR>? WrapFunc<TA, TB, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB)))
             {
@@ -1084,7 +1136,7 @@ namespace Wasmtime
                 args[0] = Value.FromValueBox(ca.Box(a));
                 args[1] = Value.FromValueBox(cb.Box(b));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1095,10 +1147,14 @@ namespace Wasmtime
         /// <typeparam name="TA">First parameter</typeparam>
         /// <typeparam name="TB">Second parameter</typeparam>
         /// <typeparam name="TC">Third parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TR>? WrapFunc<TA, TB, TC, TR>(IStore store)
+        public Func<TA, TB, TC, TR>? WrapFunc<TA, TB, TC, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC)))
             {
@@ -1120,7 +1176,7 @@ namespace Wasmtime
                 args[1] = Value.FromValueBox(cb.Box(b));
                 args[2] = Value.FromValueBox(cc.Box(c));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1132,10 +1188,14 @@ namespace Wasmtime
         /// <typeparam name="TB">Second parameter</typeparam>
         /// <typeparam name="TC">Third parameter</typeparam>
         /// <typeparam name="TD">Fourth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TR>? WrapFunc<TA, TB, TC, TD, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TR>? WrapFunc<TA, TB, TC, TD, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC), typeof(TD)))
             {
@@ -1159,7 +1219,7 @@ namespace Wasmtime
                 args[2] = Value.FromValueBox(cc.Box(c));
                 args[3] = Value.FromValueBox(cd.Box(d));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1172,10 +1232,14 @@ namespace Wasmtime
         /// <typeparam name="TC">Third parameter</typeparam>
         /// <typeparam name="TD">Fourth parameter</typeparam>
         /// <typeparam name="TE">Fifth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TR>? WrapFunc<TA, TB, TC, TD, TE, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TR>? WrapFunc<TA, TB, TC, TD, TE, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC), typeof(TD), typeof(TE)))
             {
@@ -1201,7 +1265,7 @@ namespace Wasmtime
                 args[3] = Value.FromValueBox(cd.Box(d));
                 args[4] = Value.FromValueBox(ce.Box(e));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1215,10 +1279,14 @@ namespace Wasmtime
         /// <typeparam name="TD">Fourth parameter</typeparam>
         /// <typeparam name="TE">Fifth parameter</typeparam>
         /// <typeparam name="TF">Sixth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC), typeof(TD), typeof(TE), typeof(TF)))
             {
@@ -1246,7 +1314,7 @@ namespace Wasmtime
                 args[4] = Value.FromValueBox(ce.Box(e));
                 args[5] = Value.FromValueBox(cf.Box(f));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1261,10 +1329,14 @@ namespace Wasmtime
         /// <typeparam name="TE">Fifth parameter</typeparam>
         /// <typeparam name="TF">Sixth parameter</typeparam>
         /// <typeparam name="TG">Seventh parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC), typeof(TD), typeof(TE), typeof(TF), typeof(TG)))
             {
@@ -1294,7 +1366,7 @@ namespace Wasmtime
                 args[5] = Value.FromValueBox(cf.Box(f));
                 args[6] = Value.FromValueBox(cg.Box(g));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1310,10 +1382,14 @@ namespace Wasmtime
         /// <typeparam name="TF">Sixth parameter</typeparam>
         /// <typeparam name="TG">Seventh parameter</typeparam>
         /// <typeparam name="TH">Eighth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC), typeof(TD), typeof(TE), typeof(TF), typeof(TG), typeof(TH)))
             {
@@ -1345,7 +1421,7 @@ namespace Wasmtime
                 args[6] = Value.FromValueBox(cg.Box(g));
                 args[7] = Value.FromValueBox(ch.Box(h));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1362,10 +1438,14 @@ namespace Wasmtime
         /// <typeparam name="TG">Seventh parameter</typeparam>
         /// <typeparam name="TH">Eighth parameter</typeparam>
         /// <typeparam name="TI">Ninth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC), typeof(TD), typeof(TE), typeof(TF), typeof(TG), typeof(TH), typeof(TI)))
             {
@@ -1399,7 +1479,7 @@ namespace Wasmtime
                 args[7] = Value.FromValueBox(ch.Box(h));
                 args[8] = Value.FromValueBox(ci.Box(i));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1417,10 +1497,14 @@ namespace Wasmtime
         /// <typeparam name="TH">Eighth parameter</typeparam>
         /// <typeparam name="TI">Ninth parameter</typeparam>
         /// <typeparam name="TJ">Tenth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC),
                                     typeof(TD), typeof(TE), typeof(TF), typeof(TG),
@@ -1458,7 +1542,7 @@ namespace Wasmtime
                 args[8] = Value.FromValueBox(ci.Box(i));
                 args[9] = Value.FromValueBox(cj.Box(j));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1477,10 +1561,14 @@ namespace Wasmtime
         /// <typeparam name="TI">Ninth parameter</typeparam>
         /// <typeparam name="TJ">Tenth parameter</typeparam>
         /// <typeparam name="TK">Eleventh parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC),
                                     typeof(TD), typeof(TE), typeof(TF), typeof(TG),
@@ -1520,7 +1608,7 @@ namespace Wasmtime
                 args[9] = Value.FromValueBox(cj.Box(j));
                 args[10] = Value.FromValueBox(ck.Box(k));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1540,10 +1628,14 @@ namespace Wasmtime
         /// <typeparam name="TJ">Tenth parameter</typeparam>
         /// <typeparam name="TK">Eleventh parameter</typeparam>
         /// <typeparam name="TL">Twelfth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC),
                                     typeof(TD), typeof(TE), typeof(TF), typeof(TG),
@@ -1586,7 +1678,7 @@ namespace Wasmtime
                 args[10] = Value.FromValueBox(ck.Box(k));
                 args[11] = Value.FromValueBox(cl.Box(l));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1607,10 +1699,14 @@ namespace Wasmtime
         /// <typeparam name="TK">Eleventh parameter</typeparam>
         /// <typeparam name="TL">Twelfth parameter</typeparam>
         /// <typeparam name="TM">Thirteenth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC),
                                     typeof(TD), typeof(TE), typeof(TF), typeof(TG),
@@ -1655,7 +1751,7 @@ namespace Wasmtime
                 args[11] = Value.FromValueBox(cl.Box(l));
                 args[12] = Value.FromValueBox(cm.Box(m));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1679,8 +1775,13 @@ namespace Wasmtime
         /// <typeparam name="TN">Fourteenth parameter</typeparam>
         /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC),
                                     typeof(TD), typeof(TE), typeof(TF), typeof(TG),
@@ -1727,7 +1828,7 @@ namespace Wasmtime
                 args[12] = Value.FromValueBox(cm.Box(m));
                 args[13] = Value.FromValueBox(cn.Box(n));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1750,10 +1851,14 @@ namespace Wasmtime
         /// <typeparam name="TM">Thirteenth parameter</typeparam>
         /// <typeparam name="TN">Fourteenth parameter</typeparam>
         /// <typeparam name="TO">Fifteenth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC),
                                     typeof(TD), typeof(TE), typeof(TF), typeof(TG),
@@ -1802,7 +1907,7 @@ namespace Wasmtime
                 args[13] = Value.FromValueBox(cn.Box(n));
                 args[14] = Value.FromValueBox(co.Box(o));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
 
@@ -1826,10 +1931,14 @@ namespace Wasmtime
         /// <typeparam name="TN">Fourteenth parameter</typeparam>
         /// <typeparam name="TO">Fifteenth parameter</typeparam>
         /// <typeparam name="TP">Sixteenth parameter</typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <returns>A Func to invoke this function. Null if the type signature is incompatible</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>(IStore store)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>? WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>()
         {
+            if (store is null)
+            {
+                throw new InvalidOperationException("Cannot Wrap null function");
+            }
+
             // Check that the requested type signature is compatible
             if (!CheckTypeSignature(typeof(TR), typeof(TA), typeof(TB), typeof(TC),
                                     typeof(TD), typeof(TE), typeof(TF), typeof(TG),
@@ -1880,7 +1989,7 @@ namespace Wasmtime
                 args[14] = Value.FromValueBox(co.Box(o));
                 args[15] = Value.FromValueBox(cp.Box(p));
 
-                return InvokeWithReturn(store, args, factory);
+                return InvokeWithReturn(args, factory);
             };
         }
         #endregion
@@ -1890,18 +1999,19 @@ namespace Wasmtime
         /// Assumes arguments are the correct type. Disposes the arguments.
         /// </summary>
         /// <typeparam name="TR"></typeparam>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <param name="arguments">Span of arguments, will be diposed after use.</param>
         /// <param name="factory">Factory to use to construct the return item</param>
         /// <returns>The return value from the function</returns>
-        private unsafe TR InvokeWithReturn<TR>(IStore store, ReadOnlySpan<Value> arguments, IReturnTypeFactory<TR> factory)
+        private unsafe TR InvokeWithReturn<TR>(ReadOnlySpan<Value> arguments, IReturnTypeFactory<TR> factory)
         {
             Span<Value> output = stackalloc Value[Results.Count];
 
             try
             {
-                Invoke(store, arguments, output);
-                return factory.Create(store.Context, output);
+                Invoke(arguments, output);
+
+                // Note: null suppression is safe because `Invoke` checks that `store` is not null
+                return factory.Create(store!, output);
             }
             finally
             {
@@ -1922,14 +2032,13 @@ namespace Wasmtime
         /// Invokes the wasmtime function
         /// Assumes arguments are the correct type. Disposes the arguments.
         /// </summary>
-        /// <param name="store">The store to use when calling the function.</param>
         /// <param name="arguments">Span of arguments, will be diposed after use.</param>
         /// <returns></returns>
-        private unsafe void InvokeWithoutReturn(IStore store, ReadOnlySpan<Value> arguments)
+        private unsafe void InvokeWithoutReturn(ReadOnlySpan<Value> arguments)
         {
             try
             {
-                Invoke(store, arguments, stackalloc Value[0]);
+                Invoke(arguments, stackalloc Value[0]);
             }
             finally
             {
@@ -1944,26 +2053,19 @@ namespace Wasmtime
         /// <summary>
         /// Invokes the Wasmtime function with no arguments.
         /// </summary>
-        /// <param name="store">The store that owns this function.</param>
         /// <returns>
         ///   Returns null if the function has no return value.
         ///   Returns the value if the function returns a single value.
         ///   Returns an array of values if the function returns more than one value.
         /// </returns>
-        public object? Invoke(IStore store)
+        public object? Invoke()
         {
-            if (store is null)
-            {
-                throw new ArgumentNullException(nameof(store));
-            }
-
-            return Invoke(store, new ReadOnlySpan<ValueBox>());
+            return Invoke(new ReadOnlySpan<ValueBox>());
         }
 
         /// <summary>
         /// Invokes the Wasmtime function.
         /// </summary>
-        /// <param name="store">The store that owns this function.</param>
         /// <param name="arguments">The array of arguments to pass to the function.</param>
         /// <returns>
         ///   Returns null if the function has no return value.
@@ -1971,27 +2073,21 @@ namespace Wasmtime
         ///   Returns an array of values if the function returns more than one value.
         /// </returns>
         // TODO: remove overload when https://github.com/dotnet/csharplang/issues/1757 is resolved
-        public object? Invoke(IStore store, params ValueBox[] arguments)
+        public object? Invoke(params ValueBox[] arguments)
         {
-            if (store is null)
-            {
-                throw new ArgumentNullException(nameof(store));
-            }
-
-            return Invoke(store, (ReadOnlySpan<ValueBox>)arguments);
+            return Invoke((ReadOnlySpan<ValueBox>)arguments);
         }
 
         /// <summary>
         /// Invokes the Wasmtime function.
         /// </summary>
-        /// <param name="store">The store that owns this function.</param>
         /// <param name="arguments">The arguments to pass to the function, wrapped in `ValueBox`</param>
         /// <returns>
         ///   Returns null if the function has no return value.
         ///   Returns the value if the function returns a single value.
         ///   Returns an array of values if the function returns more than one value.
         /// </returns>
-        public object? Invoke(IStore store, ReadOnlySpan<ValueBox> arguments)
+        public object? Invoke(ReadOnlySpan<ValueBox> arguments)
         {
             if (IsNull)
             {
@@ -2020,7 +2116,7 @@ namespace Wasmtime
 
             try
             {
-                Invoke(store, args, resultsSpan);
+                Invoke(args, resultsSpan);
 
                 if (Results.Count == 0)
                 {
@@ -2031,13 +2127,13 @@ namespace Wasmtime
                 {
                     if (Results.Count == 1)
                     {
-                        return resultsSpan[0].ToObject(context);
+                        return resultsSpan[0].ToObject(store);
                     }
 
                     var ret = new object?[Results.Count];
                     for (int i = 0; i < Results.Count; ++i)
                     {
-                        ret[i] = resultsSpan[i].ToObject(context);
+                        ret[i] = resultsSpan[i].ToObject(store);
                     }
 
                     return ret;
@@ -2063,13 +2159,12 @@ namespace Wasmtime
         /// <summary>
         /// Invokes the Wasmtime function. Assumes arguments are the correct type and return span is the correct size.
         /// </summary>
-        /// <param name="store">The store that owns this function.</param>
         /// <param name="arguments">The arguments to pass to the function, wrapped as `Value`</param>
         /// <param name="resultsOut">Output span to store the results in, must be the correct length</param>
         /// <returns>
         ///   Returns null if the function has no return value.
         /// </returns>
-        private unsafe void Invoke(IStore store, ReadOnlySpan<Value> arguments, Span<Value> resultsOut)
+        private unsafe void Invoke(ReadOnlySpan<Value> arguments, Span<Value> resultsOut)
         {
             if (IsNull)
             {
@@ -2111,12 +2206,18 @@ namespace Wasmtime
             };
         }
 
-        internal Function(StoreContext context, Delegate callback, bool hasReturn)
+        internal Function(IStore store, Delegate callback, bool hasReturn)
         {
             if (callback is null)
             {
                 throw new ArgumentNullException(nameof(callback));
             }
+
+            if (store is null)
+            {
+                throw new ArgumentNullException(nameof(store));
+            }
+            this.store = store;
 
             using var funcType = GetFunctionType(callback.GetType(), hasReturn, this.parameters, this.results, out var hasCaller);
 
@@ -2141,7 +2242,7 @@ namespace Wasmtime
                 }
 
                 Native.wasmtime_func_new(
-                    context.handle,
+                    store.Context.handle,
                     funcType,
                     func,
                     GCHandle.ToIntPtr(GCHandle.Alloc(func)),
@@ -2153,17 +2254,24 @@ namespace Wasmtime
 
         internal Function()
         {
+            this.store = null;
             this.func.store = 0;
             this.func.index = (UIntPtr)0;
         }
 
-        internal Function(StoreContext context, ExternFunc func)
+        internal Function(IStore store, ExternFunc func)
         {
+            if (store is null)
+            {
+                throw new ArgumentNullException(nameof(store));
+            }
+            this.store = store;
+
             this.func = func;
 
             if (!this.IsNull)
             {
-                using var type = new TypeHandle(Native.wasmtime_func_type(context.handle, this.func));
+                using var type = new TypeHandle(Native.wasmtime_func_type(store.Context.handle, this.func));
 
                 unsafe
                 {
@@ -2285,10 +2393,9 @@ namespace Wasmtime
                 }
 
                 var invokeArgsSpan = new Span<object?>(invokeArgs, offset, nargs);
-                var context = ((IStore)caller).Context;
                 for (int i = 0; i < invokeArgsSpan.Length; ++i)
                 {
-                    invokeArgsSpan[i] = args[i].ToObject(context);
+                    invokeArgsSpan[i] = args[i].ToObject(caller);
                 }
 
                 // NOTE: reflection is extremely slow for invoking methods. in the future, perhaps this could be replaced with
@@ -2370,6 +2477,7 @@ namespace Wasmtime
             public static unsafe extern IntPtr wasmtime_trap_new(byte* bytes, UIntPtr len);
         }
 
+        private readonly IStore? store;
         internal readonly ExternFunc func;
         internal readonly List<ValueKind> parameters = new List<ValueKind>();
         internal readonly List<ValueKind> results = new List<ValueKind>();

--- a/src/Global.cs
+++ b/src/Global.cs
@@ -65,7 +65,7 @@ namespace Wasmtime
         {
             var context = store.Context;
             Native.wasmtime_global_get(context.handle, this.global, out var v);
-            var val = v.ToObject(context);
+            var val = v.ToObject(store);
             v.Dispose();
             return val;
         }
@@ -213,7 +213,7 @@ namespace Wasmtime
                 var context = _store.Context;
                 Native.wasmtime_global_get(context.handle, _global.global, out var v);
 
-                var result = _converter.Unbox(context, v.ToValueBox());
+                var result = _converter.Unbox(_store, v.ToValueBox());
                 v.Dispose();
 
                 return result;

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -70,7 +70,7 @@ namespace Wasmtime
         public Action? GetAction(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapAction(store);
+                 ?.WrapAction();
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace Wasmtime
         public Action<TA>? GetAction<TA>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapAction<TA>(store);
+                 ?.WrapAction<TA>();
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Wasmtime
         public Action<TA, TB>? GetAction<TA, TB>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapAction<TA, TB>(store);
+                 ?.WrapAction<TA, TB>();
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Wasmtime
         public Action<TA, TB, TC>? GetAction<TA, TB, TC>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapAction<TA, TB, TC>(store);
+                 ?.WrapAction<TA, TB, TC>();
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Wasmtime
         public Action<TA, TB, TC, TD>? GetAction<TA, TB, TC, TD>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapAction<TA, TB, TC, TD>(store);
+                 ?.WrapAction<TA, TB, TC, TD>();
         }
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace Wasmtime
         public Action<TA, TB, TC, TD, TE>? GetAction<TA, TB, TC, TD, TE>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapAction<TA, TB, TC, TD, TE>(store);
+                 ?.WrapAction<TA, TB, TC, TD, TE>();
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace Wasmtime
         public Func<TR>? GetFunction<TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TR>(store);
+                 ?.WrapFunc<TR>();
         }
 
         /// <summary>
@@ -172,7 +172,7 @@ namespace Wasmtime
         public Func<TA, TR>? GetFunction<TA, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TR>(store);
+                 ?.WrapFunc<TA, TR>();
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace Wasmtime
         public Func<TA, TB, TR>? GetFunction<TA, TB, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TR>(store);
+                 ?.WrapFunc<TA, TB, TR>();
         }
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TR>? GetFunction<TA, TB, TC, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TR>();
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TR>? GetFunction<TA, TB, TC, TD, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TR>();
         }
 
         /// <summary>
@@ -238,7 +238,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TR>? GetFunction<TA, TB, TC, TD, TE, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TR>();
         }
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TR>();
         }
 
         /// <summary>
@@ -277,7 +277,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TG, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TR>();
         }
 
         /// <summary>
@@ -298,7 +298,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TR>();
         }
 
         /// <summary>
@@ -320,7 +320,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>();
         }
 
         /// <summary>
@@ -343,7 +343,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>();
         }
 
         /// <summary>
@@ -367,7 +367,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>();
         }
 
         /// <summary>
@@ -392,7 +392,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>();
         }
 
         /// <summary>
@@ -418,7 +418,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>();
         }
 
         /// <summary>
@@ -445,7 +445,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>();
         }
 
         /// <summary>
@@ -473,7 +473,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>();
         }
 
         /// <summary>
@@ -502,7 +502,7 @@ namespace Wasmtime
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>(IStore store, string name)
         {
             return GetFunction(store, name)
-                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>(store);
+                 ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>();
         }
         #endregion
 
@@ -549,7 +549,7 @@ namespace Wasmtime
                 return null;
             }
 
-            return new Function(context, ext.of.func);
+            return new Function(store, ext.of.func);
         }
 
         /// <summary>

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -633,7 +633,7 @@ namespace Wasmtime
                         throw WasmtimeException.FromOwnedError(error);
                     }
 
-                    return new Function(context, func);
+                    return new Function(store, func);
                 }
             }
         }
@@ -658,7 +658,7 @@ namespace Wasmtime
                 return null;
             }
 
-            return new Function(context, ext.of.func);
+            return new Function(store, ext.of.func);
         }
 
         /// <summary>

--- a/src/ReturnTypeFactory.cs
+++ b/src/ReturnTypeFactory.cs
@@ -8,7 +8,7 @@ namespace Wasmtime
 {
     interface IReturnTypeFactory<out TReturn>
     {
-        TReturn Create(StoreContext context, Span<Value> values);
+        TReturn Create(IStore store, Span<Value> values);
 
         static IReturnTypeFactory<TReturn> Create()
         {
@@ -73,9 +73,9 @@ namespace Wasmtime
             converter = ValueBox.Converter<TReturn>();
         }
 
-        public TReturn Create(StoreContext context, Span<Value> values)
+        public TReturn Create(IStore store, Span<Value> values)
         {
-            return converter.Unbox(context, values[0].ToValueBox());
+            return converter.Unbox(store, values[0].ToValueBox());
         }
     }
 
@@ -95,7 +95,7 @@ namespace Wasmtime
                 .CreateDelegate(typeof(TFunc));
         }
 
-        public abstract TReturn Create(StoreContext context, Span<Value> values);
+        public abstract TReturn Create(IStore store, Span<Value> values);
     }
 
     internal class TupleFactory2<TReturn, TA, TB>
@@ -110,11 +110,11 @@ namespace Wasmtime
             converterB = ValueBox.Converter<TB>();
         }
 
-        public override TReturn Create(StoreContext context, Span<Value> values)
+        public override TReturn Create(IStore store, Span<Value> values)
         {
             return Factory(
-                converterA.Unbox(context, values[0].ToValueBox()),
-                converterB.Unbox(context, values[1].ToValueBox())
+                converterA.Unbox(store, values[0].ToValueBox()),
+                converterB.Unbox(store, values[1].ToValueBox())
             );
         }
     }
@@ -133,12 +133,12 @@ namespace Wasmtime
             converterC = ValueBox.Converter<TC>();
         }
 
-        public override TReturn Create(StoreContext context, Span<Value> values)
+        public override TReturn Create(IStore store, Span<Value> values)
         {
             return Factory(
-                converterA.Unbox(context, values[0].ToValueBox()),
-                converterB.Unbox(context, values[1].ToValueBox()),
-                converterC.Unbox(context, values[2].ToValueBox())
+                converterA.Unbox(store, values[0].ToValueBox()),
+                converterB.Unbox(store, values[1].ToValueBox()),
+                converterC.Unbox(store, values[2].ToValueBox())
             );
         }
     }
@@ -159,13 +159,13 @@ namespace Wasmtime
             converterD = ValueBox.Converter<TD>();
         }
 
-        public override TReturn Create(StoreContext context, Span<Value> values)
+        public override TReturn Create(IStore store, Span<Value> values)
         {
             return Factory(
-                converterA.Unbox(context, values[0].ToValueBox()),
-                converterB.Unbox(context, values[1].ToValueBox()),
-                converterC.Unbox(context, values[2].ToValueBox()),
-                converterD.Unbox(context, values[3].ToValueBox())
+                converterA.Unbox(store, values[0].ToValueBox()),
+                converterB.Unbox(store, values[1].ToValueBox()),
+                converterC.Unbox(store, values[2].ToValueBox()),
+                converterD.Unbox(store, values[3].ToValueBox())
             );
         }
     }
@@ -188,14 +188,14 @@ namespace Wasmtime
             converterE = ValueBox.Converter<TE>();
         }
 
-        public override TReturn Create(StoreContext context, Span<Value> values)
+        public override TReturn Create(IStore store, Span<Value> values)
         {
             return Factory(
-                converterA.Unbox(context, values[0].ToValueBox()),
-                converterB.Unbox(context, values[1].ToValueBox()),
-                converterC.Unbox(context, values[2].ToValueBox()),
-                converterD.Unbox(context, values[3].ToValueBox()),
-                converterE.Unbox(context, values[4].ToValueBox())
+                converterA.Unbox(store, values[0].ToValueBox()),
+                converterB.Unbox(store, values[1].ToValueBox()),
+                converterC.Unbox(store, values[2].ToValueBox()),
+                converterD.Unbox(store, values[3].ToValueBox()),
+                converterE.Unbox(store, values[4].ToValueBox())
             );
         }
     }
@@ -220,15 +220,15 @@ namespace Wasmtime
             converterF = ValueBox.Converter<TF>();
         }
 
-        public override TReturn Create(StoreContext context, Span<Value> values)
+        public override TReturn Create(IStore store, Span<Value> values)
         {
             return Factory(
-                converterA.Unbox(context, values[0].ToValueBox()),
-                converterB.Unbox(context, values[1].ToValueBox()),
-                converterC.Unbox(context, values[2].ToValueBox()),
-                converterD.Unbox(context, values[3].ToValueBox()),
-                converterE.Unbox(context, values[4].ToValueBox()),
-                converterF.Unbox(context, values[5].ToValueBox())
+                converterA.Unbox(store, values[0].ToValueBox()),
+                converterB.Unbox(store, values[1].ToValueBox()),
+                converterC.Unbox(store, values[2].ToValueBox()),
+                converterD.Unbox(store, values[3].ToValueBox()),
+                converterE.Unbox(store, values[4].ToValueBox()),
+                converterF.Unbox(store, values[5].ToValueBox())
             );
         }
     }
@@ -255,16 +255,16 @@ namespace Wasmtime
             converterG = ValueBox.Converter<TG>();
         }
 
-        public override TReturn Create(StoreContext context, Span<Value> values)
+        public override TReturn Create(IStore store, Span<Value> values)
         {
             return Factory(
-                converterA.Unbox(context, values[0].ToValueBox()),
-                converterB.Unbox(context, values[1].ToValueBox()),
-                converterC.Unbox(context, values[2].ToValueBox()),
-                converterD.Unbox(context, values[3].ToValueBox()),
-                converterE.Unbox(context, values[4].ToValueBox()),
-                converterF.Unbox(context, values[5].ToValueBox()),
-                converterG.Unbox(context, values[6].ToValueBox())
+                converterA.Unbox(store, values[0].ToValueBox()),
+                converterB.Unbox(store, values[1].ToValueBox()),
+                converterC.Unbox(store, values[2].ToValueBox()),
+                converterD.Unbox(store, values[3].ToValueBox()),
+                converterE.Unbox(store, values[4].ToValueBox()),
+                converterF.Unbox(store, values[5].ToValueBox()),
+                converterG.Unbox(store, values[6].ToValueBox())
             );
         }
     }

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -87,7 +87,7 @@ namespace Wasmtime
                 throw new IndexOutOfRangeException();
             }
 
-            var val = v.ToObject(context);
+            var val = v.ToObject(store);
             v.Dispose();
             return val;
         }

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -334,7 +334,7 @@ namespace Wasmtime
             return value;
         }
 
-        public object? ToObject(StoreContext context)
+        public object? ToObject(IStore store)
         {
             switch (kind)
             {
@@ -363,7 +363,7 @@ namespace Wasmtime
                     return ResolveExternRef();
 
                 case ValueKind.FuncRef:
-                    return new Function(context, of.funcref);
+                    return new Function(store, of.funcref);
 
                 default:
                     throw new NotSupportedException("Unsupported value kind.");

--- a/src/ValueBox.cs
+++ b/src/ValueBox.cs
@@ -219,7 +219,7 @@ namespace Wasmtime
     {
         public ValueBox Box(T value);
 
-        public T Unbox(StoreContext context, ValueBox value);
+        public T Unbox(IStore store, ValueBox value);
     }
 
     internal class Int32ValueBoxConverter
@@ -236,7 +236,7 @@ namespace Wasmtime
             return value;
         }
 
-        public int Unbox(StoreContext context, ValueBox value)
+        public int Unbox(IStore store, ValueBox value)
         {
             return value.Union.i32;
         }
@@ -256,7 +256,7 @@ namespace Wasmtime
             return value;
         }
 
-        public long Unbox(StoreContext context, ValueBox value)
+        public long Unbox(IStore store, ValueBox value)
         {
             return value.Union.i64;
         }
@@ -276,7 +276,7 @@ namespace Wasmtime
             return value;
         }
 
-        public float Unbox(StoreContext context, ValueBox value)
+        public float Unbox(IStore store, ValueBox value)
         {
             return value.Union.f32;
         }
@@ -296,7 +296,7 @@ namespace Wasmtime
             return value;
         }
 
-        public double Unbox(StoreContext context, ValueBox value)
+        public double Unbox(IStore store, ValueBox value)
         {
             return value.Union.f64;
         }
@@ -316,9 +316,9 @@ namespace Wasmtime
             return value;
         }
 
-        public Function Unbox(StoreContext context, ValueBox value)
+        public Function Unbox(IStore store, ValueBox value)
         {
-            return new Function(context, value.Union.funcref);
+            return new Function(store, value.Union.funcref);
         }
     }
 
@@ -336,7 +336,7 @@ namespace Wasmtime
             return value;
         }
 
-        public V128 Unbox(StoreContext context, ValueBox value)
+        public V128 Unbox(IStore store, ValueBox value)
         {
             unsafe
             {
@@ -359,7 +359,7 @@ namespace Wasmtime
             return ValueBox.AsBox((object?)value);
         }
 
-        public T? Unbox(StoreContext context, ValueBox value)
+        public T? Unbox(IStore store, ValueBox value)
         {
             return (T?)value.ExternRefObject;
         }

--- a/tests/CallExportFromImportTests.cs
+++ b/tests/CallExportFromImportTests.cs
@@ -29,13 +29,13 @@ namespace Wasmtime.Tests
             {
                 var shiftLeftFunc = caller.GetFunction("shiftLeft");
 
-                return (int)shiftLeftFunc.Invoke(caller, arg);
+                return (int)shiftLeftFunc.Invoke(arg);
             });
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var testFunction = instance.GetFunction(Store, "testFunction");
 
-            var result = (int)testFunction.Invoke(Store, 2);
+            var result = (int)testFunction.Invoke(2);
             result.Should().Be(2 << 1);
         }
 

--- a/tests/EpochInterruptionTests.cs
+++ b/tests/EpochInterruptionTests.cs
@@ -44,7 +44,7 @@ public class EpochInterruptionTests : IClassFixture<EpochInterruptionFixture>, I
             using (var timer = new Timer(state => Fixture.Engine.IncrementEpoch()))
             {
                 timer.Change(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(Timeout.Infinite));
-                run.Invoke(Store);
+                run.Invoke();
             }
         };
 

--- a/tests/ExternRefTests.cs
+++ b/tests/ExternRefTests.cs
@@ -49,8 +49,8 @@ namespace Wasmtime.Tests
             var nullref = instance.GetFunction(Store, "nullref");
             inout.Should().NotBeNull();
 
-            (inout.Invoke(Store, ValueBox.AsBox((object)null))).Should().BeNull();
-            (nullref.Invoke(Store)).Should().BeNull();
+            (inout.Invoke(ValueBox.AsBox((object)null))).Should().BeNull();
+            (nullref.Invoke()).Should().BeNull();
         }
 
         unsafe class Value
@@ -90,7 +90,7 @@ namespace Wasmtime.Tests
                 inout.Should().NotBeNull();
                 for (int i = 0; i < 100; ++i)
                 {
-                    inout.Invoke(Store, ValueBox.AsBox(new Value(counter)));
+                    inout.Invoke(ValueBox.AsBox(new Value(counter)));
                 }
 
                 Store.Dispose();
@@ -109,7 +109,7 @@ namespace Wasmtime.Tests
             var inout = instance.GetFunction(Store, "inout");
             inout.Should().NotBeNull();
 
-            Action action = () => inout.Invoke(Store, ValueBox.AsBox((object)5));
+            Action action = () => inout.Invoke(ValueBox.AsBox((object)5));
 
             action
                 .Should()

--- a/tests/FuelConsumptionTests.cs
+++ b/tests/FuelConsumptionTests.cs
@@ -100,11 +100,11 @@ namespace Wasmtime.Tests
 
             Store.AddFuel(1000UL);
 
-            free.Invoke(Store);
+            free.Invoke();
             var consumed = Store.GetConsumedFuel();
             consumed.Should().Be(2UL);
 
-            free.Invoke(Store);
+            free.Invoke();
             consumed = Store.GetConsumedFuel();
             consumed.Should().Be(4UL);
         }
@@ -117,7 +117,7 @@ namespace Wasmtime.Tests
 
             Store.AddFuel(1000UL);
 
-            expensive.Invoke(Store);
+            expensive.Invoke();
             var consumed = Store.GetConsumedFuel();
             consumed.Should().Be(102UL);
         }
@@ -128,7 +128,7 @@ namespace Wasmtime.Tests
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var free = instance.GetFunction(Store, "free");
 
-            Action action = () => free.Invoke(Store);
+            Action action = () => free.Invoke();
             action
                 .Should()
                 .Throw<TrapException>()
@@ -146,15 +146,15 @@ namespace Wasmtime.Tests
 
             Store.AddFuel(4UL);
 
-            free.Invoke(Store);
+            free.Invoke();
             var consumed = Store.GetConsumedFuel();
             consumed.Should().Be(2UL);
 
-            free.Invoke(Store);
+            free.Invoke();
             consumed = Store.GetConsumedFuel();
             consumed.Should().Be(4UL);
 
-            Action action = () => free.Invoke(Store);
+            Action action = () => free.Invoke();
             action
                 .Should()
                 .Throw<TrapException>()
@@ -172,7 +172,7 @@ namespace Wasmtime.Tests
 
             Store.AddFuel(50UL);
 
-            Action action = () => expensive.Invoke(Store);
+            Action action = () => expensive.Invoke();
             action
                 .Should()
                 .Throw<TrapException>()
@@ -190,15 +190,15 @@ namespace Wasmtime.Tests
 
             Store.AddFuel(4UL);
 
-            free.Invoke(Store);
+            free.Invoke();
             var consumed = Store.GetConsumedFuel();
             consumed.Should().Be(2UL);
 
-            free.Invoke(Store);
+            free.Invoke();
             consumed = Store.GetConsumedFuel();
             consumed.Should().Be(4UL);
 
-            Action action = () => free.Invoke(Store);
+            Action action = () => free.Invoke();
             action
                 .Should()
                 .Throw<TrapException>()
@@ -209,7 +209,7 @@ namespace Wasmtime.Tests
 
             Store.AddFuel(3UL);
 
-            free.Invoke(Store);
+            free.Invoke();
             consumed = Store.GetConsumedFuel();
             consumed.Should().Be(7UL);
 

--- a/tests/FuncRefTests.cs
+++ b/tests/FuncRefTests.cs
@@ -17,7 +17,7 @@ namespace Wasmtime.Tests
             Linker = new Linker(Fixture.Engine);
             Store = new Store(Fixture.Engine);
 
-            Callback = Function.FromCallback(Store, (Caller caller, Function f) => f.Invoke(caller, "testing"));
+            Callback = Function.FromCallback(Store, (Caller caller, Function f) => f.Invoke("testing"));
             Assert = Function.FromCallback(Store, (string s) => { s.Should().Be("testing"); return "asserted!"; });
 
             Linker.Define("", "callback", Callback);
@@ -37,7 +37,7 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItPassesFunctionReferencesToWasm()
         {
-            var f = Function.FromCallback(Store, (Caller caller, string s) => Assert.Invoke(caller, s));
+            var f = Function.FromCallback(Store, (Caller caller, string s) => Assert.Invoke(s));
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
             var func = instance.GetFunction<Function, Function, string>(Store, "call_nested");

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -43,27 +43,27 @@ namespace Wasmtime.Tests
             var swap = instance.GetFunction(Store, "swap");
             var check = instance.GetFunction(Store, "check_string");
 
-            int x = (int)add.Invoke(Store, 40, 2);
+            int x = (int)add.Invoke(40, 2);
             x.Should().Be(42);
-            x = (int)add.Invoke(Store, 22, 5);
+            x = (int)add.Invoke(22, 5);
             x.Should().Be(27);
 
-            object[] results = (object[])swap.Invoke(Store, 10, 100);
+            object[] results = (object[])swap.Invoke(10, 100);
             results.Should().Equal(new object[] { 100, 10 });
 
-            check.Invoke(Store);
+            check.Invoke();
 
             // Collect garbage to make sure delegate function pointers passed to wasmtime are rooted.
             GC.Collect();
             GC.WaitForPendingFinalizers();
 
-            x = (int)add.Invoke(Store, 1970, 50);
+            x = (int)add.Invoke(1970, 50);
             x.Should().Be(2020);
 
-            results = (object[])swap.Invoke(Store, 2020, 1970);
+            results = (object[])swap.Invoke(2020, 1970);
             results.Should().Equal(new object[] { 1970, 2020 });
 
-            check.Invoke(Store);
+            check.Invoke();
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace Wasmtime.Tests
             var add = instance.GetFunction(Store, "add");
 
             var args = new ValueBox[] { 40, 2 };
-            int x = (int)add.Invoke(Store, args.AsSpan());
+            int x = (int)add.Invoke(args.AsSpan());
             x.Should().Be(42);
         }
 
@@ -129,7 +129,7 @@ namespace Wasmtime.Tests
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var thrower = instance.GetFunction(Store, "do_throw");
 
-            Action action = () => thrower.Invoke(Store);
+            Action action = () => thrower.Invoke();
 
             action
                 .Should()
@@ -199,7 +199,7 @@ namespace Wasmtime.Tests
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var func = instance.GetFunction(Store, "$echo_funcref");
-            var echo = func.WrapFunc<Function, Function>(Store);
+            var echo = func.WrapFunc<Function, Function>();
             echo.Should().NotBeNull();
 
             var result = echo.Invoke(func);

--- a/tests/GlobalImportBindingTests.cs
+++ b/tests/GlobalImportBindingTests.cs
@@ -142,41 +142,41 @@ namespace Wasmtime.Tests
             var get_global_f64 = instance.GetFunction(Store, "get_global_f64");
 
             global_i32_mut.GetValue().Should().Be(0);
-            get_global_i32_mut.Invoke(Store).Should().Be(0);
+            get_global_i32_mut.Invoke().Should().Be(0);
             global_i32.GetValue().Should().Be(1);
-            get_global_i32.Invoke(Store).Should().Be(1);
+            get_global_i32.Invoke().Should().Be(1);
             global_i64_mut.GetValue().Should().Be(2);
-            get_global_i64_mut.Invoke(Store).Should().Be(2);
+            get_global_i64_mut.Invoke().Should().Be(2);
             global_i64.GetValue().Should().Be(3);
-            get_global_i64.Invoke(Store).Should().Be(3);
+            get_global_i64.Invoke().Should().Be(3);
             global_f32_mut.GetValue().Should().Be(4);
-            get_global_f32_mut.Invoke(Store).Should().Be(4);
+            get_global_f32_mut.Invoke().Should().Be(4);
             global_f32.GetValue().Should().Be(5);
-            get_global_f32.Invoke(Store).Should().Be(5);
+            get_global_f32.Invoke().Should().Be(5);
             global_f64_mut.GetValue().Should().Be(6);
-            get_global_f64_mut.Invoke(Store).Should().Be(6);
+            get_global_f64_mut.Invoke().Should().Be(6);
             global_f64.GetValue().Should().Be(7);
-            get_global_f64.Invoke(Store).Should().Be(7);
+            get_global_f64.Invoke().Should().Be(7);
 
             global_i32_mut.SetValue(10);
             global_i32_mut.GetValue().Should().Be(10);
-            set_global_i32_mut.Invoke(Store, 11);
-            get_global_i32_mut.Invoke(Store).Should().Be(11);
+            set_global_i32_mut.Invoke(11);
+            get_global_i32_mut.Invoke().Should().Be(11);
 
             global_i64_mut.SetValue(12);
             global_i64_mut.GetValue().Should().Be(12);
-            set_global_i64_mut.Invoke(Store, 13);
-            get_global_i64_mut.Invoke(Store).Should().Be(13);
+            set_global_i64_mut.Invoke(13);
+            get_global_i64_mut.Invoke().Should().Be(13);
 
             global_f32_mut.SetValue(14);
             global_f32_mut.GetValue().Should().Be(14);
-            set_global_f32_mut.Invoke(Store, 15);
-            get_global_f32_mut.Invoke(Store).Should().Be(15);
+            set_global_f32_mut.Invoke(15);
+            get_global_f32_mut.Invoke().Should().Be(15);
 
             global_f64_mut.SetValue(16);
             global_f64_mut.GetValue().Should().Be(16);
-            set_global_f64_mut.Invoke(Store, 17);
-            get_global_f64_mut.Invoke(Store).Should().Be(17);
+            set_global_f64_mut.Invoke(17);
+            get_global_f64_mut.Invoke().Should().Be(17);
         }
 
         public void Dispose()

--- a/tests/LinkerFunctionsTests.cs
+++ b/tests/LinkerFunctionsTests.cs
@@ -42,27 +42,27 @@ namespace Wasmtime.Tests
             var swap = instance.GetFunction(Store, "swap");
             var check = instance.GetFunction(Store, "check_string");
 
-            int x = (int)add.Invoke(Store, 40, 2);
+            int x = (int)add.Invoke(40, 2);
             x.Should().Be(42);
-            x = (int)add.Invoke(Store, 22, 5);
+            x = (int)add.Invoke(22, 5);
             x.Should().Be(27);
 
-            object[] results = (object[])swap.Invoke(Store, 10, 100);
+            object[] results = (object[])swap.Invoke(10, 100);
             results.Should().Equal(new object[] { 100, 10 });
 
-            check.Invoke(Store);
+            check.Invoke();
 
             // Collect garbage to make sure delegate function pointers passed to wasmtime are rooted.
             GC.Collect();
             GC.WaitForPendingFinalizers();
 
-            x = (int)add.Invoke(Store, 1970, 50);
+            x = (int)add.Invoke(1970, 50);
             x.Should().Be(2020);
 
-            results = (object[])swap.Invoke(Store, 2020, 1970);
+            results = (object[])swap.Invoke(2020, 1970);
             results.Should().Equal(new object[] { 1970, 2020 });
 
-            check.Invoke(Store);
+            check.Invoke();
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace Wasmtime.Tests
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var thrower = instance.GetFunction(Store, "do_throw");
 
-            Action action = () => thrower.Invoke(Store);
+            Action action = () => thrower.Invoke();
 
             action
                 .Should()

--- a/tests/MemoryImportBindingTests.cs
+++ b/tests/MemoryImportBindingTests.cs
@@ -56,37 +56,37 @@ namespace Wasmtime.Tests
             mem.ReadByte(20).Should().Be(1);
             mem.WriteByte(20, 11);
             mem.ReadByte(20).Should().Be(11);
-            readByte.Invoke(Store).Should().Be(11);
+            readByte.Invoke().Should().Be(11);
 
             mem.ReadInt16(21).Should().Be(2);
             mem.WriteInt16(21, 12);
             mem.ReadInt16(21).Should().Be(12);
-            readInt16.Invoke(Store).Should().Be(12);
+            readInt16.Invoke().Should().Be(12);
 
             mem.ReadInt32(23).Should().Be(3);
             mem.WriteInt32(23, 13);
             mem.ReadInt32(23).Should().Be(13);
-            readInt32.Invoke(Store).Should().Be(13);
+            readInt32.Invoke().Should().Be(13);
 
             mem.ReadInt64(27).Should().Be(4);
             mem.WriteInt64(27, 14);
             mem.ReadInt64(27).Should().Be(14);
-            readInt64.Invoke(Store).Should().Be(14);
+            readInt64.Invoke().Should().Be(14);
 
             mem.ReadSingle(35).Should().Be(5);
             mem.WriteSingle(35, 15);
             mem.ReadSingle(35).Should().Be(15);
-            readFloat32.Invoke(Store).Should().Be(15);
+            readFloat32.Invoke().Should().Be(15);
 
             mem.ReadDouble(39).Should().Be(6);
             mem.WriteDouble(39, 16);
             mem.ReadDouble(39).Should().Be(16);
-            readFloat64.Invoke(Store).Should().Be(16);
+            readFloat64.Invoke().Should().Be(16);
 
             mem.ReadIntPtr(48).Should().Be((IntPtr)7);
             mem.WriteIntPtr(48, (IntPtr)17);
             mem.ReadIntPtr(48).Should().Be((IntPtr)17);
-            readIntPtr.Invoke(Store).Should().Be(17);
+            readIntPtr.Invoke().Should().Be(17);
         }
 
         public void Dispose()

--- a/tests/TableImportBindingTests.cs
+++ b/tests/TableImportBindingTests.cs
@@ -86,8 +86,8 @@ namespace Wasmtime.Tests
 
             for (int i = 0; i < 10; ++i)
             {
-                Convert.ToBoolean(is_null_func.Invoke(Store, i)).Should().BeTrue();
-                Convert.ToBoolean(is_null_extern.Invoke(Store, i)).Should().BeTrue();
+                Convert.ToBoolean(is_null_func.Invoke(i)).Should().BeTrue();
+                Convert.ToBoolean(is_null_extern.Invoke(i)).Should().BeTrue();
             }
 
             var called = new bool[10];
@@ -95,24 +95,24 @@ namespace Wasmtime.Tests
             for (int i = 0; i < 10; ++i)
             {
                 int index = i;
-                funcs.SetElement((uint)i, Function.FromCallback(Store, () => { called[index] = true; }));
-                externs.SetElement((uint)i, string.Format("string{0}", i));
+                funcs.SetElement(Store, (uint)i, Function.FromCallback(Store, () => { called[index] = true; }));
+                externs.SetElement(Store, (uint)i, string.Format("string{0}", i));
             }
 
             for (int i = 0; i < 10; ++i)
             {
-                Convert.ToBoolean(is_null_func.Invoke(Store, i)).Should().BeFalse();
-                Convert.ToBoolean(is_null_extern.Invoke(Store, i)).Should().BeFalse();
-                call.Invoke(Store, i);
-                assert_extern.Invoke(Store, i, string.Format("string{0}", i));
-                funcs.SetElement((uint)i, Function.Null);
-                externs.SetElement((uint)i, null);
+                Convert.ToBoolean(is_null_func.Invoke(i)).Should().BeFalse();
+                Convert.ToBoolean(is_null_extern.Invoke(i)).Should().BeFalse();
+                call.Invoke(i);
+                assert_extern.Invoke(i, string.Format("string{0}", i));
+                funcs.SetElement(Store, (uint)i, Function.Null);
+                externs.SetElement(Store, (uint)i, null);
             }
 
             for (int i = 0; i < 10; ++i)
             {
-                Convert.ToBoolean(is_null_func.Invoke(Store, i)).Should().BeTrue();
-                Convert.ToBoolean(is_null_extern.Invoke(Store, i)).Should().BeTrue();
+                Convert.ToBoolean(is_null_func.Invoke(i)).Should().BeTrue();
+                Convert.ToBoolean(is_null_extern.Invoke(i)).Should().BeTrue();
                 called[i].Should().BeTrue();
             }
         }
@@ -130,29 +130,29 @@ namespace Wasmtime.Tests
             var grow_funcs = instance.GetFunction(Store, "grow_funcs");
             var grow_externs = instance.GetFunction(Store, "grow_externs");
 
-            funcs.GetSize().Should().Be(10);
-            externs.GetSize().Should().Be(10);
+            funcs.GetSize(Store).Should().Be(10);
+            externs.GetSize(Store).Should().Be(10);
 
-            grow_funcs.Invoke(Store, 5);
-            grow_externs.Invoke(Store, 3);
+            grow_funcs.Invoke(5);
+            grow_externs.Invoke(3);
 
-            funcs.GetSize().Should().Be(15);
-            externs.GetSize().Should().Be(13);
+            funcs.GetSize(Store).Should().Be(15);
+            externs.GetSize(Store).Should().Be(13);
 
-            funcs.Grow(5, null).Should().Be(15);
-            externs.Grow(5, null).Should().Be(13);
+            funcs.Grow(Store, 5, null).Should().Be(15);
+            externs.Grow(Store, 5, null).Should().Be(13);
 
-            funcs.GetSize().Should().Be(20);
-            externs.GetSize().Should().Be(18);
+            funcs.GetSize(Store).Should().Be(20);
+            externs.GetSize(Store).Should().Be(18);
 
-            Action action = () => { funcs.Grow(5, null); };
+            Action action = () => { funcs.Grow(Store, 5, null); };
 
             action
                 .Should()
                 .Throw<WasmtimeException>()
                 .WithMessage("failed to grow table by `5`");
 
-            action = () => { externs.Grow(3, null); };
+            action = () => { externs.Grow(Store, 3, null); };
 
             action
                 .Should()

--- a/tests/TableImportBindingTests.cs
+++ b/tests/TableImportBindingTests.cs
@@ -95,8 +95,8 @@ namespace Wasmtime.Tests
             for (int i = 0; i < 10; ++i)
             {
                 int index = i;
-                funcs.SetElement(Store, (uint)i, Function.FromCallback(Store, () => { called[index] = true; }));
-                externs.SetElement(Store, (uint)i, string.Format("string{0}", i));
+                funcs.SetElement((uint)i, Function.FromCallback(Store, () => { called[index] = true; }));
+                externs.SetElement((uint)i, string.Format("string{0}", i));
             }
 
             for (int i = 0; i < 10; ++i)
@@ -105,8 +105,8 @@ namespace Wasmtime.Tests
                 Convert.ToBoolean(is_null_extern.Invoke(i)).Should().BeFalse();
                 call.Invoke(i);
                 assert_extern.Invoke(i, string.Format("string{0}", i));
-                funcs.SetElement(Store, (uint)i, Function.Null);
-                externs.SetElement(Store, (uint)i, null);
+                funcs.SetElement((uint)i, Function.Null);
+                externs.SetElement((uint)i, null);
             }
 
             for (int i = 0; i < 10; ++i)
@@ -130,29 +130,29 @@ namespace Wasmtime.Tests
             var grow_funcs = instance.GetFunction(Store, "grow_funcs");
             var grow_externs = instance.GetFunction(Store, "grow_externs");
 
-            funcs.GetSize(Store).Should().Be(10);
-            externs.GetSize(Store).Should().Be(10);
+            funcs.GetSize().Should().Be(10);
+            externs.GetSize().Should().Be(10);
 
             grow_funcs.Invoke(5);
             grow_externs.Invoke(3);
 
-            funcs.GetSize(Store).Should().Be(15);
-            externs.GetSize(Store).Should().Be(13);
+            funcs.GetSize().Should().Be(15);
+            externs.GetSize().Should().Be(13);
 
-            funcs.Grow(Store, 5, null).Should().Be(15);
-            externs.Grow(Store, 5, null).Should().Be(13);
+            funcs.Grow(5, null).Should().Be(15);
+            externs.Grow(5, null).Should().Be(13);
 
-            funcs.GetSize(Store).Should().Be(20);
-            externs.GetSize(Store).Should().Be(18);
+            funcs.GetSize().Should().Be(20);
+            externs.GetSize().Should().Be(18);
 
-            Action action = () => { funcs.Grow(Store, 5, null); };
+            Action action = () => { funcs.Grow(5, null); };
 
             action
                 .Should()
                 .Throw<WasmtimeException>()
                 .WithMessage("failed to grow table by `5`");
 
-            action = () => { externs.Grow(Store, 3, null); };
+            action = () => { externs.Grow(3, null); };
 
             action
                 .Should()

--- a/tests/WasiTests.cs
+++ b/tests/WasiTests.cs
@@ -29,7 +29,7 @@ namespace Wasmtime.Tests
             var call_environ_sizes_get = instance.GetFunction(store, "call_environ_sizes_get");
             call_environ_sizes_get.Should().NotBeNull();
 
-            Assert.Equal(0, call_environ_sizes_get.Invoke(store, 0, 4));
+            Assert.Equal(0, call_environ_sizes_get.Invoke(0, 4));
             Assert.Equal(0, memory.ReadInt32(0));
             Assert.Equal(0, memory.ReadInt32(4));
         }
@@ -65,10 +65,10 @@ namespace Wasmtime.Tests
             var call_environ_get = instance.GetFunction(store, "call_environ_get");
             call_environ_sizes_get.Should().NotBeNull();
 
-            Assert.Equal(0, call_environ_sizes_get.Invoke(store, 0, 4));
+            Assert.Equal(0, call_environ_sizes_get.Invoke(0, 4));
             Assert.Equal(env.Count, memory.ReadInt32(0));
             Assert.Equal(env.Sum(kvp => kvp.Key.Length + kvp.Value.Length + 2), memory.ReadInt32(4));
-            Assert.Equal(0, call_environ_get.Invoke(store, 0, 4 * env.Count));
+            Assert.Equal(0, call_environ_get.Invoke(0, 4 * env.Count));
 
             for (int i = 0; i < env.Count; ++i)
             {
@@ -100,7 +100,7 @@ namespace Wasmtime.Tests
             var call_environ_sizes_get = instance.GetFunction(store, "call_environ_sizes_get");
             call_environ_sizes_get.Should().NotBeNull();
 
-            Assert.Equal(0, call_environ_sizes_get.Invoke(store, 0, 4));
+            Assert.Equal(0, call_environ_sizes_get.Invoke(0, 4));
             Assert.Equal(Environment.GetEnvironmentVariables().Keys.Count, memory.ReadInt32(0));
         }
 
@@ -124,7 +124,7 @@ namespace Wasmtime.Tests
             var call_args_sizes_get = instance.GetFunction(store, "call_args_sizes_get");
             call_args_sizes_get.Should().NotBeNull();
 
-            Assert.Equal(0, call_args_sizes_get.Invoke(store, 0, 4));
+            Assert.Equal(0, call_args_sizes_get.Invoke(0, 4));
             Assert.Equal(0, memory.ReadInt32(0));
             Assert.Equal(0, memory.ReadInt32(4));
         }
@@ -161,10 +161,10 @@ namespace Wasmtime.Tests
             var call_args_get = instance.GetFunction(store, "call_args_get");
             call_args_get.Should().NotBeNull();
 
-            Assert.Equal(0, call_args_sizes_get.Invoke(store, 0, 4));
+            Assert.Equal(0, call_args_sizes_get.Invoke(0, 4));
             Assert.Equal(args.Count, memory.ReadInt32(0));
             Assert.Equal(args.Sum(a => a.Length + 1), memory.ReadInt32(4));
-            Assert.Equal(0, call_args_get.Invoke(store, 0, 4 * args.Count));
+            Assert.Equal(0, call_args_get.Invoke(0, 4 * args.Count));
 
             for (int i = 0; i < args.Count; ++i)
             {
@@ -196,7 +196,7 @@ namespace Wasmtime.Tests
             var call_args_sizes_get = instance.GetFunction(store, "call_args_sizes_get");
             call_args_sizes_get.Should().NotBeNull();
 
-            Assert.Equal(0, call_args_sizes_get.Invoke(store, 0, 4));
+            Assert.Equal(0, call_args_sizes_get.Invoke(0, 4));
             Assert.Equal(Environment.GetCommandLineArgs().Length, memory.ReadInt32(0));
         }
 
@@ -231,7 +231,7 @@ namespace Wasmtime.Tests
             memory.WriteInt32(0, 8);
             memory.WriteInt32(4, MESSAGE.Length);
 
-            Assert.Equal(0, call_fd_read.Invoke(store, 0, 0, 1, 32));
+            Assert.Equal(0, call_fd_read.Invoke(0, 0, 1, 32));
             Assert.Equal(MESSAGE.Length, memory.ReadInt32(32));
             Assert.Equal(MESSAGE, memory.ReadString(8, MESSAGE.Length));
         }
@@ -278,9 +278,9 @@ namespace Wasmtime.Tests
             memory.WriteInt32(4, MESSAGE.Length);
             memory.WriteString(8, MESSAGE);
 
-            Assert.Equal(0, call_fd_write.Invoke(store, fd, 0, 1, 32));
+            Assert.Equal(0, call_fd_write.Invoke(fd, 0, 1, 32));
             Assert.Equal(MESSAGE.Length, memory.ReadInt32(32));
-            Assert.Equal(0, call_fd_close.Invoke(store, fd));
+            Assert.Equal(0, call_fd_close.Invoke(fd));
             Assert.Equal(MESSAGE, File.ReadAllText(file.Path));
         }
 
@@ -319,7 +319,6 @@ namespace Wasmtime.Tests
             memory.WriteString(0, fileName);
 
             Assert.Equal(0, call_path_open.Invoke(
-                    store,
                     3,
                     0,
                     0,
@@ -339,9 +338,9 @@ namespace Wasmtime.Tests
             memory.WriteInt32(4, MESSAGE.Length);
             memory.WriteString(8, MESSAGE);
 
-            Assert.Equal(0, call_fd_write.Invoke(store, fileFd, 0, 1, 64));
+            Assert.Equal(0, call_fd_write.Invoke(fileFd, 0, 1, 64));
             Assert.Equal(MESSAGE.Length, memory.ReadInt32(64));
-            Assert.Equal(0, call_fd_close.Invoke(store, fileFd));
+            Assert.Equal(0, call_fd_close.Invoke(fileFd));
             Assert.Equal(MESSAGE, File.ReadAllText(file.Path));
         }
     }


### PR DESCRIPTION
Modified Table to keep a reference to the store which owns it.

This required a change to the `ValueBox` and `ReturnTypeFactory` to take an `IStore` instead of a `StoreContext` (so that when a function is unboxed there's an `IStore` available to construct it).