### PR TITLE
Remove `CompilerStrategy.Lightbeam`

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -16,11 +16,7 @@ namespace Wasmtime
         /// <summary>
         /// Use the Cranelift compiler.
         /// </summary>
-        Cranelift,
-        /// <summary>
-        /// Use the Lightbeam compiler.
-        /// </summary>
-        Lightbeam
+        Cranelift
     }
 
     /// <summary>


### PR DESCRIPTION
Remove `CompilerStrategy.Lightbeam`.

The corresponding value (`WASMTIME_STRATEGY_LIGHTBEAM`) was removed with bytecodealliance/wasmtime#3390 (Wasmtime 0.31.0).