### PR TITLE
Fixing Minor Code Quality Issues

### DIFF
--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -134,7 +134,7 @@ namespace Wasmtime
             public static unsafe extern bool wasmtime_caller_export_get(IntPtr caller, byte* name, UIntPtr len, out Extern item);
 
             [DllImport(Engine.LibraryName)]
-            public static unsafe extern IntPtr wasmtime_caller_context(IntPtr caller);
+            public static extern IntPtr wasmtime_caller_context(IntPtr caller);
         }
 
         private IntPtr handle;

--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -47,7 +47,7 @@ namespace Wasmtime
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    internal unsafe struct ExternUnion
+    internal struct ExternUnion
     {
         [FieldOffset(0)]
         public ExternFunc func;
@@ -69,7 +69,7 @@ namespace Wasmtime
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal unsafe struct Extern : IDisposable
+    internal struct Extern : IDisposable
     {
         public ExternKind kind;
         public ExternUnion of;

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -40,7 +40,7 @@ namespace Wasmtime
 
             unsafe
             {
-                Native.WasmtimeFuncCallback? func = (env, callerPtr, args, nargs, results, nresults) =>
+                Native.WasmtimeFuncCallback func = (env, callerPtr, args, nargs, results, nresults) =>
                 {
                     using var caller = new Caller(callerPtr);
                     return InvokeCallback(callback, callbackInvokeMethod, caller, hasCaller, args, (int)nargs, results, (int)nresults, resultKinds, returnsTuple);
@@ -1891,7 +1891,7 @@ namespace Wasmtime
 
                 if (!Value.TryGetKind(parameterTypes[i], out var kind))
                 {
-                    throw new WasmtimeException($"Unable to create a function with parameter of type '{parameterTypes[i].ToString()}'.");
+                    throw new WasmtimeException($"Unable to create a function with parameter of type '{parameterTypes[i]}'.");
                 }
 
                 parameters.Add(kind);
@@ -1901,7 +1901,7 @@ namespace Wasmtime
             {
                 if (!Value.TryGetKind(t, out var kind))
                 {
-                    throw new WasmtimeException($"Unable to create a function with a return type of type '{t.ToString()}'.");
+                    throw new WasmtimeException($"Unable to create a function with a return type of type '{t}'.");
                 }
                 return kind;
             }));

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -2008,7 +2008,7 @@ namespace Wasmtime
             public static unsafe extern IntPtr wasmtime_func_call(IntPtr context, in ExternFunc func, Value* args, UIntPtr nargs, Value* results, UIntPtr nresults, out IntPtr trap);
 
             [DllImport(Engine.LibraryName)]
-            public static unsafe extern IntPtr wasmtime_func_type(IntPtr context, in ExternFunc func);
+            public static extern IntPtr wasmtime_func_type(IntPtr context, in ExternFunc func);
 
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasm_functype_new(in ValueTypeArray parameters, in ValueTypeArray results);

--- a/src/Import.cs
+++ b/src/Import.cs
@@ -67,7 +67,7 @@ namespace Wasmtime
             public static extern void wasm_importtype_vec_delete(in ImportTypeArray vec);
 
             [DllImport(Engine.LibraryName)]
-            public static extern unsafe IntPtr wasm_importtype_type(IntPtr importType);
+            public static extern IntPtr wasm_importtype_type(IntPtr importType);
         }
     }
     /// <summary>

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -421,7 +421,7 @@ namespace Wasmtime
         internal static class Native
         {
             [DllImport(Engine.LibraryName)]
-            public static unsafe extern IntPtr wasmtime_linker_new(Engine.Handle engine);
+            public static extern IntPtr wasmtime_linker_new(Engine.Handle engine);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_linker_delete(IntPtr linker);

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -58,7 +58,7 @@ namespace Wasmtime
             var external = item as IExternal;
             if (external is null)
             {
-                throw new ArgumentException($"Objects of type `{item.GetType().ToString()}` cannot be defined in a linker.");
+                throw new ArgumentException($"Objects of type `{item.GetType()}` cannot be defined in a linker.");
             }
 
             var ext = external.AsExtern();

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -584,15 +584,15 @@ namespace Wasmtime
             public static extern IntPtr wasmtime_memorytype_new(ulong min, [MarshalAs(UnmanagedType.I1)] bool max_present, ulong max, [MarshalAs(UnmanagedType.I1)] bool is_64);
 
             [DllImport(Engine.LibraryName)]
-            public static unsafe extern ulong wasmtime_memorytype_minimum(IntPtr type);
+            public static extern ulong wasmtime_memorytype_minimum(IntPtr type);
 
             [DllImport(Engine.LibraryName)]
             [return: MarshalAs(UnmanagedType.I1)]
-            public static unsafe extern bool wasmtime_memorytype_maximum(IntPtr type, out ulong max);
+            public static extern bool wasmtime_memorytype_maximum(IntPtr type, out ulong max);
 
             [DllImport(Engine.LibraryName)]
             [return: MarshalAs(UnmanagedType.I1)]
-            public static unsafe extern bool wasmtime_memorytype_is64(IntPtr type);
+            public static extern bool wasmtime_memorytype_is64(IntPtr type);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasm_memorytype_delete(IntPtr handle);

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -45,15 +45,12 @@ namespace Wasmtime
             Maximum = maximum;
             Is64Bit = is64Bit;
 
-            unsafe
-            {
-                using var type = new TypeHandle(Native.wasmtime_memorytype_new((ulong)minimum, maximum is not null, (ulong)(maximum ?? 0), is64Bit));
+            using var type = new TypeHandle(Native.wasmtime_memorytype_new((ulong)minimum, maximum is not null, (ulong)(maximum ?? 0), is64Bit));
 
-                var error = Native.wasmtime_memory_new(store.Context.handle, type, out this.memory);
-                if (error != IntPtr.Zero)
-                {
-                    throw WasmtimeException.FromOwnedError(error);
-                }
+            var error = Native.wasmtime_memory_new(store.Context.handle, type, out this.memory);
+            if (error != IntPtr.Zero)
+            {
+                throw WasmtimeException.FromOwnedError(error);
             }
         }
 
@@ -538,17 +535,14 @@ namespace Wasmtime
 
             using var type = new TypeHandle(Native.wasmtime_memory_type(store.Context.handle, this.memory));
 
-            unsafe
-            {
-                Minimum = (long)Native.wasmtime_memorytype_minimum(type.DangerousGetHandle());
+            Minimum = (long)Native.wasmtime_memorytype_minimum(type.DangerousGetHandle());
                 
-                if (Native.wasmtime_memorytype_maximum(type.DangerousGetHandle(), out ulong max))
-                {
-                    Maximum = (long)max;
-                }
-
-                Is64Bit = Native.wasmtime_memorytype_is64(type.DangerousGetHandle());
+            if (Native.wasmtime_memorytype_maximum(type.DangerousGetHandle(), out ulong max))
+            {
+                Maximum = (long)max;
             }
+
+            Is64Bit = Native.wasmtime_memorytype_is64(type.DangerousGetHandle());
         }
 
         internal class TypeHandle : SafeHandleZeroOrMinusOneIsInvalid

--- a/src/Module.cs
+++ b/src/Module.cs
@@ -436,7 +436,7 @@ namespace Wasmtime
             public static extern unsafe IntPtr wasmtime_module_deserialize(Engine.Handle engine, byte* bytes, UIntPtr size, out IntPtr handle);
 
             [DllImport(Engine.LibraryName)]
-            public static extern unsafe IntPtr wasmtime_module_deserialize_file(Engine.Handle engine, [MarshalAs(UnmanagedType.LPUTF8Str)] string path, out IntPtr handle);
+            public static extern IntPtr wasmtime_module_deserialize_file(Engine.Handle engine, [MarshalAs(UnmanagedType.LPUTF8Str)] string path, out IntPtr handle);
         }
 
         private readonly Handle handle;

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -48,7 +48,7 @@ namespace Wasmtime
                 limits
             ));
 
