### PR TITLE
Instance Store Reference

### DIFF
--- a/benchmarks/simple/Program.cs
+++ b/benchmarks/simple/Program.cs
@@ -51,7 +51,7 @@ namespace Simple
             linker.Define("", "memory", new Memory(store, 3));
 
             var instance = linker.Instantiate(store, _module);
-            var run = instance.GetFunction(store, "run")!.WrapAction();
+            var run = instance.GetFunction("run")!.WrapAction();
             if (run == null)
             {
                 throw new InvalidOperationException();

--- a/examples/consumefuel/Program.cs
+++ b/examples/consumefuel/Program.cs
@@ -25,7 +25,7 @@ namespace Example
 
             var instance = linker.Instantiate(store, module);
 
-            var expensive = instance.GetAction(store, "expensive");
+            var expensive = instance.GetAction("expensive");
             if (expensive is null)
             {
                 Console.WriteLine("error: expensive export is missing");

--- a/examples/externref/Program.cs
+++ b/examples/externref/Program.cs
@@ -20,7 +20,7 @@ namespace Example
 
             var instance = linker.Instantiate(store, module);
 
-            var run = instance.GetFunction<string, string, string>(store, "run");
+            var run = instance.GetFunction<string, string, string>("run");
             if (run is null)
             {
                 Console.WriteLine("error: run export is missing");

--- a/examples/funcref/Program.cs
+++ b/examples/funcref/Program.cs
@@ -29,14 +29,14 @@ namespace Example
 
             var instance = linker.Instantiate(store, module);
 
-            var call = instance.GetAction<Function, string>(store, "call");
+            var call = instance.GetAction<Function, string>("call");
             if (call is null)
             {
                 Console.WriteLine("error: `call` export is missing");
                 return;
             }
 
-            var f = instance.GetAction(store, "f");
+            var f = instance.GetAction("f");
             if (f is null)
             {
                 Console.WriteLine("error: `f` export is missing");

--- a/examples/global/Program.cs
+++ b/examples/global/Program.cs
@@ -27,7 +27,7 @@ namespace Example
 
             var instance = linker.Instantiate(store, module);
 
-            var run = instance.GetAction<int>(store, "run");
+            var run = instance.GetAction<int>("run");
             if (run is null)
             {
                 Console.WriteLine("error: run export is missing");

--- a/examples/hello/Program.cs
+++ b/examples/hello/Program.cs
@@ -20,7 +20,7 @@ namespace Example
 
             var instance = linker.Instantiate(store, module);
 
-            var run = instance.GetAction(store, "run");
+            var run = instance.GetAction("run");
             if (run is null)
             {
                 Console.WriteLine("error: run export is missing");

--- a/examples/memory/Program.cs
+++ b/examples/memory/Program.cs
@@ -24,7 +24,7 @@ namespace Example
 
             var instance = linker.Instantiate(store, module);
 
-            var run = instance.GetAction(store, "run");
+            var run = instance.GetAction("run");
             if (run is null)
             {
                 Console.WriteLine("error: run export is missing");

--- a/examples/table/Program.cs
+++ b/examples/table/Program.cs
@@ -23,7 +23,7 @@ namespace Example
 
             var instance = linker.Instantiate(store, module);
 
-            var call_indirect = instance.GetFunction<int, int, int, int>(store, "call_indirect");
+            var call_indirect = instance.GetFunction<int, int, int, int>("call_indirect");
             if (call_indirect is null)
             {
                 Console.WriteLine("error: `call_indirect` export is missing");

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -33,6 +33,8 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(imports));
             }
 
+            _store = store;
+
             unsafe
             {
                 var externs = stackalloc Extern[imports.Length];
@@ -64,77 +66,71 @@ namespace Wasmtime
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Action? GetAction(IStore store, string name)
+        public Action? GetAction(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapAction();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">Parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Action<TA>? GetAction<TA>(IStore store, string name)
+        public Action<TA>? GetAction<TA>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapAction<TA>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Action<TA, TB>? GetAction<TA, TB>(IStore store, string name)
+        public Action<TA, TB>? GetAction<TA, TB>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapAction<TA, TB>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
         /// <typeparam name="TC">Third parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Action<TA, TB, TC>? GetAction<TA, TB, TC>(IStore store, string name)
+        public Action<TA, TB, TC>? GetAction<TA, TB, TC>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapAction<TA, TB, TC>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
         /// <typeparam name="TC">Third parameter type</typeparam>
         /// <typeparam name="TD">Fourth parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Action<TA, TB, TC, TD>? GetAction<TA, TB, TC, TD>(IStore store, string name)
+        public Action<TA, TB, TC, TD>? GetAction<TA, TB, TC, TD>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapAction<TA, TB, TC, TD>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -142,74 +138,69 @@ namespace Wasmtime
         /// <typeparam name="TD">Fourth parameter type</typeparam>
         /// <typeparam name="TE">Fifth parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Action<TA, TB, TC, TD, TE>? GetAction<TA, TB, TC, TD, TE>(IStore store, string name)
+        public Action<TA, TB, TC, TD, TE>? GetAction<TA, TB, TC, TD, TE>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapAction<TA, TB, TC, TD, TE>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TR>? GetFunction<TR>(IStore store, string name)
+        public Func<TR>? GetFunction<TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TR>? GetFunction<TA, TR>(IStore store, string name)
+        public Func<TA, TR>? GetFunction<TA, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TR>? GetFunction<TA, TB, TR>(IStore store, string name)
+        public Func<TA, TB, TR>? GetFunction<TA, TB, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
         /// <typeparam name="TC">Third parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TR>? GetFunction<TA, TB, TC, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TR>? GetFunction<TA, TB, TC, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -217,16 +208,15 @@ namespace Wasmtime
         /// <typeparam name="TD">Fourth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TR>? GetFunction<TA, TB, TC, TD, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TR>? GetFunction<TA, TB, TC, TD, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -235,16 +225,15 @@ namespace Wasmtime
         /// <typeparam name="TE">Fifth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TR>? GetFunction<TA, TB, TC, TD, TE, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TR>? GetFunction<TA, TB, TC, TD, TE, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -254,16 +243,15 @@ namespace Wasmtime
         /// <typeparam name="TF">Sixth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -274,16 +262,15 @@ namespace Wasmtime
         /// <typeparam name="TG">Seventh parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -295,16 +282,15 @@ namespace Wasmtime
         /// <typeparam name="TH">Eighth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -317,16 +303,15 @@ namespace Wasmtime
         /// <typeparam name="TI">Ninth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -340,16 +325,15 @@ namespace Wasmtime
         /// <typeparam name="TJ">Tenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -364,16 +348,15 @@ namespace Wasmtime
         /// <typeparam name="TK">Eleventh parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -389,16 +372,15 @@ namespace Wasmtime
         /// <typeparam name="TL">Twelfth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -415,16 +397,15 @@ namespace Wasmtime
         /// <typeparam name="TM">Thirteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -442,16 +423,15 @@ namespace Wasmtime
         /// <typeparam name="TN">Fourteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -470,16 +450,15 @@ namespace Wasmtime
         /// <typeparam name="TO">Fifteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>();
         }
 
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
@@ -499,9 +478,9 @@ namespace Wasmtime
         /// <typeparam name="TP">Sixteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
-        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>(IStore store, string name)
+        public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>(string name)
         {
-            return GetFunction(store, name)
+            return GetFunction(name)
                  ?.WrapFunc<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>();
         }
         #endregion
@@ -509,14 +488,13 @@ namespace Wasmtime
         /// <summary>
         /// Gets an exported function from the instance and check the type signature.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <param name="returnType">The return type of the function. Null if no return type. Tuple of types is multiple returns expected.</param>
         /// <param name="parameterTypes">The expected parameters to the function</param>
         /// <returns>Returns the function if a function of that name and type signature was exported or null if not.</returns>
-        public Function? GetFunction(IStore store, string name, Type? returnType, params Type[] parameterTypes)
+        public Function? GetFunction(string name, Type? returnType, params Type[] parameterTypes)
         {
-            var func = GetFunction(store, name);
+            var func = GetFunction(name);
             if (func is null)
             {
                 return null;
@@ -533,88 +511,64 @@ namespace Wasmtime
         /// <summary>
         /// Gets an exported function from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported function.</param>
         /// <returns>Returns the function if a function of that name was exported or null if not.</returns>
-        public Function? GetFunction(IStore store, string name)
+        public Function? GetFunction(string name)
         {
-            if (store is null)
-            {
-                throw new ArgumentNullException(nameof(store));
-            }
-
-            var context = store.Context;
+            var context = _store.Context;
             if (!TryGetExtern(context, name, out var ext) || ext.kind != ExternKind.Func)
             {
                 return null;
             }
 
-            return new Function(store, ext.of.func);
+            return new Function(_store, ext.of.func);
         }
 
         /// <summary>
         /// Gets an exported table from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported table.</param>
         /// <returns>Returns the table if a table of that name was exported or null if not.</returns>
-        public Table? GetTable(IStore store, string name)
+        public Table? GetTable(string name)
         {
-            if (store is null)
-            {
-                throw new ArgumentNullException(nameof(store));
-            }
-
-            var context = store.Context;
+            var context = _store.Context;
             if (!TryGetExtern(context, name, out var ext) || ext.kind != ExternKind.Table)
             {
                 return null;
             }
 
-            return new Table(store, ext.of.table);
+            return new Table(_store, ext.of.table);
         }
 
         /// <summary>
         /// Gets an exported memory from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported memory.</param>
         /// <returns>Returns the memory if a memory of that name was exported or null if not.</returns>
-        public Memory? GetMemory(IStore store, string name)
+        public Memory? GetMemory(string name)
         {
-            if (store is null)
-            {
-                throw new ArgumentNullException(nameof(store));
-            }
-
-            if (!TryGetExtern(store.Context, name, out var ext) || ext.kind != ExternKind.Memory)
+            if (!TryGetExtern(_store.Context, name, out var ext) || ext.kind != ExternKind.Memory)
             {
                 return null;
             }
 
-            return new Memory(store, ext.of.memory);
+            return new Memory(_store, ext.of.memory);
         }
 
         /// <summary>
         /// Gets an exported global from the instance.
         /// </summary>
-        /// <param name="store">The store that owns the instance.</param>
         /// <param name="name">The name of the exported global.</param>
         /// <returns>Returns the global if a global of that name was exported or null if not.</returns>
-        public Global? GetGlobal(IStore store, string name)
+        public Global? GetGlobal(string name)
         {
-            if (store is null)
-            {
-                throw new ArgumentNullException(nameof(store));
-            }
-
-            var context = store.Context;
+            var context = _store.Context;
             if (!TryGetExtern(context, name, out var ext) || ext.kind != ExternKind.Global)
             {
                 return null;
             }
 
-            return new Global(store, ext.of.global);
+            return new Global(_store, ext.of.global);
         }
 
         private bool TryGetExtern(StoreContext context, string name, out Extern ext)
@@ -629,8 +583,14 @@ namespace Wasmtime
             }
         }
 
-        internal Instance(ExternInstance instance)
+        internal Instance(IStore store, ExternInstance instance)
         {
+            if (store is null)
+            {
+                throw new ArgumentNullException(nameof(store));
+            }
+
+            this._store = store;
             this.instance = instance;
         }
 
@@ -666,6 +626,7 @@ namespace Wasmtime
             public static extern void wasmtime_instancetype_delete(IntPtr handle);
         }
 
+        private readonly IStore _store;
         internal readonly ExternInstance instance;
     }
 }

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -568,7 +568,7 @@ namespace Wasmtime
                 throw TrapException.FromOwnedTrap(trap);
             }
 
-            return new Instance(instance);
+            return new Instance(store, instance);
         }
 
         /// <summary>

--- a/tests/CallExportFromImportTests.cs
+++ b/tests/CallExportFromImportTests.cs
@@ -33,7 +33,7 @@ namespace Wasmtime.Tests
             });
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var testFunction = instance.GetFunction(Store, "testFunction");
+            var testFunction = instance.GetFunction("testFunction");
 
             var result = (int)testFunction.Invoke(2);
             result.Should().Be(2 << 1);

