### PR TITLE
Correctly use Linker.DefineFunction() for the LinkerFunctionTests

### DIFF
--- a/tests/LinkerFunctionsTests.cs
+++ b/tests/LinkerFunctionsTests.cs
@@ -31,19 +31,19 @@ namespace Wasmtime.Tests
                 caller.GetMemory("mem").ReadString(address, length).Should().Be("Hello World");
             });
 
-            Linker.Define("env", "return_i32", Function.FromCallback(Store, GetBoundFuncIntDelegate()));
+            Linker.DefineFunction("env", "return_i32", GetBoundFuncIntDelegate());
 
-            Linker.Define("env", "return_15_values", Function.FromCallback(Store, () =>
+            Linker.DefineFunction("env", "return_15_values", () =>
             {
                 return (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-            }));
+            });
 
-            Linker.Define("env", "accept_15_values", Function.FromCallback(Store,
+            Linker.DefineFunction("env", "accept_15_values",
                 (int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9, int i10, int i11, int i12, int i13, int i14, int i15) =>
                 {
                     (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15)
                         .Should().Be((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
-                }));
+                });
 
             Func<int> GetBoundFuncIntDelegate()
             {


### PR DESCRIPTION
In PR #161 I accidentally used `Linker.Define(..., Function.FromCallback(...))` instead of `Linker.DefineFunction()` for the new `LinkerFunctionTests` (Copy+Paste error... 😇) Sorry about that.