### PR TITLE
Trap Result

### DIFF
--- a/tests/Modules/Trap.wat
+++ b/tests/Modules/Trap.wat
@@ -1,5 +1,8 @@
 (module
   (export "run" (func $run))
+  (export "run_stack_overflow" (func $run_stack_overflow))
+  (export "run_stack_overflow_with_result" (func $run_stack_overflow_with_result))
+
   (func $run
     (call $first)
   )
@@ -11,5 +14,13 @@
   )
   (func $third
     unreachable
+  )
+
+  (func $run_stack_overflow_with_result (result i32)
+    (call $run_stack_overflow_with_result)
+  )
+
+  (func $run_stack_overflow
+    (call $run_stack_overflow)
   )
 )

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -46,6 +46,56 @@ namespace Wasmtime.Tests
                 .WithMessage("wasm trap: wasm `unreachable` instruction executed*");
         }
 
+        [Fact]
+        public void ItReturnsATrapCodeResult()
+        {
+
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var run = instance.GetFunction<Result>("run_stack_overflow");
+            var result = run();
+
+            result.Type.Should().Be(ResultType.Trap);
+            result.Trap.Should().Be(TrapCode.StackOverflow);
+        }
+
+        [Fact]
+        public void ItReturnsATrapCodeAndBacktraceResult()
+        {
+
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var run = instance.GetFunction<ResultWithBacktrace>("run_stack_overflow");
+            var result = run();
+
+            result.Type.Should().Be(ResultType.Trap);
+            result.Trap.Type.Should().Be(TrapCode.StackOverflow);
+            result.Trap.Frames.Count.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ItReturnsATrapCodeGenericResult()
+        {
+
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var run = instance.GetFunction<Result<int>>("run_stack_overflow_with_result");
+            var result = run();
+
+            result.Type.Should().Be(ResultType.Trap);
+            result.Trap.Should().Be(TrapCode.StackOverflow);
+        }
+
+        [Fact]
+        public void ItReturnsATrapCodeAndBacktraceGenericResult()
+        {
+
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var run = instance.GetFunction<ResultWithBacktrace<int>>("run_stack_overflow_with_result");
+            var result = run();
+
+            result.Type.Should().Be(ResultType.Trap);
+            result.Trap.Type.Should().Be(TrapCode.StackOverflow);
+            result.Trap.Frames.Count.Should().BeGreaterThan(0);
+        }
+
         public void Dispose()
         {
             Store.Dispose();


### PR DESCRIPTION
Added in 4 new `Result` types (`Result`, `ResultWithBacktrace`, `Result<T>`, `ResultWithBacktrace<T>`) which provide a better method for trap handling than exceptions. This entire new system is opt-in, the function wrappers accept these types instead of the actual return type and then, if a trap happens, it is returned in this result struct instead of as an exception.

 - `Result` represents a function with no return value, which does not capture the trap backtrace.
 - `ResultWithBacktrace` represents a function with no return value, which captures the trap backtrace.
 - `Result<T>` represents a function which returns `T`, which does not capture the trap backtrace.
 - `ResultWithBacktrace<T>` represents a function which returns `T`, which captures the trap backtrace.

Also some associated to the `TrapException`:
 - Added a `TrapCode Type` property, which was an obvious omission from traps
 - Modified `FunctionOffset` and `ModuleOffset` of the `TrapFrame` to use `nuint` instead of `int` (which could cause an arithmetic overflow) (see #150)