### PR TITLE
Add support for 64-bit Memory

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -373,46 +373,46 @@ namespace Wasmtime
             public static extern void wasm_config_delete(IntPtr config);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_debug_info_set(Handle config, bool enable);
+            public static extern void wasmtime_config_debug_info_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_epoch_interruption_set(Handle config, bool enable);
+            public static extern void wasmtime_config_epoch_interruption_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_consume_fuel_set(Handle config, bool enable);
+            public static extern void wasmtime_config_consume_fuel_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_max_wasm_stack_set(Handle config, UIntPtr size);
+            public static extern void wasmtime_config_max_wasm_stack_set(Handle config, nuint size);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_wasm_threads_set(Handle config, bool enable);
+            public static extern void wasmtime_config_wasm_threads_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_wasm_reference_types_set(Handle config, bool enable);
+            public static extern void wasmtime_config_wasm_reference_types_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_wasm_simd_set(Handle config, bool enable);
+            public static extern void wasmtime_config_wasm_simd_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_wasm_bulk_memory_set(Handle config, bool enable);
+            public static extern void wasmtime_config_wasm_bulk_memory_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_wasm_multi_value_set(Handle config, bool enable);
+            public static extern void wasmtime_config_wasm_multi_value_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_wasm_multi_memory_set(Handle config, bool enable);
+            public static extern void wasmtime_config_wasm_multi_memory_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_wasm_memory64_set(Handle config, bool enable);
+            public static extern void wasmtime_config_wasm_memory64_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_strategy_set(Handle config, byte strategy);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_cranelift_debug_verifier_set(Handle config, bool enable);
+            public static extern void wasmtime_config_cranelift_debug_verifier_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_cranelift_nan_canonicalization_set(Handle config, bool enable);
+            public static extern void wasmtime_config_cranelift_nan_canonicalization_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_cranelift_opt_level_set(Handle config, byte level);

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -190,6 +190,17 @@ namespace Wasmtime
         }
 
         /// <summary>
+        /// Sets whether or not enable WebAssembly memory64 support.
+        /// </summary>
+        /// <param name="enable">True to enable WebAssembly memory64 support or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithMemory64(bool enable)
+        {
+            Native.wasmtime_config_wasm_memory64_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
         /// Sets the compiler strategy to use.
         /// </summary>
         /// <param name="strategy">The compiler strategy to use.</param>
@@ -390,6 +401,9 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_wasm_multi_memory_set(Handle config, bool enable);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_memory64_set(Handle config, bool enable);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_strategy_set(Handle config, byte strategy);

--- a/src/Export.cs
+++ b/src/Export.cs
@@ -192,21 +192,35 @@ namespace Wasmtime
 
             unsafe
             {
-                var limits = Memory.Native.wasm_memorytype_limits(type);
-                Minimum = limits->min;
-                Maximum = limits->max;
+                Minimum = (long)Memory.Native.wasmtime_memorytype_minimum(type);
+
+                bool hasMax = Memory.Native.wasmtime_memorytype_maximum(type, out ulong max);
+                if (hasMax)
+                {
+                    Maximum = (long)max;
+                }
+
+                Is64Bit = Memory.Native.wasmtime_memorytype_is64(type);
             }
         }
 
         /// <summary>
-        /// The minimum memory size (in WebAssembly page units).
+        /// Gets the minimum memory size (in WebAssembly page units).
         /// </summary>
-        public uint Minimum { get; private set; }
+        /// <value>The minimum memory size (in WebAssembly page units).</value>
+        public long Minimum { get; }
 
         /// <summary>
-        /// The maximum memory size (in WebAssembly page units).
+        /// Gets the maximum memory size (in WebAssembly page units).
         /// </summary>
