### PR TITLE
Update example in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ namespace WasmIntro
             );
 
             var instance = linker.Instantiate(store, module);
-            var run = instance.GetAction(store, "run");
+            var run = instance.GetAction("run");
             run();
         }
     }


### PR DESCRIPTION
Hi team,

I tried the example in REAMDE.md and got this error "CS1501: No overload for method 'GetAction' takes 2 arguments".

I make this PR to fix by changing GetAction to take only function name as parameter.

Environment version: 
Macos Big Sur
dotnet 7.0.100
wasmtime-cli 2.0.1
Wasmtime-package 2.0.1

