### PR TITLE
Trap result builders

### DIFF
--- a/src/Function.cs
+++ b/src/Function.cs
@@ -554,14 +554,14 @@ namespace Wasmtime
         /// <returns>Returns true if the type signature of the function is valid or false if not.</returns>
         public bool CheckTypeSignature(Type? returnType = null, params Type[] parameters)
         {
-            // Check if the return type is Result<T>, Result, ResultWithBacktrace<T> or ResultWithBacktrace
-            if (returnType != null && returnType.IsResult())
+            // Check if the return type is a recognised result type (i.e. implements IActionResult or IFunctionResult)
+            if (returnType != null && returnType.IsResultType())
             {
                 // Try to get the type the result wraps (may be null if it's one of the non-generic result types)
-                var wrappedReturnType = returnType.IsGenericType ? returnType.GetGenericArguments()[0] : null;
+                var wrappedReturnType = returnType.GetResultInnerType();
 
                 // Check that the result does not attempt to wrap another result (e.g. Result<Result<int>>)
-                if (wrappedReturnType != null && wrappedReturnType.IsResult())
+                if (wrappedReturnType != null && wrappedReturnType.IsResultType())
                 {
                     return false;
                 }

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -562,7 +562,9 @@ namespace Wasmtime
 
                 // Check that the result does not attempt to wrap another result (e.g. Result<Result<int>>)
                 if (wrappedReturnType != null && wrappedReturnType.IsResult())
+                {
                     return false;
+                }
 
                 // Type check with the wrapped value instead of the result
                 return CheckTypeSignature(wrappedReturnType, parameters);
@@ -2124,7 +2126,9 @@ namespace Wasmtime
             // Convert arguments (ValueBox) into a form wasm can consume (Value)
             Span<Value> args = stackalloc Value[Parameters.Count];
             for (var i = 0; i < arguments.Length; ++i)
+            {
                 args[i] = arguments[i].ToValue(Parameters[i]);
+            }
 
             // Make some space to store the return results
             Span<Value> resultsSpan = stackalloc Value[Results.Count];

--- a/src/Result.cs
+++ b/src/Result.cs
@@ -1,0 +1,270 @@
+﻿using System;
+
+namespace Wasmtime
+{
+    /// <summary>
+    /// Indicates what type of result this is
+    /// </summary>
+    public enum ResultType
+    {
+        /// <summary>
+        /// Excecution succeeded
+        /// </summary>
+        Ok = 0,
+
+        /// <summary>
+        /// Result contains a trap
+        /// </summary>
+        Trap = 2,
+    }
+
+    /// <summary>
+    /// A result from a function call which may represent a Value or a Trap. If a trap happens the full backtrace is captured.
+    /// </summary>
+    public readonly struct ResultWithBacktrace
+    {
+        /// <summary>
+        /// Indicates what type of result this contains
+        /// </summary>
+        public ResultType Type { get; }
+
+        private readonly TrapException? _trap;
+
+        internal ResultWithBacktrace(IntPtr trap)
+        {
+            Type = ResultType.Trap;
+            _trap = TrapException.FromOwnedTrap(trap);
+        }
+
+        /// <summary>
+        /// Get the trap associated with this result
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Trap</exception>
+        public TrapException Trap
+        {
+            get
+            {
+                if (Type != ResultType.Trap)
+                    throw new InvalidOperationException($"Cannot get 'Trap' from '{Type}' type result");
+                return _trap!;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A result from a function call which may represent a Value or a Trap
+    /// </summary>
+    public readonly struct Result
+    {
+        /// <summary>
+        /// Indicates what type of result this contains
+        /// </summary>
+        public ResultType Type { get; }
+
+        private readonly TrapCode _trap;
+
+        internal Result(IntPtr trap)
+        {
+            Type = ResultType.Trap;
+            _trap = TrapException.GetTrapCode(trap);
+            TrapException.Native.wasm_trap_delete(trap);
+
+        }
+
+        /// <summary>
+        /// Get the trap associated with this result
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Trap</exception>
+        public TrapCode Trap
+        {
+            get
+            {
+                if (Type != ResultType.Trap)
+                    throw new InvalidOperationException($"Cannot get 'Trap' from '{Type}' type result");
+                return _trap;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A result from a function call which may represent a Value or a Trap. If a trap happens the full backtrace is captured.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public readonly struct ResultWithBacktrace<T>
+    {
+        /// <summary>
+        /// Indicates what type of result this contains
+        /// </summary>
+        public ResultType Type { get; }
+
+        private readonly T? _value;
+        private readonly TrapException? _trap;
+
+        internal ResultWithBacktrace(T value)
+        {
+            Type = ResultType.Ok;
+            _value = value;
+            _trap = null;
+        }
+
+        internal ResultWithBacktrace(IntPtr trap)
+        {
+            Type = ResultType.Trap;
+            _value = default;
+            _trap = TrapException.FromOwnedTrap(trap);
+        }
+
+        /// <summary>
+        /// Convert this result into a value, throw if it is a Trap
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="TrapException">Thrown if Type == Trap</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if Type property contains an unknown value</exception>
+        public static explicit operator T?(ResultWithBacktrace<T> value)
+        {
+            switch (value.Type)
+            {
+                case ResultType.Ok:
+                    return value._value;
+
+                case ResultType.Trap:
+                    throw value._trap!;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), $"Unknown Result Type property value '{value.Type}'");
+            }
+        }
+
+        /// <summary>
+        /// Get the value associated with this result
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Value</exception>
+        public T? Value
+        {
+            get
+            {
+                if (Type != ResultType.Ok)
+                    throw new InvalidOperationException($"Cannot get 'Value' from '{Type}' type result");
+                return _value;
+            }
+        }
+
+        /// <summary>
+        /// Get the trap associated with this result
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Trap</exception>
+        public TrapException Trap
+        {
+            get
+            {
+                if (Type != ResultType.Trap)
+                    throw new InvalidOperationException($"Cannot get 'Trap' from '{Type}' type result");
+                return _trap!;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A result from a function call which may represent a Value or a Trap
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public readonly struct Result<T>
+    {
+        /// <summary>
+        /// Indicates what type of result this contains
+        /// </summary>
+        public ResultType Type { get; }
+
+        private readonly T? _value;
+        private readonly TrapCode _trap;
+
+        internal Result(T value)
+        {
+            Type = ResultType.Ok;
+
+            _value = value;
+            _trap = default;
+        }
+
+        internal Result(IntPtr trap)
+        {
+            Type = ResultType.Trap;
+
+            _value = default;
+
+            _trap = TrapException.GetTrapCode(trap);
+            TrapException.Native.wasm_trap_delete(trap);
+
+        }
+
+        /// <summary>
+        /// Convert this result into a value, throw if it is a Trap
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        /// <exception cref="TrapException">Thrown if Type == Trap</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if Type property contains an unknoown value</exception>
+        public static explicit operator T?(Result<T> value)
+        {
+            switch (value.Type)
+            {
+                case ResultType.Ok:
+                    return value._value;
+
+                case ResultType.Trap:
+                    throw new TrapException($"{value._trap} trap", null, value._trap);
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value), $"Unknown Result Type property value '{value.Type}'");
+            }
+        }
+
+        /// <summary>
+        /// Get the value associated with this result
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Value</exception>
+        public T? Value
+        {
+            get
+            {
+                if (Type != ResultType.Ok)
+                    throw new InvalidOperationException($"Cannot get 'Value' from '{Type}' type result");
+                return _value;
+            }
+        }
+
+        /// <summary>
+        /// Get the trap associated with this result
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Trap</exception>
+        public TrapCode Trap
+        {
+            get
+            {
+                if (Type != ResultType.Trap)
+                    throw new InvalidOperationException($"Cannot get 'Trap' from '{Type}' type result");
+                return _trap;
+            }
+        }
+    }
+
+    internal static class TypeExtensions
+    {
+        internal static bool IsResult(this Type type)
+        {
+            if (type == typeof(Result) || type == typeof(ResultWithBacktrace))
+            {
+                return true;
+            }
+
+            if (!type.IsGenericType)
+            {
+                return false;
+            }
+
+            var gtd = type.GetGenericTypeDefinition();
+            return typeof(Result<>) == gtd || typeof(ResultWithBacktrace<>) == gtd;
+        }
+    }
+}

--- a/src/Result.cs
+++ b/src/Result.cs
@@ -71,14 +71,13 @@ namespace Wasmtime
             Type = ResultType.Trap;
             _trap = TrapException.GetTrapCode(trap);
             TrapException.Native.wasm_trap_delete(trap);
-
         }
 
         /// <summary>
         /// Get the trap associated with this result
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Trap</exception>
-        public TrapCode Trap
+        public TrapCode TrapCode
         {
             get
             {
@@ -253,7 +252,7 @@ namespace Wasmtime
         /// Get the trap associated with this result
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Trap</exception>
-        public TrapCode Trap
+        public TrapCode TrapCode
         {
             get
             {

--- a/src/Result.cs
+++ b/src/Result.cs
@@ -237,7 +237,7 @@ namespace Wasmtime
         /// <summary>
         /// Create a new instance indicating a trap result.
         /// </summary>
-        /// <param name="accessor"></param>
+        /// <param name="accessor">Provides access to query information about a trap</param>
         /// <returns>A new TResult instance representing a trap result</returns>
         TResult Create(TrapAccessor accessor);
     }

--- a/src/Result.cs
+++ b/src/Result.cs
@@ -18,10 +18,12 @@ namespace Wasmtime
         Trap = 1,
     }
 
+
     /// <summary>
-    /// A result from a function call which may represent a Value or a Trap. If a trap happens the full backtrace is captured.
+    /// A result from a function call which does not produce a value, represents either a successful call or a trap
     /// </summary>
-    public readonly struct ResultWithBacktrace
+    public readonly struct ActionResult
+        : IActionResult<ActionResult, ActionResultBuilder>
     {
         /// <summary>
         /// Indicates what type of result this contains
@@ -30,10 +32,10 @@ namespace Wasmtime
 
         private readonly TrapException? _trap;
 
-        internal ResultWithBacktrace(IntPtr trap)
+        internal ActionResult(TrapException trap)
         {
             Type = ResultType.Trap;
-            _trap = TrapException.FromOwnedTrap(trap);
+            _trap = trap;
         }
 
         /// <summary>
@@ -54,48 +56,61 @@ namespace Wasmtime
         }
     }
 
-    /// <summary>
-    /// A result from a function call which may represent a Value or a Trap
-    /// </summary>
-    public readonly struct Result
+    internal readonly struct ActionResultBuilder
+        : IActionResultBuilder<ActionResult>
     {
-        /// <summary>
-        /// Indicates what type of result this contains
-        /// </summary>
-        public ResultType Type { get; }
-
-        private readonly TrapCode _trap;
-
-        internal Result(IntPtr trap)
+        public ActionResult Create()
         {
-            Type = ResultType.Trap;
-            _trap = TrapException.GetTrapCode(trap);
-            TrapException.Native.wasm_trap_delete(trap);
+            return new ActionResult();
         }
 
-        /// <summary>
-        /// Get the trap associated with this result
-        /// </summary>
-        /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Trap</exception>
-        public TrapCode TrapCode
+        public ActionResult Create(TrapAccessor accessor)
         {
-            get
-            {
-                if (Type != ResultType.Trap)
-                {
-                    throw new InvalidOperationException($"Cannot get 'Trap' from '{Type}' type result");
-                }
-
-                return _trap;
-            }
+            return new ActionResult(accessor.GetException());
         }
     }
 
     /// <summary>
-    /// A result from a function call which may represent a Value or a Trap. If a trap happens the full backtrace is captured.
+    /// Indicates that the type implementing this interface is a "Result" type for actions (i.e. functions without a return value).
+    /// This means that the function WASM call will use the TBuilder type to create an instance of the TResult type and return that.
+    /// This can be used by advanced users to extract the necessary information from a trap result.
+    /// </summary>
+    /// <typeparam name="TResult">Type of this result type.</typeparam>
+    /// <typeparam name="TBuilder">Type of the builder used to construct TResult</typeparam>
+    public interface IActionResult<TResult, TBuilder>
+        where TResult : struct, IActionResult<TResult, TBuilder>
+        where TBuilder : struct, IActionResultBuilder<TResult>
+    {
+    }
+
+    /// <summary>
+    /// A factory which constructs instances of result types which do not contain a return value.
+    /// </summary>
+    /// <typeparam name="TResult">Type being constructed</typeparam>
+    public interface IActionResultBuilder<out TResult>
+        where TResult : struct
+    {
+        /// <summary>
+        /// Create an new instance indicating a successful call.
+        /// </summary>
+        /// <returns>A new TResult instance representing a successful function call</returns>
+        TResult Create();
+
+        /// <summary>
+        /// Create a new instance indicating a trap result.
+        /// </summary>
+        /// <param name="accessor"></param>
+        /// <returns>A new TResult instance representing a trap result</returns>
+        TResult Create(TrapAccessor accessor);
+    }
+
+
+    /// <summary>
+    /// A result from a function call which may represent a Value or a Trap
     /// </summary>
     /// <typeparam name="T">Type of the return value contained in this result</typeparam>
-    public readonly struct ResultWithBacktrace<T>
+    public readonly struct FunctionResult<T>
+        : IFunctionResult<FunctionResult<T>, T, FunctionResultBuilder<T>>
     {
         /// <summary>
         /// Indicates what type of result this contains
@@ -105,18 +120,18 @@ namespace Wasmtime
         private readonly T? _value;
         private readonly TrapException? _trap;
 
-        internal ResultWithBacktrace(T value)
+        internal FunctionResult(T value)
         {
             Type = ResultType.Ok;
             _value = value;
             _trap = null;
         }
 
-        internal ResultWithBacktrace(IntPtr trap)
+        internal FunctionResult(TrapException trap)
         {
             Type = ResultType.Trap;
             _value = default;
-            _trap = TrapException.FromOwnedTrap(trap);
+            _trap = trap;
         }
 
         /// <summary>
@@ -126,7 +141,7 @@ namespace Wasmtime
         /// <returns></returns>
         /// <exception cref="TrapException">Thrown if Type == Trap</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if Type property contains an unknown value</exception>
-        public static explicit operator T?(ResultWithBacktrace<T> value)
+        public static explicit operator T?(FunctionResult<T> value)
         {
             switch (value.Type)
             {
@@ -176,112 +191,104 @@ namespace Wasmtime
         }
     }
 
-    /// <summary>
-    /// A result from a function call which may represent a Value or a Trap
-    /// </summary>
-    /// <typeparam name="T">Type of the return value contained in this result</typeparam>
-    public readonly struct Result<T>
+    internal readonly struct FunctionResultBuilder<TOk>
+        : IFunctionResultBuilder<FunctionResult<TOk>, TOk>
     {
-        /// <summary>
-        /// Indicates what type of result this contains
-        /// </summary>
-        public ResultType Type { get; }
-
-        private readonly T? _value;
-        private readonly TrapCode _trap;
-
-        internal Result(T value)
+        public FunctionResult<TOk> Create(TOk value)
         {
-            Type = ResultType.Ok;
-
-            _value = value;
-            _trap = default;
+            return new FunctionResult<TOk>(value);
         }
 
-        internal Result(IntPtr trap)
+        public FunctionResult<TOk> Create(TrapAccessor accessor)
         {
-            Type = ResultType.Trap;
-
-            _value = default;
-
-            _trap = TrapException.GetTrapCode(trap);
-            TrapException.Native.wasm_trap_delete(trap);
-
-        }
-
-        /// <summary>
-        /// Convert this result into a value, throw if it is a Trap
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns>The value contained within this result if Type == ResultType.Ok</returns>
-        /// <exception cref="TrapException">Thrown if Type == Trap</exception>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown if Type property contains an unknoown value</exception>
-        public static explicit operator T?(Result<T> value)
-        {
-            switch (value.Type)
-            {
-                case ResultType.Ok:
-                    return value._value;
-
-                case ResultType.Trap:
-                    throw new TrapException($"{value._trap} trap", null, value._trap);
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(value), $"Unknown Result Type property value '{value.Type}'");
-            }
-        }
-
-        /// <summary>
-        /// Get the value associated with this result
-        /// </summary>
-        /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Value</exception>
-        public T? Value
-        {
-            get
-            {
-                if (Type != ResultType.Ok)
-                {
-                    throw new InvalidOperationException($"Cannot get 'Value' from '{Type}' type result");
-                }
-
-                return _value;
-            }
-        }
-
-        /// <summary>
-        /// Get the trap associated with this result
-        /// </summary>
-        /// <exception cref="InvalidOperationException">Thrown if this Type != Types.Trap</exception>
-        public TrapCode TrapCode
-        {
-            get
-            {
-                if (Type != ResultType.Trap)
-                {
-                    throw new InvalidOperationException($"Cannot get 'Trap' from '{Type}' type result");
-                }
-
-                return _trap;
-            }
+            return new FunctionResult<TOk>(accessor.GetException());
         }
     }
 
+    /// <summary>
+    /// Indicates that the type implementing this interface is a "Result" type for function.
+    /// This means that the function WASM call will use the TBuilder type to create an instance of the TSelf type and return that.
+    /// This can be used by advanced users to extract the necessary information from a trap result.
+    /// </summary>
+    /// <typeparam name="TResult">Type of this result type.</typeparam>
+    /// <typeparam name="TBuilder">Type of the builder used to construct TResult</typeparam>
+    /// <typeparam name="TOk">Type contained in the result in the success case</typeparam>
+    public interface IFunctionResult<TResult, TOk, TBuilder>
+        where TResult : struct, IFunctionResult<TResult, TOk, TBuilder>
+        where TBuilder : struct, IFunctionResultBuilder<TResult, TOk>
+    {
+    }
+
+    /// <summary>
+    /// A factory which constructs instances of result types which contain a return value.
+    /// </summary>
+    /// <typeparam name="TResult">Type being constructed</typeparam>
+    /// <typeparam name="TOk">Type contained in the result in the success case</typeparam>
+    public interface IFunctionResultBuilder<out TResult, in TOk>
+        where TResult : struct
+    {
+        /// <summary>
+        /// Create an new instance indicating a successful call.
+        /// </summary>
+        /// <param name="value">The return value of the function call</param>
+        /// <returns>A new TResult instance representing a successful function call</returns>
+        TResult Create(TOk value);
+
+        /// <summary>
+        /// Create a new instance indicating a trap result.
+        /// </summary>
+        /// <param name="accessor"></param>
+        /// <returns>A new TResult instance representing a trap result</returns>
+        TResult Create(TrapAccessor accessor);
+    }
+
+
     internal static class TypeExtensions
     {
-        internal static bool IsResult(this Type type)
+        public static Type? TryGetResultInterface(this Type type)
         {
-            if (type == typeof(Result) || type == typeof(ResultWithBacktrace))
+            foreach (var @interface in type.GetInterfaces())
             {
-                return true;
+                if (!@interface.IsGenericType)
+                {
+                    continue;
+                }
+
+                var gtd = @interface.GetGenericTypeDefinition();
+                if (gtd == typeof(IActionResult<,>) || gtd == typeof(IFunctionResult<,,>))
+                {
+                    return @interface;
+                }
             }
 
-            if (!type.IsGenericType)
+            return null;
+        }
+
+        public static bool IsResultType(this Type type)
+        {
+            return type.TryGetResultInterface() != null;
+        }
+
+        public static Type? GetResultInnerType(this Type type)
+        {
+            var result = type.TryGetResultInterface();
+            if (result == null)
             {
-                return false;
+                throw new ArgumentException("Type must implement IActionResult<,> or IFunctionResult<,,>", nameof(type));
             }
 
-            var gtd = type.GetGenericTypeDefinition();
-            return typeof(Result<>) == gtd || typeof(ResultWithBacktrace<>) == gtd;
+            if (result.GetGenericTypeDefinition() == typeof(IActionResult<,>))
+            {
+                return null;
+            }
+
+            if (result.GetGenericTypeDefinition() == typeof(IFunctionResult<,,>))
+            {
+                var types = result.GetGenericArguments();
+                return types[1];
+            }
+
+            throw new ArgumentException("Type is not a recognised Result type");
         }
     }
 }

--- a/src/Result.cs
+++ b/src/Result.cs
@@ -15,7 +15,7 @@ namespace Wasmtime
         /// <summary>
         /// Result contains a trap
         /// </summary>
-        Trap = 2,
+        Trap = 1,
     }
 
     /// <summary>
@@ -45,7 +45,10 @@ namespace Wasmtime
             get
             {
                 if (Type != ResultType.Trap)
+                {
                     throw new InvalidOperationException($"Cannot get 'Trap' from '{Type}' type result");
+                }
+
                 return _trap!;
             }
         }
@@ -80,7 +83,10 @@ namespace Wasmtime
             get
             {
                 if (Type != ResultType.Trap)
+                {
                     throw new InvalidOperationException($"Cannot get 'Trap' from '{Type}' type result");
+                }
+
                 return _trap;
             }
         }
@@ -89,7 +95,7 @@ namespace Wasmtime
     /// <summary>
     /// A result from a function call which may represent a Value or a Trap. If a trap happens the full backtrace is captured.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">Type of the return value contained in this result</typeparam>
     public readonly struct ResultWithBacktrace<T>
     {
         /// <summary>
@@ -145,7 +151,10 @@ namespace Wasmtime
             get
             {
                 if (Type != ResultType.Ok)
+                {
                     throw new InvalidOperationException($"Cannot get 'Value' from '{Type}' type result");
+                }
+
                 return _value;
             }
         }
@@ -159,7 +168,10 @@ namespace Wasmtime
             get
             {
                 if (Type != ResultType.Trap)
+                {
                     throw new InvalidOperationException($"Cannot get 'Trap' from '{Type}' type result");
+                }
+
                 return _trap!;
             }
         }
@@ -168,7 +180,7 @@ namespace Wasmtime
     /// <summary>
     /// A result from a function call which may represent a Value or a Trap
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">Type of the return value contained in this result</typeparam>
     public readonly struct Result<T>
     {
         /// <summary>
@@ -202,7 +214,7 @@ namespace Wasmtime
         /// Convert this result into a value, throw if it is a Trap
         /// </summary>
         /// <param name="value"></param>
-        /// <returns></returns>
+        /// <returns>The value contained within this result if Type == ResultType.Ok</returns>
         /// <exception cref="TrapException">Thrown if Type == Trap</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if Type property contains an unknoown value</exception>
         public static explicit operator T?(Result<T> value)
@@ -229,7 +241,10 @@ namespace Wasmtime
             get
             {
                 if (Type != ResultType.Ok)
+                {
                     throw new InvalidOperationException($"Cannot get 'Value' from '{Type}' type result");
+                }
+
                 return _value;
             }
         }
@@ -243,7 +258,10 @@ namespace Wasmtime
             get
             {
                 if (Type != ResultType.Trap)
+                {
                     throw new InvalidOperationException($"Cannot get 'Trap' from '{Type}' type result");
+                }
+
                 return _trap;
             }
         }

--- a/tests/FuelConsumptionTests.cs
+++ b/tests/FuelConsumptionTests.cs
@@ -96,15 +96,15 @@ namespace Wasmtime.Tests
         public void ItConsumesFuelWhenCallingImportMethods()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var free = instance.GetFunction("free");
+            var free = instance.GetFunction("free").WrapFunc<ActionResult>();
 
             Store.AddFuel(1000UL);
 
-            free.Invoke();
+            free.Invoke().Type.Should().Be(ResultType.Ok);
             var consumed = Store.GetConsumedFuel();
             consumed.Should().Be(2UL);
 
-            free.Invoke();
+            free.Invoke().Type.Should().Be(ResultType.Ok);
             consumed = Store.GetConsumedFuel();
             consumed.Should().Be(4UL);
         }

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -165,10 +165,10 @@ namespace Wasmtime.Tests
         public void ItEchoesFloat32()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<float, float>("$echo_f32");
