### PR TITLE
Fix the `bool` return type declaration for native Trap functions

### DIFF
--- a/src/TrapException.cs
+++ b/src/TrapException.cs
@@ -333,9 +333,11 @@ namespace Wasmtime
             public static extern void wasm_frame_vec_delete(in FrameArray vec);
 
             [DllImport(Engine.LibraryName)]
+            [return: MarshalAs(UnmanagedType.I1)]
             internal static extern bool wasmtime_trap_exit_status(IntPtr trap, out int exitStatus);
 
             [DllImport(Engine.LibraryName)]
+            [return: MarshalAs(UnmanagedType.I1)]
             internal static extern bool wasmtime_trap_code(IntPtr trap, out TrapCode exitCode);
         }
     }

--- a/tests/Modules/Trap.wat
+++ b/tests/Modules/Trap.wat
@@ -1,9 +1,11 @@
 (module
+  (import "" "host_trap" (func $host_trap))
   (export "ok" (func $ok))
   (export "ok_value" (func $ok_value))
   (export "run" (func $run))
   (export "run_div_zero" (func $run_div_zero))
   (export "run_div_zero_with_result" (func $run_div_zero_with_result))
+  (export "host_trap" (func $host_trap))
 
   (func $run
     (call $first)

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -52,6 +52,8 @@ namespace Wasmtime.Tests
             Fixture = fixture;
             Store = new Store(Fixture.Engine);
             Linker = new Linker(Fixture.Engine);
+
+            Linker.Define("", "host_trap", Function.FromCallback(Store, () => throw new Exception()));
         }
 
         [Fact]
@@ -142,6 +144,17 @@ namespace Wasmtime.Tests
             result.Trap.Type.Should().Be(TrapCode.IntegerDivisionByZero);
             result.Trap.Frames.Count.Should().Be(1);
             result.Trap.Frames[0].FunctionName.Should().Be("run_div_zero_with_result");
+        }
+
+        [Fact]
+        public void ItReturnsCorrectTrapCodeForHostTrap()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var hostTrap = instance.GetFunction<ActionResult>("host_trap");
+            var result = hostTrap();
+
+            result.Type.Should().Be(ResultType.Trap);
+            result.Trap.Type.Should().Be(TrapCode.Undefined);
         }
 
         [Fact]


### PR DESCRIPTION
The return type for native functions `wasmtime_trap_exit_status` and `wasmtime_trap_code` was incorrectly declared as `bool` without `[return: MarshalAs(UnmanagedType.I1)]`, which meant .NET marshaled the value as 4-byte `BOOL` instead of an 1-byte value.

For example, this caused `TrapException.Type` incorrectly being set to `TrapCode.StackOverflow` instead of `TrapCode.Undefined`, because the return value of `wasmtime_trap_code` was not correctly marshaled.

Fixes #171

Thanks!