### PR TITLE
Allow to access a `Memory` with more than 32767 pages

### DIFF
--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -221,42 +221,10 @@ namespace Wasmtime
         /// Note that WebAssembly always uses little endian as byte order. On platforms 
         /// that use big endian, you will need to convert numeric values accordingly.
         /// </remarks>
-        public T Read<T>(int address)
-            where T : unmanaged
-        {
-            return GetSpan<T>(address, 1)[0];
-        }
-
-        /// <summary>
-        /// Read a struct from memory.
-        /// </summary>
-        /// <typeparam name="T">Type of the struct to read. Ensure layout in C# is identical to layout in WASM.</typeparam>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <returns>Returns the struct read from memory.</returns>
-        /// <remarks>
-        /// Note that WebAssembly always uses little endian as byte order. On platforms 
-        /// that use big endian, you will need to convert numeric values accordingly.
-        /// </remarks>
         public T Read<T>(long address)
             where T : unmanaged
         {
             return GetSpan<T>(address, 1)[0];
-        }
-
-        /// <summary>
-        /// Write a struct to memory.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <param name="value">The struct to write.</param>
-        /// <remarks>
-        /// Note that WebAssembly always uses little endian as byte order. On platforms 
-        /// that use big endian, you will need to convert numeric values accordingly.
-        /// </remarks>
-        public void Write<T>(int address, T value)
-            where T : unmanaged
-        {
-            GetSpan<T>(address, 1)[0] = value;
         }
 
         /// <summary>
@@ -282,23 +250,6 @@ namespace Wasmtime
         /// <param name="length">The length of bytes to read.</param>
         /// <param name="encoding">The encoding to use when reading the string; if null, UTF-8 encoding is used.</param>
         /// <returns>Returns the string read from memory.</returns>
-        public string ReadString(int address, int length, Encoding? encoding = null)
-        {
-            if (encoding is null)
-            {
-                encoding = Encoding.UTF8;
-            }
-
-            return encoding.GetString(GetSpan(address, length));
-        }
-
-        /// <summary>
-        /// Reads a string from memory with the specified encoding.
-        /// </summary>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <param name="length">The length of bytes to read.</param>
-        /// <param name="encoding">The encoding to use when reading the string; if null, UTF-8 encoding is used.</param>
-        /// <returns>Returns the string read from memory.</returns>
         public string ReadString(long address, int length, Encoding? encoding = null)
         {
             if (encoding is null)
@@ -307,29 +258,6 @@ namespace Wasmtime
             }
 
             return encoding.GetString(GetSpan(address, length));
-        }
-
-        /// <summary>
-        /// Reads a null-terminated UTF-8 string from memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <returns>Returns the string read from memory.</returns>
-        public string ReadNullTerminatedString(int address)
-        {
-            if (address < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(address));
-            }
-
-            // We can only read a maximum of 2 GiB.
-            var slice = GetSpan(address, (int)Math.Min(int.MaxValue, GetLength() - address));
-            var terminator = slice.IndexOf((byte)0);
-            if (terminator == -1)
-            {
-                throw new InvalidOperationException("string is not null terminated");
-            }
-
-            return Encoding.UTF8.GetString(slice.Slice(0, terminator));
         }
 
         /// <summary>
@@ -362,27 +290,6 @@ namespace Wasmtime
         /// <param name="value">The string to write.</param>
         /// <param name="encoding">The encoding to use when writing the string; if null, UTF-8 encoding is used.</param>
         /// <return>Returns the number of bytes written.</return>