+            var echo = instance.GetFunction<float, FunctionResult<float>>("$echo_f32");
             echo.Should().NotBeNull();
 
-            var result = echo.Invoke(42);
+            var result = (float)echo.Invoke(42);
             result.Should().Be(42);
         }
 
@@ -176,10 +176,10 @@ namespace Wasmtime.Tests
         public void ItEchoesFloat64()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var echo = instance.GetFunction<double, double>("$echo_f64");
+            var echo = instance.GetFunction<double, FunctionResult<double>>("$echo_f64");
             echo.Should().NotBeNull();
 
-            var result = echo.Invoke(42);
+            var result = (double)echo.Invoke(42);
             result.Should().Be(42);
         }
 

--- a/tests/Modules/Trap.wat
+++ b/tests/Modules/Trap.wat
@@ -1,4 +1,6 @@
 (module
+  (export "ok" (func $ok))
+  (export "ok_value" (func $ok_value))
   (export "run" (func $run))
   (export "run_div_zero" (func $run_div_zero))
   (export "run_div_zero_with_result" (func $run_div_zero_with_result))
@@ -25,5 +27,10 @@
   (func $run_div_zero
     (call $run_div_zero_with_result)
     (drop)
+  )
+
+  (func $ok)
+  (func $ok_value (result i32)
+    (i32.const 1)
   )
 )

