### PR TITLE
Add .NET Standard 2.1 (`netstandard2.1`) as target framework

### DIFF
--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>


### PR DESCRIPTION
Hi!

As noted by @martindevans in https://github.com/bytecodealliance/wasmtime-dotnet/pull/160#issuecomment-1273516711, Unity up to version 2022.2 currently supports .NET Standard 2.1 (`netstandard2.1`, released with .NET Core 3.1) as highest .NET target framework. See [.NET profile support](https://docs.unity3d.com/2022.2/Documentation/Manual/dotnetProfileSupport.html) in the Unity documentation.

While the `net6.0` library apparently could also be used in Unity, it would break as soon as any feature/type introduced in a newer .NET version was used. Therefore, I think it would be a good idea to also build for .NET Standard 2.1 for the time being in order to support Unity users. Note that `Wasmtime` already builds successfully for `netstandard2.1` without any code change (at least when using C# 10).

(The `net6.0` target can be kept to benefit from the newest analyzers and NRT annotations.)

What do you think?

Thanks!