-        public int WriteString(int address, string value, Encoding? encoding = null)
-        {
-            if (address < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(address));
-            }
-
-            if (encoding is null)
-            {
-                encoding = Encoding.UTF8;
-            }
-            return encoding.GetBytes(value, GetSpan(address, (int)Math.Min(int.MaxValue, GetLength() - address)));
-        }
-
-        /// <summary>
-        /// Writes a string at the given address with the given encoding.
-        /// </summary>
-        /// <param name="address">The zero-based address to write to.</param>
-        /// <param name="value">The string to write.</param>
-        /// <param name="encoding">The encoding to use when writing the string; if null, UTF-8 encoding is used.</param>
-        /// <return>Returns the number of bytes written.</return>
         public int WriteString(long address, string value, Encoding? encoding = null)
         {
             if (address < 0)
@@ -402,29 +309,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="address">The zero-based address to read from.</param>
         /// <returns>Returns the byte read from memory.</returns>
-        public byte ReadByte(int address)
-        {
-            return GetSpan(address, sizeof(byte))[0];
-        }
-
-        /// <summary>
-        /// Reads a byte from memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <returns>Returns the byte read from memory.</returns>
         public byte ReadByte(long address)
         {
             return GetSpan(address, sizeof(byte))[0];
-        }
-
-        /// <summary>
-        /// Writes a byte to memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to write to.</param>
-        /// <param name="value">The byte to write.</param>
-        public void WriteByte(int address, byte value)
-        {
-            GetSpan(address, sizeof(byte))[0] = value;
         }
 
         /// <summary>
@@ -442,29 +329,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="address">The zero-based address to read from.</param>
         /// <returns>Returns the short read from memory.</returns>
-        public short ReadInt16(int address)
-        {
-            return BinaryPrimitives.ReadInt16LittleEndian(GetSpan(address, sizeof(short)));
-        }
-
-        /// <summary>
-        /// Reads a short from memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <returns>Returns the short read from memory.</returns>
         public short ReadInt16(long address)
         {
             return BinaryPrimitives.ReadInt16LittleEndian(GetSpan(address, sizeof(short)));
-        }
-
-        /// <summary>
-        /// Writes a short to memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to write to.</param>
-        /// <param name="value">The short to write.</param>
-        public void WriteInt16(int address, short value)
-        {
-            BinaryPrimitives.WriteInt16LittleEndian(GetSpan(address, sizeof(short)), value);
         }
 
         /// <summary>
@@ -482,29 +349,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="address">The zero-based address to read from.</param>
         /// <returns>Returns the int read from memory.</returns>
-        public int ReadInt32(int address)
-        {
-            return BinaryPrimitives.ReadInt32LittleEndian(GetSpan(address, sizeof(int)));
-        }
-
-        /// <summary>
-        /// Reads an int from memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <returns>Returns the int read from memory.</returns>
         public int ReadInt32(long address)
         {
             return BinaryPrimitives.ReadInt32LittleEndian(GetSpan(address, sizeof(int)));
-        }
-
-        /// <summary>
-        /// Writes an int to memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to write to.</param>
-        /// <param name="value">The int to write.</param>
-        public void WriteInt32(int address, int value)
-        {
-            BinaryPrimitives.WriteInt32LittleEndian(GetSpan(address, sizeof(int)), value);
         }
 
         /// <summary>
@@ -522,29 +369,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="address">The zero-based address to read from.</param>
         /// <returns>Returns the long read from memory.</returns>
-        public long ReadInt64(int address)
-        {
-            return BinaryPrimitives.ReadInt64LittleEndian(GetSpan(address, sizeof(long)));
-        }
-
-        /// <summary>
-        /// Reads a long from memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <returns>Returns the long read from memory.</returns>
         public long ReadInt64(long address)
         {
             return BinaryPrimitives.ReadInt64LittleEndian(GetSpan(address, sizeof(long)));
-        }
-
-        /// <summary>
-        /// Writes a long to memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to write to.</param>
-        /// <param name="value">The long to write.</param>
-        public void WriteInt64(int address, long value)
-        {
-            BinaryPrimitives.WriteInt64LittleEndian(GetSpan(address, sizeof(long)), value);
         }
 
         /// <summary>
@@ -562,20 +389,6 @@ namespace Wasmtime
         /// </summary>
         /// <param name="address">The zero-based address to read from.</param>
         /// <returns>Returns the IntPtr read from memory.</returns>
-        public IntPtr ReadIntPtr(int address)
-        {
-            if (IntPtr.Size == 4)
-            {
-                return (IntPtr)ReadInt32(address);
-            }
-            return (IntPtr)ReadInt64(address);
-        }
-
-        /// <summary>
-        /// Reads an IntPtr from memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <returns>Returns the IntPtr read from memory.</returns>
         public IntPtr ReadIntPtr(long address)
         {
             if (IntPtr.Size == 4)
@@ -583,23 +396,6 @@ namespace Wasmtime
                 return (IntPtr)ReadInt32(address);
             }
             return (IntPtr)ReadInt64(address);
-        }
-
-        /// <summary>
-        /// Writes an IntPtr to memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to write to.</param>
-        /// <param name="value">The IntPtr to write.</param>
-        public void WriteIntPtr(int address, IntPtr value)
-        {
-            if (IntPtr.Size == 4)
-            {
-                WriteInt32(address, (int)value);
-            }
-            else
-            {
-                WriteInt64(address, (long)value);
-            }
         }
 
         /// <summary>