--- a/tests/Modules/Trap.wat
+++ b/tests/Modules/Trap.wat
@@ -1,7 +1,7 @@
 (module
   (export "run" (func $run))
-  (export "run_stack_overflow" (func $run_stack_overflow))
-  (export "run_stack_overflow_with_result" (func $run_stack_overflow_with_result))
+  (export "run_div_zero" (func $run_div_zero))
+  (export "run_div_zero_with_result" (func $run_div_zero_with_result))
 
   (func $run
     (call $first)
@@ -16,11 +16,14 @@
     unreachable
   )
 
-  (func $run_stack_overflow_with_result (result i32)
-    (call $run_stack_overflow_with_result)
+  (func $run_div_zero_with_result (result i32)
+    (i32.const 1)
+    (i32.const 0)
+    (i32.div_s)
   )
 
-  (func $run_stack_overflow
-    (call $run_stack_overflow)
+  (func $run_div_zero
+    (call $run_div_zero_with_result)
+    (drop)
   )
 )

--- a/tests/Modules/Trap.wat
+++ b/tests/Modules/Trap.wat
@@ -1,5 +1,8 @@
 (module
   (export "run" (func $run))
+  (export "run_stack_overflow" (func $run_stack_overflow))
+  (export "run_stack_overflow_with_result" (func $run_stack_overflow_with_result))
+
   (func $run
     (call $first)
   )
@@ -11,5 +14,13 @@
   )
   (func $third
     unreachable
+  )
+
+  (func $run_stack_overflow_with_result (result i32)
+    (call $run_stack_overflow_with_result)
+  )
+
+  (func $run_stack_overflow
+    (call $run_stack_overflow)
   )
 )

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -68,7 +68,9 @@ namespace Wasmtime.Tests
 
             result.Type.Should().Be(ResultType.Trap);
             result.Trap.Type.Should().Be(TrapCode.IntegerDivisionByZero);
-            result.Trap.Frames.Count.Should().BeGreaterThan(0);
+            result.Trap.Frames.Count.Should().Be(2);
+            result.Trap.Frames[0].FunctionName.Should().Be("run_div_zero_with_result");
+            result.Trap.Frames[1].FunctionName.Should().Be("run_div_zero");
         }
 
         [Fact]