-        public uint Maximum { get; private set; }
+        /// <value>The maximum memory size (in WebAssembly page units), or <c>null</c> if no maximum is specified.</value>
+        public long? Maximum { get; }
+
+        /// <summary>
+        /// Gets a value that indicates whether this type of memory represents a 64-bit memory.
+        /// </summary>
+        /// <value><c>true</c> if this type of memory represents a 64-bit memory, <c>false</c> if it represents a 32-bit memory.</value>
+        public bool Is64Bit { get; }
 
         private static class Native
         {

--- a/src/Export.cs
+++ b/src/Export.cs
@@ -194,8 +194,7 @@ namespace Wasmtime
             {
                 Minimum = (long)Memory.Native.wasmtime_memorytype_minimum(type);
 
-                bool hasMax = Memory.Native.wasmtime_memorytype_maximum(type, out ulong max);
-                if (hasMax)
+                if (Memory.Native.wasmtime_memorytype_maximum(type, out ulong max))
                 {
                     Maximum = (long)max;
                 }

--- a/src/Import.cs
+++ b/src/Import.cs
@@ -207,8 +207,7 @@ namespace Wasmtime
             {
                 Minimum = (long)Memory.Native.wasmtime_memorytype_minimum(type);
 
-                bool hasMax = Memory.Native.wasmtime_memorytype_maximum(type, out ulong max);
-                if (hasMax)
+                if (Memory.Native.wasmtime_memorytype_maximum(type, out ulong max))
                 {
                     Maximum = (long)max;
                 }

--- a/src/Import.cs
+++ b/src/Import.cs
@@ -205,21 +205,35 @@ namespace Wasmtime
 
             unsafe
             {
-                var limits = Memory.Native.wasm_memorytype_limits(type);
-                Minimum = limits->min;
-                Maximum = limits->max;
+                Minimum = (long)Memory.Native.wasmtime_memorytype_minimum(type);
+
+                bool hasMax = Memory.Native.wasmtime_memorytype_maximum(type, out ulong max);
+                if (hasMax)
+                {
+                    Maximum = (long)max;
+                }
+
+                Is64Bit = Memory.Native.wasmtime_memorytype_is64(type);
             }
         }
 
         /// <summary>
-        /// The minimum memory size (in WebAssembly page units).
+        /// Gets the minimum memory size (in WebAssembly page units).
         /// </summary>
-        public uint Minimum { get; private set; }
+        /// <value>The minimum memory size (in WebAssembly page units).</value>
+        public long Minimum { get; }
 
         /// <summary>
-        /// The maximum memory size (in WebAssembly page units).
+        /// Gets the maximum memory size (in WebAssembly page units).
         /// </summary>
-        public uint Maximum { get; private set; }
+        /// <value>The maximum memory size (in WebAssembly page units), or <c>null</c> if no maximum is specified.</value>
+        public long? Maximum { get; }
+
+        /// <summary>
+        /// Gets a value that indicates whether this type of memory represents a 64-bit memory.
+        /// </summary>
+        /// <value><c>true</c> if this type of memory represents a 64-bit memory, <c>false</c> if it represents a 32-bit memory.</value>
+        public bool Is64Bit { get; }
 
         private static class Native
         {

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -16,8 +16,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the memory in.</param>
         /// <param name="minimum">The minimum number of WebAssembly pages.</param>
-        /// <param name="maximum">The maximum number of WebAssembly pages.</param>
-        public Memory(IStore store, uint minimum = 0, uint maximum = uint.MaxValue)
+        /// <param name="maximum">The maximum number of WebAssembly pages, or <c>null</c> to not specify a maximum.</param>
+        /// <param name="is64Bit"><c>true</c> when memory type represents a 64-bit memory, <c>false</c> when it represents a 32-bit memory.</param>
+        public Memory(IStore store, long minimum = 0, long? maximum = null, bool is64Bit = false)
         {
             if (store is null)
             {
@@ -32,14 +33,12 @@ namespace Wasmtime
             this.store = store;
             Minimum = minimum;
             Maximum = maximum;
+            Is64Bit = is64Bit;
 
             unsafe
             {
-                var limits = new Native.Limits();
-                limits.min = minimum;
-                limits.max = maximum;
+                using var type = new TypeHandle(Native.wasmtime_memorytype_new((ulong)minimum, maximum is not null, (ulong)(maximum ?? 0), is64Bit));
 
-                using var type = new TypeHandle(Native.wasm_memorytype_new(limits));
                 var error = Native.wasmtime_memory_new(store.Context.handle, type, out this.memory);
                 if (error != IntPtr.Zero)
                 {
@@ -54,22 +53,30 @@ namespace Wasmtime
         public const int PageSize = 65536;
 
         /// <summary>
-        /// The minimum memory size (in WebAssembly page units).
+        /// Gets the minimum memory size (in WebAssembly page units).
         /// </summary>
-        public uint Minimum { get; private set; }
+        /// <value>The minimum memory size (in WebAssembly page units).</value>
+        public long Minimum { get; }
 
         /// <summary>
-        /// The maximum memory size (in WebAssembly page units).
+        /// Gets the maximum memory size (in WebAssembly page units).
         /// </summary>
-        public uint Maximum { get; private set; }
+        /// <value>The maximum memory size (in WebAssembly page units), or <c>null</c> if no maximum is specified.</value>
+        public long? Maximum { get; }
+
+        /// <summary>
+        /// Gets a value that indicates whether this type of memory represents a 64-bit memory.
+        /// </summary>
+        /// <value><c>true</c> if this type of memory represents a 64-bit memory, <c>false</c> otherwise.</value>
+        public bool Is64Bit { get; }
 
         /// <summary>
         /// Gets the current size of the memory, in WebAssembly page units.
         /// </summary>
         /// <returns>Returns the current size of the memory, in WebAssembly page units.</returns>
-        public uint GetSize()
+        public long GetSize()
         {
-            return Native.wasmtime_memory_size(store.Context.handle, this.memory);
+            return (long)Native.wasmtime_memory_size(store.Context.handle, this.memory);
         }
 
         /// <summary>
@@ -78,7 +85,7 @@ namespace Wasmtime
         /// <returns>Returns the current length of the memory, in bytes.</returns>
         public long GetLength()
         {
-            return checked((long)(nuint)Native.wasmtime_memory_data_size(store.Context.handle, this.memory));
+            return checked((long)Native.wasmtime_memory_data_size(store.Context.handle, this.memory));
         }
 
         /// <summary>
@@ -485,20 +492,25 @@ namespace Wasmtime
         /// <param name="delta">The number of WebAssembly pages to grow the memory by.</param>
         /// <returns>Returns the previous size of the Webassembly memory, in pages.</returns>
         /// <remarks>This method will invalidate previously returned values from `GetSpan`.</remarks>
-        public uint Grow(uint delta)
+        public long Grow(long delta)
         {
             if (store is null)
             {
                 throw new ArgumentNullException(nameof(store));
             }
 
-            var error = Native.wasmtime_memory_grow(store.Context.handle, this.memory, delta, out var prev);
+            if (delta < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(delta));
+            }
+
+            var error = Native.wasmtime_memory_grow(store.Context.handle, this.memory, (ulong)delta, out var prev);
             if (error != IntPtr.Zero)
             {
                 throw WasmtimeException.FromOwnedError(error);
             }
 
-            return prev;
+            return (long)prev;
         }
 
         Extern IExternal.AsExtern()
@@ -518,9 +530,15 @@ namespace Wasmtime
 
             unsafe
             {
-                var limits = Native.wasm_memorytype_limits(type.DangerousGetHandle());
-                Minimum = limits->min;
-                Maximum = limits->max;
+                Minimum = (long)Native.wasmtime_memorytype_minimum(type.DangerousGetHandle());
+                
+                bool hasMax = Native.wasmtime_memorytype_maximum(type.DangerousGetHandle(), out ulong max);
+                if (hasMax)
+                {
+                    Maximum = (long)max;
+                }
+
+                Is64Bit = Native.wasmtime_memorytype_is64(type.DangerousGetHandle());
             }
         }
 
@@ -541,14 +559,6 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [StructLayout(LayoutKind.Sequential)]
-            internal struct Limits
-            {
-                public uint min;
-
-                public uint max;
-            }
-
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasmtime_memory_new(IntPtr context, TypeHandle type, out ExternMemory memory);
 
@@ -556,22 +566,30 @@ namespace Wasmtime
             public static unsafe extern byte* wasmtime_memory_data(IntPtr context, in ExternMemory memory);
 
             [DllImport(Engine.LibraryName)]
-            public static extern UIntPtr wasmtime_memory_data_size(IntPtr context, in ExternMemory memory);
+            public static extern nuint wasmtime_memory_data_size(IntPtr context, in ExternMemory memory);
 
             [DllImport(Engine.LibraryName)]
-            public static extern uint wasmtime_memory_size(IntPtr context, in ExternMemory memory);
+            public static extern ulong wasmtime_memory_size(IntPtr context, in ExternMemory memory);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_memory_grow(IntPtr context, in ExternMemory memory, uint delta, out uint prev);
+            public static extern IntPtr wasmtime_memory_grow(IntPtr context, in ExternMemory memory, ulong delta, out ulong prev);
 
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasmtime_memory_type(IntPtr context, in ExternMemory memory);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasm_memorytype_new(in Limits limits);
+            public static extern IntPtr wasmtime_memorytype_new(ulong min, [MarshalAs(UnmanagedType.I1)] bool max_present, ulong max, [MarshalAs(UnmanagedType.I1)] bool is_64);
 
             [DllImport(Engine.LibraryName)]
-            public static unsafe extern Limits* wasm_memorytype_limits(IntPtr type);
+            public static unsafe extern ulong wasmtime_memorytype_minimum(IntPtr type);
+
+            [DllImport(Engine.LibraryName)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            public static unsafe extern bool wasmtime_memorytype_maximum(IntPtr type, out ulong max);
+
+            [DllImport(Engine.LibraryName)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            public static unsafe extern bool wasmtime_memorytype_is64(IntPtr type);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasm_memorytype_delete(IntPtr handle);

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -25,6 +25,16 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(store));
             }
 
+            if (minimum < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minimum));
+            }
+
+            if (maximum < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximum));
+            }
+
             if (maximum < minimum)
             {
                 throw new ArgumentException("The maximum cannot be less than the minimum.", nameof(maximum));

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -542,8 +542,7 @@ namespace Wasmtime
             {
                 Minimum = (long)Native.wasmtime_memorytype_minimum(type.DangerousGetHandle());
                 
-                bool hasMax = Native.wasmtime_memorytype_maximum(type.DangerousGetHandle(), out ulong max);
-                if (hasMax)
+                if (Native.wasmtime_memorytype_maximum(type.DangerousGetHandle(), out ulong max))
                 {
                     Maximum = (long)max;
                 }

--- a/tests/Memory64AccessTests.cs
+++ b/tests/Memory64AccessTests.cs
@@ -5,20 +5,20 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class MemoryAccessFixture : ModuleFixture
+    public class Memory64AccessFixture : ModuleFixture
     {
-        protected override string ModuleFileName => "MemoryAccess.wat";
+        protected override string ModuleFileName => "Memory64Access.wat";
     }
 
-    public class MemoryAccessTests : IClassFixture<MemoryAccessFixture>, IDisposable
+    public class Memory64AccessTests : IClassFixture<Memory64AccessFixture>, IDisposable
     {
-        private MemoryAccessFixture Fixture { get; set; }
+        private Memory64AccessFixture Fixture { get; set; }
 
         private Store Store { get; set; }
 
         private Linker Linker { get; set; }
 
-        public MemoryAccessTests(MemoryAccessFixture fixture)
+        public Memory64AccessTests(Memory64AccessFixture fixture)
         {
             Fixture = fixture;
             Store = new Store(Fixture.Engine);
@@ -26,40 +26,40 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
-        public unsafe void ItCanAccessMemoryWith65536Pages()
+        public unsafe void ItCanAccessMemoryWith65537Pages()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var memory = instance.GetMemory("mem");
 
-            memory.GetLength().Should().Be(0x100000000);
+            memory.GetLength().Should().Be(0x100010000);
 
             memory.ReadInt32(0).Should().Be(0);
 
             memory.WriteInt64(100, 1234);
             memory.ReadInt64(100).Should().Be(1234);
 
-            memory.ReadByte(0xFFFFFFFF).Should().Be(0x63);
-            memory.ReadInt16(0xFFFFFFFE).Should().Be(0x6364);
-            memory.ReadInt32(0xFFFFFFFC).Should().Be(0x63646500);
+            memory.ReadByte(0x10000FFFF).Should().Be(0x63);
+            memory.ReadInt16(0x10000FFFE).Should().Be(0x6364);
+            memory.ReadInt32(0x10000FFFC).Should().Be(0x63646500);
 
-            memory.ReadSingle(0xFFFFFFFC).Should().Be(4.2131355E+21F);
+            memory.ReadSingle(0x10000FFFC).Should().Be(4.2131355E+21F);
 
-            var span = memory.GetSpan(0xFFFFFFFE, 2);
+            var span = memory.GetSpan(0x10000FFFE, 2);
             span.SequenceEqual(new byte[] { 0x64, 0x63 }).Should().BeTrue();
 
-            var int16Span = memory.GetSpan<short>(0, int.MaxValue);
+            var int16Span = memory.GetSpan<short>(0x10000, int.MaxValue);
             int16Span[0x7FFFFFFE].Should().Be(0x6500);
 
-            int16Span = memory.GetSpan<short>(2);
+            int16Span = memory.GetSpan<short>(0x10002);
             int16Span[0x7FFFFFFE].Should().Be(0x6364);
 
             byte* ptr = (byte*)memory.GetPointer();
-            ptr += 0xFFFFFFFF;
+            ptr += 0x10000FFFF;
             (*ptr).Should().Be(0x63);
 
             string str1 = "Hello World";
-            memory.WriteString(0xFFFFFFFF - str1.Length, str1);
-            memory.ReadString(0xFFFFFFFF - str1.Length, str1.Length).Should().Be(str1);
+            memory.WriteString(0x10000FFFF - str1.Length, str1);
+            memory.ReadString(0x10000FFFF - str1.Length, str1.Length).Should().Be(str1);
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace Wasmtime.Tests
 #pragma warning restore CS0618 // Type or member is obsolete
             action.Should().Throw<OverflowException>();
 
-            action = () => memory.GetSpan<short>(0);
+            action = () => memory.GetSpan<short>(0x10000);
             action.Should().Throw<OverflowException>();
 
             action = () => memory.GetSpan(-1L, 0);
@@ -82,10 +82,10 @@ namespace Wasmtime.Tests
             action = () => memory.GetSpan(0L, -1);
             action.Should().Throw<ArgumentOutOfRangeException>();
 
-            action = () => memory.ReadInt16(0xFFFFFFFF);
+            action = () => memory.ReadInt16(0x10000FFFF);
             action.Should().Throw<ArgumentException>();
 
-            action = () => memory.GetSpan<short>(0xFFFFFFFF, 1);
+            action = () => memory.GetSpan<short>(0x10000FFFF, 1);
             action.Should().Throw<ArgumentException>();
         }
 

--- a/tests/Memory64AccessTests.cs
+++ b/tests/Memory64AccessTests.cs
@@ -31,14 +31,14 @@ namespace Wasmtime.Tests
             var memoryExport = Fixture.Module.Exports.OfType<MemoryExport>().Single();
             memoryExport.Minimum.Should().Be(0x10001);
             memoryExport.Maximum.Should().Be(0x1000000000000);
-            memoryExport.Is64Bit.Should().Be(true);
+            memoryExport.Is64Bit.Should().BeTrue();
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var memory = instance.GetMemory("mem");
 
             memory.Minimum.Should().Be(0x10001);
             memory.Maximum.Should().Be(0x1000000000000);
-            memory.Is64Bit.Should().Be(true);
+            memory.Is64Bit.Should().BeTrue();
             memory.GetSize().Should().Be(0x10001);
             memory.GetLength().Should().Be(0x100010000);
 

--- a/tests/Memory64AccessTests.cs
+++ b/tests/Memory64AccessTests.cs
@@ -28,9 +28,18 @@ namespace Wasmtime.Tests
         [Fact]
         public unsafe void ItCanAccessMemoryWith65537Pages()
         {
+            var memoryExport = Fixture.Module.Exports.OfType<MemoryExport>().Single();
+            memoryExport.Minimum.Should().Be(0x10001);
+            memoryExport.Maximum.Should().Be(0x1000000000000);
+            memoryExport.Is64Bit.Should().Be(true);
+
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var memory = instance.GetMemory("mem");
 
+            memory.Minimum.Should().Be(0x10001);
+            memory.Maximum.Should().Be(0x1000000000000);
+            memory.Is64Bit.Should().Be(true);
+            memory.GetSize().Should().Be(0x10001);
             memory.GetLength().Should().Be(0x100010000);
 
             memory.ReadInt32(0).Should().Be(0);

--- a/tests/MemoryAccessTests.cs
+++ b/tests/MemoryAccessTests.cs
@@ -30,15 +30,15 @@ namespace Wasmtime.Tests
         {
             var memoryExport = Fixture.Module.Exports.OfType<MemoryExport>().Single();
             memoryExport.Minimum.Should().Be(0x10000);
-            memoryExport.Maximum.Should().Be(null);
-            memoryExport.Is64Bit.Should().Be(false);
+            memoryExport.Maximum.Should().BeNull();
+            memoryExport.Is64Bit.Should().BeFalse();
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var memory = instance.GetMemory("mem");
 
             memory.Minimum.Should().Be(0x10000);
-            memory.Maximum.Should().Be(null);
-            memory.Is64Bit.Should().Be(false);
+            memory.Maximum.Should().BeNull();
+            memory.Is64Bit.Should().BeFalse();
             memory.GetSize().Should().Be(0x10000);
             memory.GetLength().Should().Be(0x100000000);
 

--- a/tests/MemoryAccessTests.cs
+++ b/tests/MemoryAccessTests.cs
@@ -28,9 +28,18 @@ namespace Wasmtime.Tests
         [Fact]
         public unsafe void ItCanAccessMemoryWith65536Pages()
         {
+            var memoryExport = Fixture.Module.Exports.OfType<MemoryExport>().Single();
+            memoryExport.Minimum.Should().Be(0x10000);
+            memoryExport.Maximum.Should().Be(null);
+            memoryExport.Is64Bit.Should().Be(false);
+
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var memory = instance.GetMemory("mem");
 
+            memory.Minimum.Should().Be(0x10000);
+            memory.Maximum.Should().Be(null);
+            memory.Is64Bit.Should().Be(false);
+            memory.GetSize().Should().Be(0x10000);
             memory.GetLength().Should().Be(0x100000000);
 
             memory.ReadInt32(0).Should().Be(0);

--- a/tests/MemoryExportsTests.cs
+++ b/tests/MemoryExportsTests.cs
@@ -29,12 +29,13 @@ namespace Wasmtime.Tests
 
         [Theory]
         [MemberData(nameof(GetMemoryExports))]
-        public void ItHasTheExpectedMemoryExports(string exportName, uint expectedMinimum, uint expectedMaximum)
+        public void ItHasTheExpectedMemoryExports(string exportName, long expectedMinimum, long? expectedMaximum, bool is64Bit)
         {
             var export = Fixture.Module.Exports.Where(m => m.Name == exportName).FirstOrDefault() as MemoryExport;
             export.Should().NotBeNull();
             export.Minimum.Should().Be(expectedMinimum);
             export.Maximum.Should().Be(expectedMaximum);
+            export.Is64Bit.Should().Be(is64Bit);
         }
 
         [Fact]
@@ -109,8 +110,9 @@ namespace Wasmtime.Tests
         {
             yield return new object[] {
                 "mem",
-                1,
-                2
+                1L,
+                2L,
+                false
             };
         }
 

--- a/tests/MemoryImportFromModuleTests.cs
+++ b/tests/MemoryImportFromModuleTests.cs
@@ -28,8 +28,9 @@ namespace Wasmtime.Tests
             memory.Should().NotBeNull();
             memory.ModuleName.Should().Be("js");
             memory.Name.Should().Be("mem");
-            memory.Minimum.Should().Be(1);
-            memory.Maximum.Should().Be(2);
+            memory.Minimum.Should().Be(1L);
+            memory.Maximum.Should().Be(2L);
+            memory.Is64Bit.Should().BeFalse();
         }
     }
 }

--- a/tests/MemoryImportNoUpperBoundTests.cs
+++ b/tests/MemoryImportNoUpperBoundTests.cs
@@ -28,8 +28,9 @@ namespace Wasmtime.Tests
             memory.Should().NotBeNull();
             memory.ModuleName.Should().Be("");
             memory.Name.Should().Be("mem");
-            memory.Minimum.Should().Be(1);
-            memory.Maximum.Should().Be(uint.MaxValue);
+            memory.Minimum.Should().Be(1L);
+            memory.Maximum.Should().BeNull();
+            memory.Is64Bit.Should().BeFalse();
         }
     }
 }

--- a/tests/MemoryImportWithUpperBoundTests.cs
+++ b/tests/MemoryImportWithUpperBoundTests.cs
@@ -28,8 +28,9 @@ namespace Wasmtime.Tests
             memory.Should().NotBeNull();
             memory.ModuleName.Should().Be("");
             memory.Name.Should().Be("mem");
-            memory.Minimum.Should().Be(10);
-            memory.Maximum.Should().Be(100);
+            memory.Minimum.Should().Be(10L);
+            memory.Maximum.Should().Be(100L);
+            memory.Is64Bit.Should().BeFalse();
         }
     }
 }