@@ -624,29 +420,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="address">The zero-based address to read from.</param>
         /// <returns>Returns the single read from memory.</returns>
-        public float ReadSingle(int address)
-        {
-            return BitConverter.Int32BitsToSingle(ReadInt32(address));
-        }
-
-        /// <summary>
-        /// Reads a single from memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <returns>Returns the single read from memory.</returns>
         public float ReadSingle(long address)
         {
             return BitConverter.Int32BitsToSingle(ReadInt32(address));
-        }
-
-        /// <summary>
-        /// Writes a single to memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to write to.</param>
-        /// <param name="value">The single to write.</param>
-        public void WriteSingle(int address, float value)
-        {
-            WriteInt32(address, BitConverter.SingleToInt32Bits(value));
         }
 
         /// <summary>
@@ -664,29 +440,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="address">The zero-based address to read from.</param>
         /// <returns>Returns the double read from memory.</returns>
-        public double ReadDouble(int address)
-        {
-            return BitConverter.Int64BitsToDouble(ReadInt64(address));
-        }
-
-        /// <summary>
-        /// Reads a double from memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to read from.</param>
-        /// <returns>Returns the double read from memory.</returns>
         public double ReadDouble(long address)
         {
             return BitConverter.Int64BitsToDouble(ReadInt64(address));
-        }
-
-        /// <summary>
-        /// Writes a double to memory.
-        /// </summary>
-        /// <param name="address">The zero-based address to write to.</param>
-        /// <param name="value">The double to write.</param>
-        public void WriteDouble(int address, double value)
-        {
-            WriteInt64(address, BitConverter.DoubleToInt64Bits(value));
         }
 
         /// <summary>

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -87,13 +87,16 @@ namespace Wasmtime
         /// </summary>
         /// <returns>Returns a pointer to the start of the memory.</returns>
         /// <remarks>
+        /// <para>
         /// The pointer may become invalid if the memory grows.
         ///
         /// This may happen if the memory is explicitly requested to grow or
         /// grows as a result of WebAssembly execution.
-        ///
+        /// </para>
+        /// <para>
         /// Therefore, the returned pointer should not be used after calling the grow method or
         /// after calling into WebAssembly code.