@@ -93,7 +95,8 @@ namespace Wasmtime.Tests
 
             result.Type.Should().Be(ResultType.Trap);
             result.Trap.Type.Should().Be(TrapCode.IntegerDivisionByZero);
-            result.Trap.Frames.Count.Should().BeGreaterThan(0);
+            result.Trap.Frames.Count.Should().Be(1);
+            result.Trap.Frames[0].FunctionName.Should().Be("run_div_zero_with_result");
         }
 
         public void Dispose()

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -51,11 +51,11 @@ namespace Wasmtime.Tests
         {
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var run = instance.GetFunction<Result>("run_stack_overflow");
+            var run = instance.GetFunction<Result>("run_div_zero");
             var result = run();
 
             result.Type.Should().Be(ResultType.Trap);
-            result.Trap.Should().Be(TrapCode.StackOverflow);
+            result.Trap.Should().Be(TrapCode.IntegerDivisionByZero);
         }
 
         [Fact]
@@ -63,11 +63,11 @@ namespace Wasmtime.Tests
         {
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var run = instance.GetFunction<ResultWithBacktrace>("run_stack_overflow");
+            var run = instance.GetFunction<ResultWithBacktrace>("run_div_zero");
             var result = run();
 
             result.Type.Should().Be(ResultType.Trap);
-            result.Trap.Type.Should().Be(TrapCode.StackOverflow);
+            result.Trap.Type.Should().Be(TrapCode.IntegerDivisionByZero);
             result.Trap.Frames.Count.Should().BeGreaterThan(0);
         }
 