--- a/tests/EpochInterruptionTests.cs
+++ b/tests/EpochInterruptionTests.cs
@@ -37,7 +37,7 @@ public class EpochInterruptionTests : IClassFixture<EpochInterruptionFixture>, I
         Store.SetEpochDeadline(1);
 
         var instance = Linker.Instantiate(Store, Fixture.Module);
-        var run = instance.GetFunction(Store, "run");
+        var run = instance.GetFunction("run");
 
         var action = () =>
         {

--- a/tests/ExitTrapTests.cs
+++ b/tests/ExitTrapTests.cs
@@ -22,10 +22,10 @@ namespace Wasmtime.Tests
             store.SetWasiConfiguration(new WasiConfiguration());
             var instance = linker.Instantiate(store, module);
 
-            var memory = instance.GetMemory(store, "memory");
+            var memory = instance.GetMemory("memory");
             memory.Should().NotBeNull();
 
-            var exit = instance.GetAction<int>(store, "exit")!;
+            var exit = instance.GetAction<int>("exit")!;
             exit.Should().NotBeNull();
 
             try

--- a/tests/ExternRefTests.cs
+++ b/tests/ExternRefTests.cs
@@ -31,7 +31,7 @@ namespace Wasmtime.Tests
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
-            var inout = instance.GetFunction<string, string>(Store, "inout");
+            var inout = instance.GetFunction<string, string>("inout");
             inout.Should().NotBeNull();
 
             var input = "input";
@@ -43,10 +43,10 @@ namespace Wasmtime.Tests
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
-            var inout = instance.GetFunction(Store, "inout");
+            var inout = instance.GetFunction("inout");
             inout.Should().NotBeNull();
 
-            var nullref = instance.GetFunction(Store, "nullref");
+            var nullref = instance.GetFunction("nullref");
             inout.Should().NotBeNull();
 
             (inout.Invoke(ValueBox.AsBox((object)null))).Should().BeNull();
@@ -86,7 +86,7 @@ namespace Wasmtime.Tests
             {
                 var instance = Linker.Instantiate(Store, Fixture.Module);
 
-                var inout = instance.GetFunction(Store, "inout");
+                var inout = instance.GetFunction("inout");
                 inout.Should().NotBeNull();
                 for (int i = 0; i < 100; ++i)
                 {
@@ -106,7 +106,7 @@ namespace Wasmtime.Tests
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
-            var inout = instance.GetFunction(Store, "inout");
+            var inout = instance.GetFunction("inout");
             inout.Should().NotBeNull();
 
             Action action = () => inout.Invoke(ValueBox.AsBox((object)5));

--- a/tests/FuelConsumptionTests.cs
+++ b/tests/FuelConsumptionTests.cs
@@ -96,7 +96,7 @@ namespace Wasmtime.Tests
         public void ItConsumesFuelWhenCallingImportMethods()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var free = instance.GetFunction(Store, "free");
+            var free = instance.GetFunction("free");
 
             Store.AddFuel(1000UL);
 
@@ -113,7 +113,7 @@ namespace Wasmtime.Tests
         public void ItConsumesFuelFromInsideAnImportMethod()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var expensive = instance.GetFunction(Store, "expensive");
+            var expensive = instance.GetFunction("expensive");
 
             Store.AddFuel(1000UL);
 
@@ -126,7 +126,7 @@ namespace Wasmtime.Tests
         public void ItThrowsOnCallingImportMethodIfNoFuelAdded()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var free = instance.GetFunction(Store, "free");
+            var free = instance.GetFunction("free");
 
             Action action = () => free.Invoke();
             action
@@ -142,7 +142,7 @@ namespace Wasmtime.Tests
         public void ItThrowsOnCallingImportMethodIfNotEnoughFuelAdded()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var free = instance.GetFunction(Store, "free");
+            var free = instance.GetFunction("free");
 
             Store.AddFuel(4UL);
 
@@ -168,7 +168,7 @@ namespace Wasmtime.Tests
         public void ItThrowsWhenConsumingTooMuchFuelFromInsideAnImportMethod()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var expensive = instance.GetFunction(Store, "expensive");
+            var expensive = instance.GetFunction("expensive");
 
             Store.AddFuel(50UL);
 
@@ -186,7 +186,7 @@ namespace Wasmtime.Tests
         public void ItAddsAdditonalFuelAfterCallingImportMethods()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var free = instance.GetFunction(Store, "free");
+            var free = instance.GetFunction("free");
 
             Store.AddFuel(4UL);
 

--- a/tests/FuncRefTests.cs
+++ b/tests/FuncRefTests.cs
@@ -40,7 +40,7 @@ namespace Wasmtime.Tests
             var f = Function.FromCallback(Store, (Caller caller, string s) => Assert.Invoke(s));
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
-            var func = instance.GetFunction<Function, Function, string>(Store, "call_nested");
+            var func = instance.GetFunction<Function, Function, string>("call_nested");
             func.Should().NotBeNull();
 
             func(Callback, f).Should().Be("asserted!");
@@ -51,7 +51,7 @@ namespace Wasmtime.Tests
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
-            var func = instance.GetFunction<string>(Store, "call_callback");
+            var func = instance.GetFunction<string>("call_callback");
             func.Should().NotBeNull();
 
             func().Should().Be("asserted!");
@@ -61,7 +61,7 @@ namespace Wasmtime.Tests
         public void ItThrowsForInvokingANullFunctionReference()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var func = instance.GetFunction<object>(Store, "call_with_null");
+            var func = instance.GetFunction<object>("call_with_null");
             func.Should().NotBeNull();
 
             func

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -39,9 +39,9 @@ namespace Wasmtime.Tests
         public void ItBindsImportMethodsAndCallsThemCorrectly()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var add = instance.GetFunction(Store, "add");
-            var swap = instance.GetFunction(Store, "swap");
-            var check = instance.GetFunction(Store, "check_string");
+            var add = instance.GetFunction("add");
+            var swap = instance.GetFunction("swap");
+            var check = instance.GetFunction("check_string");
 
             int x = (int)add.Invoke(40, 2);
             x.Should().Be(42);
@@ -70,7 +70,7 @@ namespace Wasmtime.Tests
         public void ItWrapsASimpleAction()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var noop = instance.GetAction(Store, "noop");
+            var noop = instance.GetAction("noop");
             noop.Should().NotBeNull();
             noop();
         }
@@ -79,7 +79,7 @@ namespace Wasmtime.Tests
         public void ItWrapsArgumentsInValueBox()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var add = instance.GetFunction(Store, "add");
+            var add = instance.GetFunction("add");
 
             var args = new ValueBox[] { 40, 2 };
             int x = (int)add.Invoke(args.AsSpan());
@@ -91,7 +91,7 @@ namespace Wasmtime.Tests
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
-            var add = instance.GetFunction<int, int, int>(Store, "add");
+            var add = instance.GetFunction<int, int, int>("add");
             add.Should().NotBeNull();
 
             int x = add(40, 2);
@@ -103,11 +103,11 @@ namespace Wasmtime.Tests
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
-            instance.GetFunction<double, int, int>(Store, "add").Should().BeNull();
-            instance.GetFunction<int, double, int>(Store, "add").Should().BeNull();
-            instance.GetFunction<int, int, double>(Store, "add").Should().BeNull();
-            instance.GetFunction<int, int, int, int>(Store, "add").Should().BeNull();
-            instance.GetAction<int, int>(Store, "add").Should().BeNull();
+            instance.GetFunction<double, int, int>("add").Should().BeNull();
+            instance.GetFunction<int, double, int>("add").Should().BeNull();
+            instance.GetFunction<int, int, double>("add").Should().BeNull();
+            instance.GetFunction<int, int, int, int>("add").Should().BeNull();
+            instance.GetAction<int, int>("add").Should().BeNull();
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace Wasmtime.Tests
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
-            var swap = instance.GetFunction<int, int, (int, int)>(Store, "swap");
+            var swap = instance.GetFunction<int, int, (int, int)>("swap");
             swap.Should().NotBeNull();
 
             (int x, int y) = swap(100, 10);
@@ -127,7 +127,7 @@ namespace Wasmtime.Tests
         public void ItPropagatesExceptionsToCallersViaTraps()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var thrower = instance.GetFunction(Store, "do_throw");
+            var thrower = instance.GetFunction("do_throw");
 
             Action action = () => thrower.Invoke();
 
@@ -143,7 +143,7 @@ namespace Wasmtime.Tests
         public void ItEchoesInt32()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<int, int>(Store, "$echo_i32");
+            var echo = instance.GetFunction<int, int>("$echo_i32");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke(42);
@@ -154,7 +154,7 @@ namespace Wasmtime.Tests
         public void ItEchoesInt64()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<long, long>(Store, "$echo_i64");
+            var echo = instance.GetFunction<long, long>("$echo_i64");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke(42);
@@ -165,7 +165,7 @@ namespace Wasmtime.Tests
         public void ItEchoesFloat32()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<float, float>(Store, "$echo_f32");
+            var echo = instance.GetFunction<float, float>("$echo_f32");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke(42);
@@ -176,7 +176,7 @@ namespace Wasmtime.Tests
         public void ItEchoesFloat64()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<double, double>(Store, "$echo_f64");
+            var echo = instance.GetFunction<double, double>("$echo_f64");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke(42);
@@ -187,7 +187,7 @@ namespace Wasmtime.Tests
         public void ItEchoesV128()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<V128, V128>(Store, "$echo_v128");
+            var echo = instance.GetFunction<V128, V128>("$echo_v128");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke(V128.AllBitsSet);
@@ -198,7 +198,7 @@ namespace Wasmtime.Tests
         public void ItEchoesFuncref()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var func = instance.GetFunction(Store, "$echo_funcref");
+            var func = instance.GetFunction("$echo_funcref");
             var echo = func.WrapFunc<Function, Function>();
             echo.Should().NotBeNull();
 
@@ -212,7 +212,7 @@ namespace Wasmtime.Tests
         public void ItEchoesExternref()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<object, object>(Store, "$echo_externref");
+            var echo = instance.GetFunction<object, object>("$echo_externref");
             echo.Should().NotBeNull();
 
             var obj = new object();
@@ -227,7 +227,7 @@ namespace Wasmtime.Tests
         public void ItEchoesExternrefString()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<object, object>(Store, "$echo_externref");
+            var echo = instance.GetFunction<object, object>("$echo_externref");
             echo.Should().NotBeNull();
 
             var str = "Hello Wasmtime";
@@ -242,7 +242,7 @@ namespace Wasmtime.Tests
         public void ItReturnsTwoItemTuple()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<(int, int)>(Store, "$echo_tuple2");
+            var echo = instance.GetFunction<(int, int)>("$echo_tuple2");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke();
@@ -253,7 +253,7 @@ namespace Wasmtime.Tests
         public void ItReturnsThreeItemTuple()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<(int, int, int)>(Store, "$echo_tuple3");
+            var echo = instance.GetFunction<(int, int, int)>("$echo_tuple3");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke();
@@ -264,7 +264,7 @@ namespace Wasmtime.Tests
         public void ItReturnsFourItemTuple()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<(int, int, int, float)>(Store, "$echo_tuple4");
+            var echo = instance.GetFunction<(int, int, int, float)>("$echo_tuple4");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke();
@@ -275,7 +275,7 @@ namespace Wasmtime.Tests
         public void ItReturnsFiveItemTuple()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<(int, int, int, float, double)>(Store, "$echo_tuple5");
+            var echo = instance.GetFunction<(int, int, int, float, double)>("$echo_tuple5");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke();
@@ -286,7 +286,7 @@ namespace Wasmtime.Tests
         public void ItReturnsSixItemTuple()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<(int, int, int, float, double, int)>(Store, "$echo_tuple6");
+            var echo = instance.GetFunction<(int, int, int, float, double, int)>("$echo_tuple6");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke();
@@ -297,7 +297,7 @@ namespace Wasmtime.Tests
         public void ItReturnsSevenItemTuple()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<(int, int, int, float, double, int, int)>(Store, "$echo_tuple7");
+            var echo = instance.GetFunction<(int, int, int, float, double, int, int)>("$echo_tuple7");
             echo.Should().NotBeNull();
 
             var result = echo.Invoke();
@@ -311,7 +311,7 @@ namespace Wasmtime.Tests
             // to support longer tuples, in which case this test will need modifying.
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            instance.GetFunction<(int, int, int, float, double, int, int, int)>(Store, "$echo_tuple8")
+            instance.GetFunction<(int, int, int, float, double, int, int, int)>("$echo_tuple8")
                 .Should()
                 .BeNull();
         }

--- a/tests/GlobalExportsTests.cs
+++ b/tests/GlobalExportsTests.cs
@@ -47,48 +47,48 @@ namespace Wasmtime.Tests
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
-            var i32 = instance.GetGlobal(Store, "global_i32");
+            var i32 = instance.GetGlobal("global_i32");
             i32.Kind.Should().Be(ValueKind.Int32);
             i32.Mutability.Should().Be(Mutability.Immutable);
             i32.GetValue().Should().Be(0);
 
-            var i32Mut = instance.GetGlobal(Store, "global_i32_mut");
+            var i32Mut = instance.GetGlobal("global_i32_mut");
             i32Mut.Kind.Should().Be(ValueKind.Int32);
             i32Mut.Mutability.Should().Be(Mutability.Mutable);
             i32Mut.GetValue().Should().Be(1);
             i32Mut.SetValue(11);
             i32Mut.GetValue().Should().Be(11);
 
-            var i64 = instance.GetGlobal(Store, "global_i64");
+            var i64 = instance.GetGlobal("global_i64");
             i64.Kind.Should().Be(ValueKind.Int64);
             i64.Mutability.Should().Be(Mutability.Immutable);
             i64.GetValue().Should().Be(2);
 
-            var i64Mut = instance.GetGlobal(Store, "global_i64_mut");
+            var i64Mut = instance.GetGlobal("global_i64_mut");
             i64Mut.Kind.Should().Be(ValueKind.Int64);
             i64Mut.Mutability.Should().Be(Mutability.Mutable);
             i64Mut.GetValue().Should().Be(3);
             i64Mut.SetValue(13);
             i64Mut.GetValue().Should().Be(13);
 
-            var f32 = instance.GetGlobal(Store, "global_f32");
+            var f32 = instance.GetGlobal("global_f32");
             f32.Kind.Should().Be(ValueKind.Float32);
             f32.Mutability.Should().Be(Mutability.Immutable);
             f32.GetValue().Should().Be(4);
 
-            var f32Mut = instance.GetGlobal(Store, "global_f32_mut");
+            var f32Mut = instance.GetGlobal("global_f32_mut");
             f32Mut.Kind.Should().Be(ValueKind.Float32);
             f32Mut.Mutability.Should().Be(Mutability.Mutable);
             f32Mut.GetValue().Should().Be(5);
             f32Mut.SetValue(15);
             f32Mut.GetValue().Should().Be(15);
 
-            var f64 = instance.GetGlobal(Store, "global_f64");
+            var f64 = instance.GetGlobal("global_f64");
             f64.Kind.Should().Be(ValueKind.Float64);
             f64.Mutability.Should().Be(Mutability.Immutable);
             f64.GetValue().Should().Be(6);
 
-            var f64Mut = instance.GetGlobal(Store, "global_f64_mut");
+            var f64Mut = instance.GetGlobal("global_f64_mut");
             f64Mut.Kind.Should().Be(ValueKind.Float64);
             f64Mut.Mutability.Should().Be(Mutability.Mutable);
             f64Mut.GetValue().Should().Be(7);

--- a/tests/GlobalImportBindingTests.cs
+++ b/tests/GlobalImportBindingTests.cs
@@ -128,18 +128,18 @@ namespace Wasmtime.Tests
             Linker.Define("", "global_f64", global_f64);
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var get_global_i32_mut = instance.GetFunction(Store, "get_global_i32_mut");
-            var set_global_i32_mut = instance.GetFunction(Store, "set_global_i32_mut");
-            var get_global_i32 = instance.GetFunction(Store, "get_global_i32");
-            var get_global_i64_mut = instance.GetFunction(Store, "get_global_i64_mut");
-            var set_global_i64_mut = instance.GetFunction(Store, "set_global_i64_mut");
-            var get_global_i64 = instance.GetFunction(Store, "get_global_i64");
-            var get_global_f32_mut = instance.GetFunction(Store, "get_global_f32_mut");
-            var set_global_f32_mut = instance.GetFunction(Store, "set_global_f32_mut");
-            var get_global_f32 = instance.GetFunction(Store, "get_global_f32");
-            var get_global_f64_mut = instance.GetFunction(Store, "get_global_f64_mut");
-            var set_global_f64_mut = instance.GetFunction(Store, "set_global_f64_mut");
-            var get_global_f64 = instance.GetFunction(Store, "get_global_f64");
+            var get_global_i32_mut = instance.GetFunction("get_global_i32_mut");
+            var set_global_i32_mut = instance.GetFunction("set_global_i32_mut");
+            var get_global_i32 = instance.GetFunction("get_global_i32");
+            var get_global_i64_mut = instance.GetFunction("get_global_i64_mut");
+            var set_global_i64_mut = instance.GetFunction("set_global_i64_mut");
+            var get_global_i64 = instance.GetFunction("get_global_i64");
+            var get_global_f32_mut = instance.GetFunction("get_global_f32_mut");
+            var set_global_f32_mut = instance.GetFunction("set_global_f32_mut");
+            var get_global_f32 = instance.GetFunction("get_global_f32");
+            var get_global_f64_mut = instance.GetFunction("get_global_f64_mut");
+            var set_global_f64_mut = instance.GetFunction("set_global_f64_mut");
+            var get_global_f64 = instance.GetFunction("get_global_f64");
 
             global_i32_mut.GetValue().Should().Be(0);
             get_global_i32_mut.Invoke().Should().Be(0);

--- a/tests/LinkerFunctionsTests.cs
+++ b/tests/LinkerFunctionsTests.cs
@@ -38,9 +38,9 @@ namespace Wasmtime.Tests
         public void ItBindsImportMethodsAndCallsThemCorrectly()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var add = instance.GetFunction(Store, "add");
-            var swap = instance.GetFunction(Store, "swap");
-            var check = instance.GetFunction(Store, "check_string");
+            var add = instance.GetFunction("add");
+            var swap = instance.GetFunction("swap");
+            var check = instance.GetFunction("check_string");
 
             int x = (int)add.Invoke(40, 2);
             x.Should().Be(42);
@@ -69,7 +69,7 @@ namespace Wasmtime.Tests
         public void ItPropagatesExceptionsToCallersViaTraps()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var thrower = instance.GetFunction(Store, "do_throw");
+            var thrower = instance.GetFunction("do_throw");
 
             Action action = () => thrower.Invoke();
 

--- a/tests/MemoryExportsTests.cs
+++ b/tests/MemoryExportsTests.cs
@@ -47,7 +47,7 @@ namespace Wasmtime.Tests
         public void ItReadsAndWritesGenericTypes()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var memory = instance.GetMemory(Store, "mem");
+            var memory = instance.GetMemory("mem");
 
             memory.Should().NotBeNull();
 
@@ -68,7 +68,7 @@ namespace Wasmtime.Tests
         public void ItCreatesExternsForTheMemories()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var memory = instance.GetMemory(Store, "mem");
+            var memory = instance.GetMemory("mem");
 
             memory.Should().NotBeNull();
 

--- a/tests/MemoryImportBindingTests.cs
+++ b/tests/MemoryImportBindingTests.cs
@@ -41,13 +41,13 @@ namespace Wasmtime.Tests
             var mem = new Memory(Store, 1);
             Linker.Define("", "mem", mem);
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var readByte = instance.GetFunction(Store, "ReadByte");
-            var readInt16 = instance.GetFunction(Store, "ReadInt16");
-            var readInt32 = instance.GetFunction(Store, "ReadInt32");
-            var readInt64 = instance.GetFunction(Store, "ReadInt64");
-            var readFloat32 = instance.GetFunction(Store, "ReadFloat32");
-            var readFloat64 = instance.GetFunction(Store, "ReadFloat64");
-            var readIntPtr = instance.GetFunction(Store, "ReadIntPtr");
+            var readByte = instance.GetFunction("ReadByte");
+            var readInt16 = instance.GetFunction("ReadInt16");
+            var readInt32 = instance.GetFunction("ReadInt32");
+            var readInt64 = instance.GetFunction("ReadInt64");
+            var readFloat32 = instance.GetFunction("ReadFloat32");
+            var readFloat64 = instance.GetFunction("ReadFloat64");
+            var readIntPtr = instance.GetFunction("ReadIntPtr");
 
             mem.ReadString(0, 11).Should().Be("Hello World");
             int written = mem.WriteString(0, "WebAssembly Rocks!");

--- a/tests/TableExportsTests.cs
+++ b/tests/TableExportsTests.cs
@@ -48,19 +48,19 @@ namespace Wasmtime.Tests
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
 
-            var table1 = instance.GetTable(Store, "table1");
+            var table1 = instance.GetTable("table1");
             table1.Should().NotBeNull();
             table1.Kind.Should().Be(ValueKind.FuncRef);
             table1.Minimum.Should().Be(1);
             table1.Maximum.Should().Be(10);
 
-            var table2 = instance.GetTable(Store, "table2");
+            var table2 = instance.GetTable("table2");
             table2.Should().NotBeNull();
             table2.Kind.Should().Be(ValueKind.FuncRef);
             table2.Minimum.Should().Be(10);
             table2.Maximum.Should().Be(uint.MaxValue);
 
-            var table3 = instance.GetTable(Store, "table3");
+            var table3 = instance.GetTable("table3");
             table3.Should().NotBeNull();
             table3.Kind.Should().Be(ValueKind.FuncRef);
             table3.Minimum.Should().Be(100);

--- a/tests/TableImportBindingTests.cs
+++ b/tests/TableImportBindingTests.cs
@@ -79,10 +79,10 @@ namespace Wasmtime.Tests
             Linker.Define("", "externs", externs);
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var is_null_func = instance.GetFunction(Store, "is_null_extern");
-            var is_null_extern = instance.GetFunction(Store, "is_null_extern");
-            var call = instance.GetFunction(Store, "call");
-            var assert_extern = instance.GetFunction(Store, "assert_extern");
+            var is_null_func = instance.GetFunction("is_null_extern");
+            var is_null_extern = instance.GetFunction("is_null_extern");
+            var call = instance.GetFunction("call");
+            var assert_extern = instance.GetFunction("assert_extern");
 
             for (int i = 0; i < 10; ++i)
             {
@@ -127,8 +127,8 @@ namespace Wasmtime.Tests
             Linker.Define("", "externs", externs);
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var grow_funcs = instance.GetFunction(Store, "grow_funcs");
-            var grow_externs = instance.GetFunction(Store, "grow_externs");
+            var grow_funcs = instance.GetFunction("grow_funcs");
+            var grow_externs = instance.GetFunction("grow_externs");
 
             funcs.GetSize().Should().Be(10);
             externs.GetSize().Should().Be(10);

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -30,7 +30,7 @@ namespace Wasmtime.Tests
             Action action = () =>
             {
                 var instance = Linker.Instantiate(Store, Fixture.Module);
-                var run = instance.GetAction(Store, "run");
+                var run = instance.GetAction("run");
                 run.Should().NotBeNull();
                 run();
             };

--- a/tests/WasiTests.cs
+++ b/tests/WasiTests.cs
@@ -24,9 +24,9 @@ namespace Wasmtime.Tests
             store.SetWasiConfiguration(new WasiConfiguration());
             var instance = linker.Instantiate(store, module);
 
-            var memory = instance.GetMemory(store, "memory");
+            var memory = instance.GetMemory("memory");
             memory.Should().NotBeNull();
-            var call_environ_sizes_get = instance.GetFunction(store, "call_environ_sizes_get");
+            var call_environ_sizes_get = instance.GetFunction("call_environ_sizes_get");
             call_environ_sizes_get.Should().NotBeNull();
 
             Assert.Equal(0, call_environ_sizes_get.Invoke(0, 4));
@@ -58,11 +58,11 @@ namespace Wasmtime.Tests
             store.SetWasiConfiguration(config);
             var instance = linker.Instantiate(store, module);
 
-            var memory = instance.GetMemory(store, "memory");
+            var memory = instance.GetMemory("memory");
             memory.Should().NotBeNull();
-            var call_environ_sizes_get = instance.GetFunction(store, "call_environ_sizes_get");
+            var call_environ_sizes_get = instance.GetFunction("call_environ_sizes_get");
             call_environ_sizes_get.Should().NotBeNull();
-            var call_environ_get = instance.GetFunction(store, "call_environ_get");
+            var call_environ_get = instance.GetFunction("call_environ_get");
             call_environ_sizes_get.Should().NotBeNull();
 
             Assert.Equal(0, call_environ_sizes_get.Invoke(0, 4));
@@ -95,9 +95,9 @@ namespace Wasmtime.Tests
             store.SetWasiConfiguration(config);
             var instance = linker.Instantiate(store, module);
 
-            var memory = instance.GetMemory(store, "memory");
+            var memory = instance.GetMemory("memory");
             memory.Should().NotBeNull();
-            var call_environ_sizes_get = instance.GetFunction(store, "call_environ_sizes_get");
+            var call_environ_sizes_get = instance.GetFunction("call_environ_sizes_get");
             call_environ_sizes_get.Should().NotBeNull();
 
             Assert.Equal(0, call_environ_sizes_get.Invoke(0, 4));
@@ -119,9 +119,9 @@ namespace Wasmtime.Tests
             store.SetWasiConfiguration(new WasiConfiguration());
             var instance = linker.Instantiate(store, module);
 
-            var memory = instance.GetMemory(store, "memory");
+            var memory = instance.GetMemory("memory");
             memory.Should().NotBeNull();
-            var call_args_sizes_get = instance.GetFunction(store, "call_args_sizes_get");
+            var call_args_sizes_get = instance.GetFunction("call_args_sizes_get");
             call_args_sizes_get.Should().NotBeNull();
 
             Assert.Equal(0, call_args_sizes_get.Invoke(0, 4));
@@ -154,11 +154,11 @@ namespace Wasmtime.Tests
             store.SetWasiConfiguration(config);
             var instance = linker.Instantiate(store, module);
 
-            var memory = instance.GetMemory(store, "memory");
+            var memory = instance.GetMemory("memory");
             memory.Should().NotBeNull();
-            var call_args_sizes_get = instance.GetFunction(store, "call_args_sizes_get");
+            var call_args_sizes_get = instance.GetFunction("call_args_sizes_get");
             call_args_sizes_get.Should().NotBeNull();
-            var call_args_get = instance.GetFunction(store, "call_args_get");
+            var call_args_get = instance.GetFunction("call_args_get");
             call_args_get.Should().NotBeNull();
 
             Assert.Equal(0, call_args_sizes_get.Invoke(0, 4));
@@ -191,9 +191,9 @@ namespace Wasmtime.Tests
             store.SetWasiConfiguration(config);
             var instance = linker.Instantiate(store, module);
 
-            var memory = instance.GetMemory(store, "memory");
+            var memory = instance.GetMemory("memory");
             memory.Should().NotBeNull();
-            var call_args_sizes_get = instance.GetFunction(store, "call_args_sizes_get");
+            var call_args_sizes_get = instance.GetFunction("call_args_sizes_get");
             call_args_sizes_get.Should().NotBeNull();
 
             Assert.Equal(0, call_args_sizes_get.Invoke(0, 4));
@@ -223,9 +223,9 @@ namespace Wasmtime.Tests
             store.SetWasiConfiguration(config);
             var instance = linker.Instantiate(store, module);
 
-            var memory = instance.GetMemory(store, "memory");
+            var memory = instance.GetMemory("memory");
             memory.Should().NotBeNull();
-            var call_fd_read = instance.GetFunction(store, "call_fd_read");
+            var call_fd_read = instance.GetFunction("call_fd_read");
             call_fd_read.Should().NotBeNull();
 
             memory.WriteInt32(0, 8);
@@ -267,11 +267,11 @@ namespace Wasmtime.Tests
             store.SetWasiConfiguration(config);
             var instance = linker.Instantiate(store, module);
 
-            var memory = instance.GetMemory(store, "memory");
+            var memory = instance.GetMemory("memory");
             memory.Should().NotBeNull();
-            var call_fd_write = instance.GetFunction(store, "call_fd_write");
+            var call_fd_write = instance.GetFunction("call_fd_write");
             call_fd_write.Should().NotBeNull();
-            var call_fd_close = instance.GetFunction(store, "call_fd_close");
+            var call_fd_close = instance.GetFunction("call_fd_close");
             call_fd_close.Should().NotBeNull();
 
             memory.WriteInt32(0, 8);
@@ -306,13 +306,13 @@ namespace Wasmtime.Tests
             store.SetWasiConfiguration(config);
             var instance = linker.Instantiate(store, module);
 
-            var memory = instance.GetMemory(store, "memory");
+            var memory = instance.GetMemory("memory");
             memory.Should().NotBeNull();
-            var call_path_open = instance.GetFunction(store, "call_path_open");
+            var call_path_open = instance.GetFunction("call_path_open");
             call_path_open.Should().NotBeNull();
-            var call_fd_write = instance.GetFunction(store, "call_fd_write");
+            var call_fd_write = instance.GetFunction("call_fd_write");
             call_fd_write.Should().NotBeNull();
-            var call_fd_close = instance.GetFunction(store, "call_fd_close");
+            var call_fd_close = instance.GetFunction("call_fd_close");
             call_fd_close.Should().NotBeNull();
 
             var fileName = Path.GetFileName(file.Path);


### PR DESCRIPTION
Basically the same change as my previous 3 PRs, this time applied to the `Instance`. Removes another potential footgun of mixing up stores between instances.