--- a/tests/ModuleFixture.cs
+++ b/tests/ModuleFixture.cs
@@ -16,7 +16,7 @@ namespace Wasmtime.Tests
         public virtual Config GetEngineConfig()
         {
             return new Config()
-                .WithReferenceTypes(true);
+                .WithMemory64(true);
         }
 
         public void Dispose()

--- a/tests/Modules/Memory64Access.wat
+++ b/tests/Modules/Memory64Access.wat
@@ -1,13 +1,13 @@
 (module
-  (memory (export "mem") 65536)
+  (memory (export "mem") i64 65537)
   (func $start
-	i32.const 0xFFFFFFFF
+	i64.const 0x10000FFFF
 	i32.const 99
 	i32.store8
-	i32.const 0xFFFFFFFE
+	i64.const 0x10000FFFE
 	i32.const 100
 	i32.store8
-	i32.const 0xFFFFFFFD
+	i64.const 0x10000FFFD
 	i32.const 101
 	i32.store8
   )

--- a/tests/Modules/Memory64Access.wat
+++ b/tests/Modules/Memory64Access.wat
@@ -1,5 +1,5 @@
 (module
-  (memory (export "mem") i64 65537)
+  (memory (export "mem") i64 0x10001 0x1000000000000)
   (func $start
 	i64.const 0x10000FFFF
 	i32.const 99

--- a/tests/Modules/MemoryAccess.wat
+++ b/tests/Modules/MemoryAccess.wat
@@ -1,5 +1,5 @@
 (module
-  (memory (export "mem") 65536)
+  (memory (export "mem") 0x10000)
   (func $start
 	i32.const 0xFFFFFFFF
 	i32.const 99


### PR DESCRIPTION
Hi, this PR adds support for 64-bit memories, by adjusting the APIs to match the C API introduced with bytecodealliance/wasmtime#3153 and bytecodealliance/wasmtime#3182.

It contains the following changes:
- Add `Config.WithMemory64()` for enabling the Memory64 proposal.
- Change properties/parameters in `Memory`, `MemoryExport` and `MemoryImport` that work with pages (like `Minimum`, `Maximum`, `Grow()`) to use a `long` instead of `uint`. (I chose `long` instead of `ulong` because memory pages cannot exceed `2**48`, and because `ulong` isn't CLS-compliant.)
  (This will be a breaking change.)
  - Added an `Is64Bit` property that specifies whether the memory is a 64-bit memory.
- Add tests to verify the new APIs added with #166 are able to access a memory beyond the 4 GiB area, and that the new APIs correctly retrieve the memory type definitions.

Additionally, this fixes previously incorrect definitions of native functions `wasmtime_memory_size` and `wasmtime_memory_grow`, where the parameter incorrectly used `uint` instead of `ulong` after the changes introduced in the Wasmtime C API.
Also, I noticed that for native Config functions taking a C `bool` parameter, the `[MarshalAs]` attribute was missing, which meant these parameter were marshaled by .NET as 4-byte `BOOL` instead of an 1-byte value.

What do you think?

Thanks!