+        /// </para>
         /// </remarks>
         public unsafe IntPtr GetPointer()
         {
@@ -107,13 +110,16 @@ namespace Wasmtime
         /// <returns>Returns the span of the memory.</returns>
         /// <exception cref="OverflowException">The memory has more than 32767 pages.</exception>
         /// <remarks>
+        /// <para>
         /// The span may become invalid if the memory grows.
         ///
         /// This may happen if the memory is explicitly requested to grow or
         /// grows as a result of WebAssembly execution.
-        ///
+        /// </para>
+        /// <para>
         /// Therefore, the returned span should not be used after calling the grow method or
         /// after calling into WebAssembly code.
+        /// </para>
         /// </remarks>
         [Obsolete("This method will throw an OverflowException if the memory has more than 32767 pages. " +
             "Use the " + nameof(GetSpan) + " overload taking an address and a length.")]
@@ -129,13 +135,16 @@ namespace Wasmtime
         /// <param name="address">The zero-based address of the start of the span.</param>
         /// <param name="length">The length of the span.</param>
         /// <remarks>
+        /// <para>
         /// The span may become invalid if the memory grows.
-        ///
+        /// 
         /// This may happen if the memory is explicitly requested to grow or
         /// grows as a result of WebAssembly execution.
-        ///
+        /// </para>
+        /// <para>
         /// Therefore, the returned span should not be used after calling the grow method or
         /// after calling into WebAssembly code.
+        /// </para>
         /// </remarks>
         public Span<byte> GetSpan(long address, int length)
         {
@@ -150,16 +159,20 @@ namespace Wasmtime
         /// <exception cref="OverflowException">The memory exceeds the byte length that can be 
         /// represented by a <see cref="Span{T}"/>.</exception>
         /// <remarks>
+        /// <para>
         /// The span may become invalid if the memory grows.
         ///
         /// This may happen if the memory is explicitly requested to grow or
         /// grows as a result of WebAssembly execution.
-        ///
+        /// </para>
+        /// <para>
         /// Therefore, the returned span should not be used after calling the grow method or
         /// after calling into WebAssembly code.
-        /// 
+        /// </para>
+        /// <para>
         /// Note that WebAssembly always uses little endian as byte order. On platforms 
         /// that use big endian, you will need to convert numeric values accordingly.
+        /// </para>
         /// </remarks>
         public unsafe Span<T> GetSpan<T>(int address)
             where T : unmanaged
@@ -174,16 +187,20 @@ namespace Wasmtime
         /// <param name="address">The zero-based address of the start of the span.</param>
         /// <param name="length">The length of the span.</param>
         /// <remarks>
+        /// <para>
         /// The span may become invalid if the memory grows.
         ///
         /// This may happen if the memory is explicitly requested to grow or
         /// grows as a result of WebAssembly execution.
-        ///
+        /// </para>
+        /// <para>
         /// Therefore, the returned span should not be used after calling the grow method or
         /// after calling into WebAssembly code.
-        /// 
+        /// </para>
+        /// <para>
         /// Note that WebAssembly always uses little endian as byte order. On platforms 
         /// that use big endian, you will need to convert numeric values accordingly.
+        /// </para>
         /// </remarks>
         public unsafe Span<T> GetSpan<T>(long address, int length)
             where T : unmanaged
@@ -220,8 +237,10 @@ namespace Wasmtime
         /// <param name="address">The zero-based address to read from.</param>
         /// <returns>Returns the struct read from memory.</returns>
         /// <remarks>
+        /// <para>
         /// Note that WebAssembly always uses little endian as byte order. On platforms 
         /// that use big endian, you will need to convert numeric values accordingly.
+        /// </para>
         /// </remarks>
         public T Read<T>(long address)
             where T : unmanaged
@@ -236,8 +255,10 @@ namespace Wasmtime
         /// <param name="address">The zero-based address to read from.</param>
         /// <param name="value">The struct to write.</param>
         /// <remarks>
+        /// <para>
         /// Note that WebAssembly always uses little endian as byte order. On platforms 
         /// that use big endian, you will need to convert numeric values accordingly.
+        /// </para>
         /// </remarks>
         public void Write<T>(long address, T value)
             where T : unmanaged

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -85,6 +85,7 @@ namespace Wasmtime
         /// Returns a pointer to the start of the memory. The length for which the pointer
         /// is valid can be retrieved with <see cref="GetLength"/>.
         /// </summary>
+        /// <returns>Returns a pointer to the start of the memory.</returns>
         /// <remarks>
         /// The pointer may become invalid if the memory grows.
         ///
@@ -94,7 +95,6 @@ namespace Wasmtime
         /// Therefore, the returned pointer should not be used after calling the grow method or
         /// after calling into WebAssembly code.
         /// </remarks>
-        /// <returns></returns>
         public unsafe IntPtr GetPointer()
         {
             var data = Native.wasmtime_memory_data(store.Context.handle, this.memory);
@@ -206,7 +206,9 @@ namespace Wasmtime
             long byteLength = (long)length * sizeof(T);
 
             if (address > memoryLength - byteLength)
+            {
                 throw new ArgumentException("The specified address and length exceed the Memory's bounds.");
+            }
 
             return new Span<T>((T*)(data + address), length);
         }
@@ -301,6 +303,7 @@ namespace Wasmtime
             {
                 encoding = Encoding.UTF8;
             }
+
             return encoding.GetBytes(value, GetSpan(address, (int)Math.Min(int.MaxValue, GetLength() - address)));
         }
 

--- a/tests/MemoryAccessTests.cs
+++ b/tests/MemoryAccessTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Wasmtime.Tests
+{
+    public class MemoryAccessFixture : ModuleFixture
+    {
+        protected override string ModuleFileName => "MemoryAccess.wat";
+    }
+
+    public class MemoryAccessTests : IClassFixture<MemoryAccessFixture>, IDisposable
+    {
+        private MemoryAccessFixture Fixture { get; set; }
+
+        private Store Store { get; set; }
+
+        private Linker Linker { get; set; }
+
+        public MemoryAccessTests(MemoryAccessFixture fixture)
+        {
+            Fixture = fixture;
+            Store = new Store(Fixture.Engine);
+            Linker = new Linker(Fixture.Engine);
+        }
+
+        [Fact]
+        public unsafe void ItCanAccessMemoryWith65536Pages()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var memory = instance.GetMemory("mem");
+
+            memory.GetLength().Should().Be(uint.MaxValue + 1L);
+
+            memory.ReadInt32(0).Should().Be(0);
+            memory.ReadInt32(0L).Should().Be(0);
+
+            memory.WriteInt64(100, 1234);
+            memory.ReadInt64(100L).Should().Be(1234);
+
+            memory.ReadByte(uint.MaxValue).Should().Be(0x63);
+            memory.ReadInt16(uint.MaxValue - 1).Should().Be(0x6364);
+            memory.ReadInt32(uint.MaxValue - 3).Should().Be(0x63646500);
+
+            memory.ReadSingle(uint.MaxValue - 3).Should().Be(4.2131355E+21F);
+
+            var span = memory.GetSpan(uint.MaxValue - 1, 2);
+            span.SequenceEqual(new byte[] { 0x64, 0x63 }).Should().BeTrue();
+
+            var int16Span = memory.GetSpan<short>(0, int.MaxValue);
+            int16Span[int.MaxValue - 1].Should().Be(0x6500);
+
+            int16Span = memory.GetSpan<short>(2);
+            int16Span[int.MaxValue - 1].Should().Be(0x6364);
+
+            byte* ptr = (byte*)memory.GetPointer();
+            ptr += uint.MaxValue;
+            (*ptr).Should().Be(0x63);
+
+            string str1 = "Hello World";
+            memory.WriteString(uint.MaxValue - str1.Length, str1);
+            memory.ReadString(uint.MaxValue - str1.Length, str1.Length).Should().Be(str1);
+        }
+
+        [Fact]
+        public void ItThrowsForOutOfBoundsAccess()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var memory = instance.GetMemory("mem");
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            Action action = () => memory.GetSpan();
+#pragma warning restore CS0618 // Type or member is obsolete
+            action.Should().Throw<OverflowException>();
+
+            action = () => memory.GetSpan<short>(0);
+            action.Should().Throw<OverflowException>();
+
+            action = () => memory.GetSpan(-1L, 0);
+            action.Should().Throw<ArgumentOutOfRangeException>();
+
+            action = () => memory.GetSpan(0L, -1);
+            action.Should().Throw<ArgumentOutOfRangeException>();
+
+            action = () => memory.ReadInt16(uint.MaxValue);
+            action.Should().Throw<ArgumentException>();
+
+            action = () => memory.GetSpan<short>(uint.MaxValue, 1);
+            action.Should().Throw<ArgumentException>();
+        }
+
+        public void Dispose()
+        {
+            Store.Dispose();
+            Linker.Dispose();
+        }
+    }
+}

