### PR TITLE
Run the template commands (`dotnet tool t4`) only once

### DIFF
--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -69,6 +69,9 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
   </ItemGroup>
 
   <Target Name="RunCodeTemplates" BeforeTargets="DispatchToInnerBuilds">
+    <!-- Generate the code files from the T4 text templates.
+         We use the "DispatchToInnerBuilds" target so that they are only run once when
+         building the project, instead of for each target framework. -->
     <Exec Command="dotnet tool restore" />
     <Exec Command="dotnet tool run t4 Linker.DefineFunction.tt" />
     <Exec Command="dotnet tool run t4 Function.FromCallback.tt" />

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -68,11 +68,8 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 
-  <Target Name="RestoreTools" BeforeTargets="BeforeBuild">
+  <Target Name="RunCodeTemplates" BeforeTargets="DispatchToInnerBuilds">
     <Exec Command="dotnet tool restore" />
-  </Target>
-
-  <Target Name="RunCodeTemplates" BeforeTargets="BeforeBuild">
     <Exec Command="dotnet tool run t4 Linker.DefineFunction.tt" />
     <Exec Command="dotnet tool run t4 Function.FromCallback.tt" />
   </Target>


### PR DESCRIPTION
Run the template commands (`dotnet tool t4`, introduced with #163) only once when building the project.
Otherwise, the commands would be run one time for each target framework (`netstandard2.1` and `net6.0`), which can sometimes cause file lock errors (and can degrade performance).

This is based on this StackOverflow answer: https://stackoverflow.com/questions/50071932/how-do-i-call-my-script-before-all-the-builds-for-only-once-in-a-multi-targeting/50080946#50080946 (similar to the existing target that downloads the `wasmtime` binary).

Thank you!