@@ -76,11 +76,11 @@ namespace Wasmtime.Tests
         {
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var run = instance.GetFunction<Result<int>>("run_stack_overflow_with_result");
+            var run = instance.GetFunction<Result<int>>("run_div_zero_with_result");
             var result = run();
 
             result.Type.Should().Be(ResultType.Trap);
-            result.Trap.Should().Be(TrapCode.StackOverflow);
+            result.Trap.Should().Be(TrapCode.IntegerDivisionByZero);
         }
 
         [Fact]
@@ -88,11 +88,11 @@ namespace Wasmtime.Tests
         {
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var run = instance.GetFunction<ResultWithBacktrace<int>>("run_stack_overflow_with_result");
+            var run = instance.GetFunction<ResultWithBacktrace<int>>("run_div_zero_with_result");
             var result = run();
 
             result.Type.Should().Be(ResultType.Trap);
-            result.Trap.Type.Should().Be(TrapCode.StackOverflow);
+            result.Trap.Type.Should().Be(TrapCode.IntegerDivisionByZero);
             result.Trap.Frames.Count.Should().BeGreaterThan(0);
         }
 

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -46,6 +46,56 @@ namespace Wasmtime.Tests
                 .WithMessage("wasm trap: wasm `unreachable` instruction executed*");
         }
 
