### PR TITLE
Trap Stackoverflow Test

### DIFF
--- a/src/TrapException.cs
+++ b/src/TrapException.cs
@@ -47,9 +47,9 @@ namespace Wasmtime
     {
         unsafe internal TrapFrame(IntPtr frame)
         {
-            FunctionOffset = (int)Native.wasm_frame_func_offset(frame);
+            FunctionOffset = (nuint)Native.wasm_frame_func_offset(frame);
             FunctionName = null;
-            ModuleOffset = (int)Native.wasm_frame_module_offset(frame);
+            ModuleOffset = (nuint)Native.wasm_frame_module_offset(frame);
             ModuleName = null;
 
             var bytes = Native.wasmtime_frame_func_name(frame);
@@ -68,7 +68,7 @@ namespace Wasmtime
         /// <summary>
         /// Gets the frame's byte offset from the start of the function.
         /// </summary>
-        public int FunctionOffset { get; private set; }
+        public nuint FunctionOffset { get; private set; }
 
         /// <summary>
         /// Gets the frame's function name.
@@ -78,7 +78,7 @@ namespace Wasmtime
         /// <summary>
         /// Gets the frame's module offset from the start of the module.
         /// </summary>
-        public int ModuleOffset { get; private set; }
+        public nuint ModuleOffset { get; private set; }
 
         /// <summary>
         /// Gets the frame's module name.

--- a/tests/Modules/Trap.wat
+++ b/tests/Modules/Trap.wat
@@ -1,5 +1,9 @@
 (module
   (export "run" (func $run))
+  (export "run_div_zero" (func $run_div_zero))
+  (export "run_div_zero_with_result" (func $run_div_zero_with_result))
+  (export "run_stack_overflow" (func $run_stack_overflow))
+
   (func $run
     (call $first)
   )
@@ -11,5 +15,20 @@
   )
   (func $third
     unreachable
+  )
+
+  (func $run_div_zero_with_result (result i32)
+    (i32.const 1)
+    (i32.const 0)
+    (i32.div_s)
+  )
+
+  (func $run_div_zero
+    (call $run_div_zero_with_result)
+    (drop)
+  )
+
+  (func $run_stack_overflow
+    (call $run_stack_overflow)
   )
 )

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -46,6 +46,22 @@ namespace Wasmtime.Tests
                 .WithMessage("wasm trap: wasm `unreachable` instruction executed*");
         }
 
+        [Fact]
+        public void ItCatchesAStackOverflow()
+        {
+            Action action = () =>
+            {
+                var instance = Linker.Instantiate(Store, Fixture.Module);
+                var run = instance.GetAction("run_stack_overflow");
+                run.Should().NotBeNull();
+                run();
+            };
+
+            action
+                .Should()
+                .Throw<TrapException>();
+        }
+
         public void Dispose()
         {
             Store.Dispose();


### PR DESCRIPTION
My other PR (#151) was failing CI on MacOS only, I think this is due to a bug in wasmtime dotnet, although I'm not sure what and unfortunately I cannot debug it further since I don't own a Mac.

This PR includes the minimal set of changes to (hopefully) reproduce the problem.

Note that the `nuint` change is necessary to prevent an `OverflowException` (as mentioned in #150).