-            var value = Wasmtime.Value.FromObject(initialValue, Kind);
+            var value = Value.FromObject(initialValue, Kind);
             var error = Native.wasmtime_table_new(store.Context.handle, tableType, in value, out this.table);
             value.Dispose();
 

--- a/src/V128.cs
+++ b/src/V128.cs
@@ -18,7 +18,9 @@ namespace Wasmtime
             byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue
         );
 
+#pragma warning disable CS0649 // "Field `bytes` is never assigned". Justification: This is assigned through the span returned from AsSpan().
         private unsafe fixed byte bytes[16];
+#pragma warning restore CS0649
 
         /// <summary>
         /// Construct a new V128 from a 16 element byte span

--- a/src/WasmtimeException.cs
+++ b/src/WasmtimeException.cs
@@ -9,7 +9,7 @@ namespace Wasmtime
     /// <summary>
     /// The base type for Wasmtime exceptions.
     /// </summary>
-    [System.Serializable]
+    [Serializable]
     public class WasmtimeException : Exception
     {
         /// <inheritdoc/>


### PR DESCRIPTION
Cleaned up some minor issues which were triggering warnings for me:
 - Redundant nullability
 - Redundant `unsafe` contexts
 - Redundant `ToString` calls

Some other cleanup opportunities I did not include in this PR:

#### `public static unsafe extern IntPtr wasmtime_caller_context(IntPtr caller);`
This method (and many others like it) does not need `unsafe`. Should I remove all of them? I've avoided touching anything marked `extern` so far.

#### `checked((int)name->size)` (`size` is `nuint`)
There are many checked conversions from `nuint` to `int`. R# warns: `﻿Checked context is redundant: no operators or conversions with overflow checks`. I'm pretty sure this is an incorrect warning (e.g. see [this test here](https://dotnetfiddle.net/aamMPY)), but I just wanted to double check that before reporting it to Jetbrains.