+        [Fact]
+        public void ItReturnsATrapCodeResult()
+        {
+
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var run = instance.GetFunction<Result>("run_stack_overflow");
+            var result = run();
+
+            result.Type.Should().Be(ResultType.Trap);
+            result.Trap.Should().Be(TrapCode.StackOverflow);
+        }
+
+        [Fact]
+        public void ItReturnsATrapCodeAndBacktraceResult()
+        {
+
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var run = instance.GetFunction<ResultWithBacktrace>("run_stack_overflow");
+            var result = run();
+
+            result.Type.Should().Be(ResultType.Trap);
+            result.Trap.Type.Should().Be(TrapCode.StackOverflow);
+            result.Trap.Frames.Count.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void ItReturnsATrapCodeGenericResult()
+        {
+
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var run = instance.GetFunction<Result<int>>("run_stack_overflow_with_result");
+            var result = run();
+
+            result.Type.Should().Be(ResultType.Trap);
+            result.Trap.Should().Be(TrapCode.StackOverflow);
+        }
+
+        [Fact]
+        public void ItReturnsATrapCodeAndBacktraceGenericResult()
+        {
+
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var run = instance.GetFunction<ResultWithBacktrace<int>>("run_stack_overflow_with_result");
+            var result = run();
+
+            result.Type.Should().Be(ResultType.Trap);
+            result.Trap.Type.Should().Be(TrapCode.StackOverflow);
+            result.Trap.Frames.Count.Should().BeGreaterThan(0);
+        }
+
         public void Dispose()
         {
             Store.Dispose();

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -55,7 +55,7 @@ namespace Wasmtime.Tests
             var result = run();
 
             result.Type.Should().Be(ResultType.Trap);
-            result.Trap.Should().Be(TrapCode.IntegerDivisionByZero);
+            result.TrapCode.Should().Be(TrapCode.IntegerDivisionByZero);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace Wasmtime.Tests
             var result = run();
 
             result.Type.Should().Be(ResultType.Trap);
-            result.Trap.Should().Be(TrapCode.IntegerDivisionByZero);
+            result.TrapCode.Should().Be(TrapCode.IntegerDivisionByZero);
         }
 
         [Fact]


### PR DESCRIPTION
Created a new system to allow users of wasmtime-dotnet to create fully custom result types. This means that the library can ship a basic result type that fits 99% of usecases (just containing a `TrapException` object) and advanced users can build whatever they need for weirder usecases (e.g. making this work in Unity Jobs+Burst, which was my original goal for all this).

A custom result type implements one of two interfaces:
 - `IFunctionResult<,,>`, this represents a return value from a function (approximately equivalent to `Result<Whatever, Trap>` in Rust)
 - `IActionResult<,>`, this represents a return value from an action (approximately like returning `Option<Trap>` instead of `Result<(), Trap>` in Rust)

Unfortunately since `static abstract` methods aren't available yet (they're available soon, but would require a dependency on .NET7 afaik) the construction of these custom types is a little more complex than I'd like. The result interfaces contain a parameter refencing a "builder" interface which acts as a factory for the result type. You can see this in action in the `TrapTests` where I have implemented a very simple custom result:

```csharp
public struct MyCustomResult<T>
    : IFunctionResult<MyCustomResult<T>, T, MyCustomResult<T>.MyCustomResultBuilder>
{
    public int TrapStackDepth;

    public struct MyCustomResultBuilder
        : IFunctionResultBuilder<MyCustomResult<T>, T>
    {
        public MyCustomResult<T> Create(T value)
        {
            return new MyCustomResult<T> { TrapStackDepth = -1 };
        }

        public MyCustomResult<T> Create(TrapAccessor accessor)
        {
            return new MyCustomResult<T> { TrapStackDepth = accessor.GetFrames().Count };
        }
    }
}
```