### PR TITLE
Disable 64-bit memory test for CI.

### DIFF
--- a/tests/Memory64AccessTests.cs
+++ b/tests/Memory64AccessTests.cs
@@ -71,7 +71,7 @@ namespace Wasmtime.Tests
             memory.ReadString(0x10000FFFF - str1.Length, str1.Length).Should().Be(str1);
         }
 
-        [Fact]
+        [Fact(Skip = "Test consumes too much memory for CI")]
         public void ItThrowsForOutOfBoundsAccess()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);

--- a/tests/Memory64AccessTests.cs
+++ b/tests/Memory64AccessTests.cs
@@ -25,7 +25,7 @@ namespace Wasmtime.Tests
             Linker = new Linker(Fixture.Engine);
         }
 
-        [Fact]
+        [Fact(Skip = "Test consumes too much memory for CI")]
         public unsafe void ItCanAccessMemoryWith65537Pages()
         {
             var memoryExport = Fixture.Module.Exports.OfType<MemoryExport>().Single();


### PR DESCRIPTION
This PR disables the 64-bit memory test as it consumes too much memory for CI to run reliably.