### PR TITLE
Use code generation with an DynamicMethod (System.Reflection.Emit)

### DIFF
--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -759,7 +759,7 @@ namespace Wasmtime
             using var funcType = Function.GetFunctionType(callback.GetType(), hasReturn, parameterKinds, resultKinds, out var hasCaller, out var returnsTuple);
 
             // Generate code for invoking the callback without reflection.
-            var generatedDelegate = Function.GenerateInvokeCallbackDelegate(callback, hasCaller, returnsTuple);
+            var generatedDelegate = Function.GenerateInvokeCallbackDelegate(callback, hasCaller, returnsTuple, parameterKinds, resultKinds);
 
             unsafe
             {

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -195,7 +195,7 @@ namespace Wasmtime
         /// Constructs a new store.
         /// </summary>
         /// <param name="engine">The engine to use for the store.</param>
-        public Store(Engine engine)
+        public unsafe Store(Engine engine)
         {
             if (engine is null)
             {
@@ -289,10 +289,8 @@ namespace Wasmtime
 
         private static class Native
         {
-            public delegate void Finalizer(IntPtr data);
-
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_store_new(Engine.Handle engine, IntPtr data, Finalizer? finalizer);
+            public static extern unsafe IntPtr wasmtime_store_new(Engine.Handle engine, IntPtr data, delegate* unmanaged<IntPtr, void> finalizer);
 
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasmtime_store_context(Handle store);

--- a/tests/ExternRefTests.cs
+++ b/tests/ExternRefTests.cs
@@ -114,7 +114,7 @@ namespace Wasmtime.Tests
             action
                 .Should()
                 .Throw<Wasmtime.TrapException>()
-                .WithMessage("Object of type 'System.Int32' cannot be converted to type 'System.String'*");
+                .WithMessage("Unable to cast object of type 'System.Int32' to type 'System.String'*");
         }
 
         public void Dispose()

--- a/tests/ExternRefTests.cs
+++ b/tests/ExternRefTests.cs
@@ -124,10 +124,13 @@ namespace Wasmtime.Tests
 
             Action action = () => inout.Invoke(ValueBox.AsBox((object)5));
 
+            // The first message occurs when using DynamicMethod to call the callback,
+            // the second one occurs when using reflection.
             action
                 .Should()
                 .Throw<Wasmtime.TrapException>()
-                .WithMessage("Unable to cast object of type 'System.Int32' to type 'System.String'*");
+                .Where(e => e.Message.StartsWith("Unable to cast object of type 'System.Int32' to type 'System.String'") ||
+                    e.Message.StartsWith("Object of type 'System.Int32' cannot be converted to type 'System.String'"));
         }
 
         public void Dispose()

--- a/tests/ExternRefTests.cs
+++ b/tests/ExternRefTests.cs
@@ -53,6 +53,19 @@ namespace Wasmtime.Tests
             (nullref.Invoke()).Should().BeNull();
         }
 
+        [Fact]
+        public void ItReturnsBoxedValueTupleAsExternRef()
+        {
+            // Test for issue #158
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+
+            var inout = instance.GetFunction<object, object>("inout");
+            inout.Should().NotBeNull();
+
+            var input = (object)(1, 2, 3);
+            inout(input).Should().BeSameAs(input);
+        }
+
         unsafe class Value
         {
             internal Value(int* counter)

--- a/tests/LinkerFunctionsTests.cs
+++ b/tests/LinkerFunctionsTests.cs
@@ -30,6 +30,36 @@ namespace Wasmtime.Tests
             {
                 caller.GetMemory("mem").ReadString(address, length).Should().Be("Hello World");
             });
+
+            Linker.Define("env", "return_i32", Function.FromCallback(Store, GetBoundFuncIntDelegate()));
+
+            Linker.Define("env", "return_15_values", Function.FromCallback(Store, () =>
+            {
+                return (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+            }));
+
+            Linker.Define("env", "accept_15_values", Function.FromCallback(Store,
+                (int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9, int i10, int i11, int i12, int i13, int i14, int i15) =>
+                {
+                    (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15)
+                        .Should().Be((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
+                }));
+
+            Func<int> GetBoundFuncIntDelegate()
+            {
+                // Get a delegate that is bound over an argument.
+                // See #159
+                var getLengthDelegate = GetLength;
+                var getLengthMethod = getLengthDelegate.Method;
+
+                string str = "abc";
+                return (Func<int>)Delegate.CreateDelegate(typeof(Func<int>), str, getLengthMethod);
+
+                int GetLength(string s)
+                {
+                    return s.Length;
+                }
+            }
         }
 
         private LinkerFunctionsFixture Fixture { get; }
@@ -40,12 +70,15 @@ namespace Wasmtime.Tests
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var add = instance.GetFunction("add");
             var swap = instance.GetFunction("swap");
-            var check = instance.GetFunction("check_string");
+            var check = instance.GetFunction("check_string"); ;
+            var getInt32 = instance.GetFunction<int>("return_i32");
 
             int x = (int)add.Invoke(40, 2);
             x.Should().Be(42);
             x = (int)add.Invoke(22, 5);
             x.Should().Be(27);
+            x = getInt32.Invoke();
+            x.Should().Be(3);
 
             object[] results = (object[])swap.Invoke(10, 100);
             results.Should().Equal(new object[] { 100, 10 });

--- a/tests/Modules/Functions.wat
+++ b/tests/Modules/Functions.wat
@@ -3,11 +3,16 @@
  (import "env" "swap" (func $env.swap (param i32 i32) (result i32 i32)))
  (import "env" "do_throw" (func $env.do_throw))
  (import "env" "check_string" (func $env.check_string (param i32 i32)))
+ (import "env" "return_i32" (func $env.return_i32 (result i32)))
+ (import "env" "return_15_values" (func $env.return_15_values (result i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)))
+ (import "env" "accept_15_values" (func $env.accept_15_values (param i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32)))
  (memory (export "mem") 1)
  (export "add" (func $add))
  (export "swap" (func $swap))
  (export "do_throw" (func $do_throw))
  (export "check_string" (func $check_string))
+ (export "return_i32" (func $env.return_i32))
+ (export "get_and_pass_15_values" (func $get_and_pass_15_values))
  (func $add (param i32 i32) (result i32)
   (call $env.add (local.get 0) (local.get 1))
  )
@@ -19,6 +24,10 @@
  )
  (func $check_string
   (call $env.check_string (i32.const 0) (i32.const 11))
+ )
+ (func $get_and_pass_15_values
+	call $env.return_15_values
+	call $env.accept_15_values
  )
  (data (i32.const 0) "Hello World")
 


### PR DESCRIPTION
Hi, this is a PR to use [`DynamicMethod`](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.emit.dynamicmethod?view=net-6.0) (`System.Reflection.Emit`) for generating code to call callbacks defined with `Function.FromCallback()` and `Linker.DefineFunction()`, instead of using reflection. This improves performance (although not as much as I imagined), and avoids a number of heap allocations (e.g. allocating the arguments array, and boxing the arguments and return values), thereby contributing to #113.

Additionally, I fixed the handling of nested ValueTuples, which previously only worked one level. For example, returning a `ValueTuple<..., ValueTuple<..., ValueTuple<int>>>` (= 15 values) now should work correctly. Additionally, issues #158 and #159 should be fixed with this change.
I also changed the static `Function.Finalizer` and `Value.Finalizer` delegates to a method with an [`UnmanagedCallersOnlyAttribute`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.unmanagedcallersonlyattribute) and use it as [function pointer](https://devblogs.microsoft.com/dotnet/improvements-in-native-code-interop-in-net-5-0/) (`delegate* unmanaged<IntPtr, void>`), since it is a static method, which can also improve performance.

**Edit:** I updated the PR so that when the current .NET runtime/platform interprets or doesn't support dynamic code (e.g. on Unity when using the IL2CPP backend, where it might be possible to use precompiled wasm modules that don't require a JIT), reflection is still used as a fallback to call the callback.


For example, when using a `Func<Caller, int, long, string, ValueTuple<int, float, double, long, object, Function, int, ValueTuple<int>>>`, the generated code will be equivalent to the following:

```cs
static unsafe void InvokeCallback(Delegate callback, Caller caller, Value* args, int nargs, Value* results, int nresults)
{
    var dele = (Func<Caller, int, long, string, ValueTuple<int, float, double, long, object, Function, int, ValueTuple<int>>>)callback;

    ValueTuple<int, float, double, long, object, Function, int, ValueTuple<int>> result = dele(
        caller,
        Int32ValueBoxConverter.Instance.Unbox(caller, args[0].ToValueBox()),
        Int64ValueBoxConverter.Instance.Unbox(caller, args[1].ToValueBox()),
        GenericValueBoxConverter<string>.Instance.Unbox(caller, args[2].ToValueBox()));

    results[0] = Value.FromValueBox(Int32ValueBoxConverter.Instance.Box(result.Item1));
    results[1] = Value.FromValueBox(Float32ValueBoxConverter.Instance.Box(result.Item2));
    results[2] = Value.FromValueBox(Float64ValueBoxConverter.Instance.Box(result.Item3));
    results[3] = Value.FromValueBox(Int64ValueBoxConverter.Instance.Box(result.Item4));
    results[4] = Value.FromValueBox(GenericValueBoxConverter<object>.Box(result.Item5));
    results[5] = Value.FromValueBox(FuncRefValueBoxConverter.Instance.Box(result.Item6));
    results[6] = Value.FromValueBox(Int32ValueBoxConverter.Instance.Box(result.Item7));
    results[7] = Value.FromValueBox(Int32ValueBoxConverter.Instance.Box(result.Rest.Item1));
}
```

The most performance boost occurs when defining a function with a single parameter. When testing with the following code with .NET 7.0.0-rc.1 on Windows 10 Version 21H2 x64, using an `Action<int>`:
```cs
    using var config = new Config();
    config.WithOptimizationLevel(OptimizationLevel.Speed);

    using var engine = new Engine(config);
    using var module = Module.FromText(
        engine,
        "hello",
        @"
(module 
    (func $hello (import """" ""hello"") (param i32))
    (func (export ""run"")
        (local $0 i32)
        loop $for-loop|0
            local.get $0
            i32.const 2000000
            i32.lt_s
            if
                local.get $0
                call $hello

                local.get $0
                i32.const 1
                i32.add
                local.set $0
                br $for-loop|0
            end
        end
    )
)
");

    using var linker = new Linker(engine);
    using var store = new Store(engine);

    int calls = 0;
    linker.Define(
        "",
        "hello",
        Function.FromCallback(store, (int x) =>
        {
            calls++;
        })
    );

    var instance = linker.Instantiate(store, module);
    var run = instance.GetAction("run")!;

    var sw = new Stopwatch();
    for (int i = 0; i < 5; i++)
    {
        sw.Restart();
        run();
        sw.Stop();

        Console.WriteLine("Elapsed: " + sw.Elapsed);
    }
```

Before the change, the times are listed as follows (when compiling for `Release`):
```
Elapsed: 00:00:00.3099829
Elapsed: 00:00:00.4299516
Elapsed: 00:00:00.4231544
Elapsed: 00:00:00.4376052
Elapsed: 00:00:00.4250763
```

After the change:
```
Elapsed: 00:00:00.1626791
Elapsed: 00:00:00.1181175
Elapsed: 00:00:00.1178859
Elapsed: 00:00:00.1169129
Elapsed: 00:00:00.1146859
```

However, when using more than one arguments, the time with reflection suddenly decreases, and the performance gain is much less. For example, using a `Action<int, float, long>`:
```cs
    using var config = new Config();
    config.WithOptimizationLevel(OptimizationLevel.Speed);

    using var engine = new Engine(config);
    using var module = Module.FromText(
        engine,
        "hello",
        @"
(module 
    (func $hello (import """" ""hello"") (param i32 f32 i64))
    (func (export ""run"")
        (local $0 i32)
        loop $for-loop|0
            local.get $0
            i32.const 2000000
            i32.lt_s
            if
                local.get $0
                f32.const 123.456
                i64.const 1234567890
                call $hello

                local.get $0
                i32.const 1
                i32.add
                local.set $0
                br $for-loop|0
            end
        end
    )
)
");

    using var linker = new Linker(engine);
    using var store = new Store(engine);

    int calls = 0;
    linker.Define(
        "",
        "hello",
        Function.FromCallback(store, (int x, float y, long z) =>
        {
            calls++;
        })
    );

    var instance = linker.Instantiate(store, module);
    var run = instance.GetAction("run")!;

    var sw = new Stopwatch();
    for (int i = 0; i < 5; i++)
    {
        sw.Restart();
        run();
        sw.Stop();

        Console.WriteLine("Elapsed: " + sw.Elapsed);
    }
```

Before the change:
```
Elapsed: 00:00:00.3110580
Elapsed: 00:00:00.2320351
Elapsed: 00:00:00.2336036
Elapsed: 00:00:00.2323470
Elapsed: 00:00:00.2347170
```

After the change:
```
Elapsed: 00:00:00.2313183
Elapsed: 00:00:00.2069259
Elapsed: 00:00:00.2080663
Elapsed: 00:00:00.2107904
Elapsed: 00:00:00.2098015
```

Testing with a `Func<int, float, long, ValueTuple<int, int, long>>`:
```cs
    using var config = new Config();
    config.WithOptimizationLevel(OptimizationLevel.Speed);

    using var engine = new Engine(config);
    using var module = Module.FromText(
        engine,
        "hello",
        @"
(module 
    (func $hello (import """" ""hello"") (param i32 f32 i64) (result i32 i32 i64))
    (func (export ""run"")
        (local $0 i32)
        loop $for-loop|0
            local.get $0
            i32.const 2000000
            i32.lt_s
            if
                local.get $0
                f32.const 123.456
                i64.const 1234567890
                call $hello
                drop
                drop
                drop

                local.get $0
                i32.const 1
                i32.add
                local.set $0
                br $for-loop|0
            end
        end
    )
)
");

    using var linker = new Linker(engine);
    using var store = new Store(engine);

    int calls = 0;
    linker.Define(
        "",
        "hello",
        Function.FromCallback(store, (int x, float y, long z) =>
        {
            calls++;
            return (1, 2, 3L);
        })
    );

    var instance = linker.Instantiate(store, module);
    var run = instance.GetAction("run")!;

    var sw = new Stopwatch();
    for (int i = 0; i < 5; i++)
    {
        sw.Restart();
        run();
        sw.Stop();

        Console.WriteLine("Elapsed: " + sw.Elapsed);
    }
```

Before:
```
Elapsed: 00:00:00.6005550
Elapsed: 00:00:00.5286508
Elapsed: 00:00:00.5350325
Elapsed: 00:00:00.5246926
Elapsed: 00:00:00.5371668
```

After:
```
Elapsed: 00:00:00.4315517
Elapsed: 00:00:00.3945320
Elapsed: 00:00:00.3934935
Elapsed: 00:00:00.4064949
Elapsed: 00:00:00.3909994
```

Note: Currently the delegate types that can be used to define a callback are limited to `Action<...>` and `Func<...>`. I think this restriction could be lifted in the future, to allow delegates of any type. (This would require a change in `Function.GetFunctionType()`, to not iterate through the generic type arguments, but interate through the parameter types of the delegate's `Invoke` method.)

---

Another approach could be to use a source generator, as noted in the previous comments in `Function.InvokeCallback()`. I chose the `DynamicMethod` approach as it is agnositc to the consumer's language used (e.g. C#, F#, VB.NET etc), and also works if the assembly that defines the delegates has already been compiled (e.g. in a plugin system).

A difference is that with the `DynamicMethod` approach, code (IL, and then native code by the JIT when called) is generated when defining the methods; however I think that is negligible since because this usually happens when there is already another code generation (by `Wasmtime` itself).
However, the .NET runtime/platform must support compiling dynamic code. If dynamic code isn't supported, or is supported but would be interpreted (which would probably cause a performance slowdown), we need to fall back using reflection to call the callback.

What do you think?

Thanks!