--- a/tests/Modules/MemoryAccess.wat
+++ b/tests/Modules/MemoryAccess.wat
@@ -1,0 +1,15 @@
+(module
+  (memory (export "mem") 65536)
+  (func $start
+	i32.const 4294967295
+	i32.const 99
+	i32.store8
+	i32.const 4294967294
+	i32.const 100
+	i32.store8
+	i32.const 4294967293
+	i32.const 101
+	i32.store8
+  )
+  (start $start)
+)

--- a/tests/Wasmtime.Tests.csproj
+++ b/tests/Wasmtime.Tests.csproj
@@ -26,12 +26,6 @@
     <EmbeddedResource Include="Modules/hello.wasm" LogicalName="hello.wasm" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Modules\MemoryAccess.wat">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/tests/Wasmtime.Tests.csproj
+++ b/tests/Wasmtime.Tests.csproj
@@ -26,6 +26,12 @@
     <EmbeddedResource Include="Modules/hello.wasm" LogicalName="hello.wasm" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Modules\MemoryAccess.wat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
Hi, this PR adds new `Int64`-based APIs to `Memory` to allow to access memories with more than 32767 pages.

Fixes #165 

I added a new method `GetSpan<byte>(long address, int length)` as well as `GetSpan<T>(long address, int length)` to retrieve a `Span` starting at the given `Int64` address. Additionally, I added a `GetLength()` and `GetPointer()` methods for getting a raw pointer to the memory, and the memory length in bytes (in case you want to access the whole memory area at once, even if it exceeds a size of 2 GiB).

Additionally, for the `ReadXyz()`/`WriteXyz()` methods, I added new overloads taking an `Int64` address, and fixed the existing (`Int32`-based) methods to not throw an `OverflowException`.

I also added an `ObsoleteAttribute` to the `GetSpan()` method to indicate that it will throw an `OverflowException` when the memory has more than 32767 pages, with a recommendation to use the `GetSpan(long address, int length)` method instead.

Alternatively, we could also drop the old (`Int32`-based) APIs as breaking change.

What do you think?

Thanks!