### PR TITLE
Implement bindings for StoreContext data

### DIFF
--- a/Examples.sln
+++ b/Examples.sln
@@ -17,7 +17,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "table", "examples\table\tab
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wasmtime", "src\Wasmtime.csproj", "{82B01E4A-1CAD-44BB-B923-11FA37173BD7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "consumefuel", "examples\consumefuel\consumefuel.csproj", "{F79FAA27-3CA6-4CC3-BB50-CE27191770F1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "consumefuel", "examples\consumefuel\consumefuel.csproj", "{F79FAA27-3CA6-4CC3-BB50-CE27191770F1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "storedata", "storedata\storedata.csproj", "{E8749BAF-9D8B-4CF9-ACFF-490E86D52A20}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +59,10 @@ Global
 		{F79FAA27-3CA6-4CC3-BB50-CE27191770F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F79FAA27-3CA6-4CC3-BB50-CE27191770F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F79FAA27-3CA6-4CC3-BB50-CE27191770F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8749BAF-9D8B-4CF9-ACFF-490E86D52A20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8749BAF-9D8B-4CF9-ACFF-490E86D52A20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8749BAF-9D8B-4CF9-ACFF-490E86D52A20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8749BAF-9D8B-4CF9-ACFF-490E86D52A20}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -128,10 +128,15 @@ namespace Wasmtime
         public ulong GetConsumedFuel() => ((IStore)this).Context.GetConsumedFuel();
 
         /// <summary>
-        /// Gets the data from the Store's Context. 
+        /// Gets the user-defined data from the Store's Context. 
         /// </summary>
-        /// <returns></returns>
+        /// <returns>An object represeting the user defined data from this Store</returns>
         public object? GetData() => ((IStore)this).Context.GetData();
+
+        /// <summary>
+        /// Replaces the user-defined data in the Store's Context 
+        /// </summary>
+        public void SetData(object data) => ((IStore)this).Context.SetData(data);
 
         internal static class Native
         {

--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -136,7 +136,7 @@ namespace Wasmtime
         /// <summary>
         /// Replaces the user-defined data in the Store's Context 
         /// </summary>
-        public void SetData(object data) => ((IStore)this).Context.SetData(data);
+        public void SetData(object? data) => ((IStore)this).Context.SetData(data);
 
         internal static class Native
         {

--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -127,6 +127,36 @@ namespace Wasmtime
         /// <returns>Returns the fuel consumed by the executing WebAssembly code or 0 if fuel consumption was not enabled.</returns>
         public ulong GetConsumedFuel() => ((IStore)this).Context.GetConsumedFuel();
 
+        /// <summary>
+        /// Gets the data from the Store's Context. 
+        /// </summary>
+        /// <returns></returns>
+        public object? GetData() => ((IStore)this).Context.GetData();
+        
+        /// <summary>
+        /// Gets the data from the Store's Context and attempts to cast it to the specified type. 
+        /// </summary>
+        /// <returns>The typed store data, or null in case of a failed cast</returns>
+        public T? GetData<T>() 
+            where T: class
+        {
+            var data = this.GetData();
+            if (data is null) { return null; }
+
+            try  
+            { 
+                return (T)data; 
+            }
+            catch (InvalidCastException _) 
+            { 
+                return null; 
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
         internal static class Native
         {
             [DllImport(Engine.LibraryName)]

--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -132,30 +132,6 @@ namespace Wasmtime
         /// </summary>
         /// <returns></returns>
         public object? GetData() => ((IStore)this).Context.GetData();
-        
-        /// <summary>
-        /// Gets the data from the Store's Context and attempts to cast it to the specified type. 
-        /// </summary>
-        /// <returns>The typed store data, or null in case of a failed cast</returns>
-        public T? GetData<T>() 
-            where T: class
-        {
-            var data = this.GetData();
-            if (data is null) { return null; }
-
-            try  
-            { 
-                return (T)data; 
-            }
-            catch (InvalidCastException _) 
-            { 
-                return null; 
-            }
-            catch
-            {
-                throw;
-            }
-        }
 
         internal static class Native
         {

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -101,9 +101,6 @@ namespace Wasmtime
             [DllImport(Engine.LibraryName)]
             [return: MarshalAs(UnmanagedType.IUnknown)]
             public static extern object wasmtime_context_get_data(IntPtr handle);
-            
-            [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_context_set_data(IntPtr handle, IntPtr data);
         }
 
         internal readonly IntPtr handle;
@@ -133,12 +130,10 @@ namespace Wasmtime
         /// Constructs a new store.
         /// </summary>
         /// <param name="engine">The engine to use for the store.</param>
-        public Store(Engine engine) : this(engine, null)
-        {
-        }
+        public Store(Engine engine) : this(engine, null) { }
 
         /// <summary>
-        /// Constructs a new store with 
+        /// Constructs a new store.
         /// </summary>
         /// <param name="engine">The engine to use for the store.</param>
         /// <param name="data">Data to initialize the store with, this can later be accessed from the Caller in host functions<param>
@@ -151,7 +146,7 @@ namespace Wasmtime
 
             var dataPtr = data == null 
                 ? IntPtr.Zero
-                : (IntPtr) GCHandle.Alloc(data);
+                : (IntPtr)GCHandle.Alloc(data);
 
             handle = new Handle(Native.wasmtime_store_new(engine.NativeHandle, dataPtr, null));
         }

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -148,7 +148,12 @@ namespace Wasmtime
                 ? IntPtr.Zero
                 : (IntPtr)GCHandle.Alloc(data);
 
-            handle = new Handle(Native.wasmtime_store_new(engine.NativeHandle, dataPtr, null));
+            var storePtr = Native.wasmtime_store_new(engine.NativeHandle, dataPtr, (IntPtr ptr) => {
+                var handle = GCHandle.FromIntPtr(ptr);
+                handle.Free();
+            });
+
+            handle = new Handle(storePtr);
         }
 
         /// <summary>

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -31,8 +31,12 @@ namespace Wasmtime
         internal object? GetData()
         {
             var data = Native.wasmtime_context_get_data(handle);
+            if (data == IntPtr.Zero)
+            {
+                return null;
+            }
 
-            return data;
+            return GCHandle.FromIntPtr(data).Target;
         }
 
         internal ulong ConsumeFuel(ulong fuel)
@@ -99,8 +103,7 @@ namespace Wasmtime
             public static extern void wasmtime_context_set_epoch_deadline(IntPtr handle, ulong ticksBeyondCurrent);
             
             [DllImport(Engine.LibraryName)]
-            [return: MarshalAs(UnmanagedType.IUnknown)]
-            public static extern object wasmtime_context_get_data(IntPtr handle);
+            public static extern IntPtr wasmtime_context_get_data(IntPtr handle);
         }
 
         internal readonly IntPtr handle;

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -157,10 +157,10 @@ namespace Wasmtime
         public Store(Engine engine) : this(engine, null) { }
 
         /// <summary>
-        /// Constructs a new store.
+        /// Constructs a new store with the given context data.
         /// </summary>
         /// <param name="engine">The engine to use for the store.</param>
-        /// <param name="data">Data to initialize the store with, this can later be accessed from the Caller in host functions</param>
+        /// <param name="data">The data to initialize the store with; this can later be accessed with the GetData function.</param>
         public Store(Engine engine, object? data)
         {
             if (engine is null)

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -148,6 +148,7 @@ namespace Wasmtime
                 ? IntPtr.Zero
                 : (IntPtr)GCHandle.Alloc(data);
 
+            dataHandle = new Handle(dataPtr);
             handle = new Handle(Native.wasmtime_store_new(engine.NativeHandle, dataPtr, null));
         }
 
@@ -208,6 +209,7 @@ namespace Wasmtime
         public void Dispose()
         {
             handle.Dispose();
+            dataHandle.Dispose();
         }
 
         internal Handle NativeHandle
@@ -253,5 +255,7 @@ namespace Wasmtime
         }
 
         private readonly Handle handle;
+
+        private readonly Handle dataHandle;
     }
 }

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -28,6 +28,15 @@ namespace Wasmtime
             }
         }
 
+        internal IntPtr GetData()
+        {
+            var data = Native.wasmtime_context_get_data(handle);
+            // TODO: Handle no data?
+
+            return data;
+
+        }
+
         internal ulong ConsumeFuel(ulong fuel)
         {
             var error = Native.wasmtime_context_consume_fuel(handle, fuel, out var remaining);
@@ -90,6 +99,12 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_context_set_epoch_deadline(IntPtr handle, ulong ticksBeyondCurrent);
+            
+            [DllImport(Engine.LibraryName)]
+            public static extern IntPtr wasmtime_context_get_data(IntPtr handle);
+            
+            [DllImport(Engine.LibraryName)]
+            public static extern IntPtr wasmtime_context_set_data(IntPtr handle, IntPtr data);
         }
 
         internal readonly IntPtr handle;

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -42,15 +42,18 @@ namespace Wasmtime
         internal void SetData(object? data)
         {
             var oldData = Native.wasmtime_context_get_data(handle);
+
+            var newPtr = IntPtr.Zero;
+            if (data != null)
+            {
+                newPtr = (IntPtr)GCHandle.Alloc(data);
+            }
+
+            Native.wasmtime_context_set_data(handle, newPtr);
+
             if (oldData != IntPtr.Zero) 
             {
                 GCHandle.FromIntPtr(oldData).Free();
-            }
-            
-            if (data != null)
-            {
-                var newPtr = (IntPtr)GCHandle.Alloc(data);
-                Native.wasmtime_context_set_data(handle, newPtr);
             }
         }
 

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -148,7 +148,6 @@ namespace Wasmtime
                 ? IntPtr.Zero
                 : (IntPtr)GCHandle.Alloc(data);
 
-            dataHandle = new Handle(dataPtr);
             handle = new Handle(Native.wasmtime_store_new(engine.NativeHandle, dataPtr, null));
         }
 
@@ -209,7 +208,6 @@ namespace Wasmtime
         public void Dispose()
         {
             handle.Dispose();
-            dataHandle.Dispose();
         }
 
         internal Handle NativeHandle
@@ -255,7 +253,5 @@ namespace Wasmtime
         }
 
         private readonly Handle handle;
-
-        private readonly Handle dataHandle;
     }
 }

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Data;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -139,7 +139,7 @@ namespace Wasmtime
         /// Constructs a new store.
         /// </summary>
         /// <param name="engine">The engine to use for the store.</param>
-        /// <param name="data">Data to initialize the store with, this can later be accessed from the Caller in host functions<param>
+        /// <param name="data">Data to initialize the store with, this can later be accessed from the Caller in host functions</param>
         public Store(Engine engine, object? data)
         {
             if (engine is null)

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -226,7 +226,7 @@ namespace Wasmtime
         /// <summary>
         /// Replaces the data stored in the Store context 
         /// </summary>
-        public void SetData(object data)
+        public void SetData(object? data)
         {
            ((IStore)this).Context.SetData(data);
         }

--- a/storedata/Program.cs
+++ b/storedata/Program.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Wasmtime;
+
+namespace Example
+{
+    class Program
+    {
+        private class StoreData
+        {
+            public int Id { get; set; }
+
+            public string Message { get; set; }
+
+            public StoreData(string message, int id = 0)
+            {
+                Message = message;
+                Id = id;
+            }
+
+            public override string ToString()
+            {
+                return $"ID {Id}: {Message}";
+            }
+        }
+
+        static void Main(string[] args)
+        {
+            using var engine = new Engine(new Config().WithReferenceTypes(true));
+            using var module = Module.FromTextFile(engine, "storedata.wat");
+            using var linker = new Linker(engine);
+
+            var storeData = new StoreData("Hello, WASM", 0);
+            using var store = new Store(engine, storeData);
+
+            linker.DefineFunction("", "store_data", (Caller caller) =>
+            {
+                var data = caller.GetData() as StoreData;
+
+                Console.WriteLine($"ID {data.Id}: {data.Message}"); // 'ID 0: Hello, WASM' 
+
+                // Fully replace store data
+                var newStoreData = new StoreData("Store data replaced", 1);
+                caller.SetData(newStoreData);
+                data = caller.GetData() as StoreData;
+
+                Console.WriteLine($"ID {data.Id}: {data.Message}"); // 'ID 1: Store data replaced' 
+
+                // Change properties normally
+                data.Message = "Properties changed";
+                data.Id = 2;
+            });
+
+            var instance = linker.Instantiate(store, module);
+
+            var run = instance.GetAction("run");
+            if (run is null)
+            {
+                Console.WriteLine("error: run export is missing");
+                return;
+            }
+            run();
+
+            // Retrieve final data from store directly
+            var data = store.GetData() as StoreData;
+            Console.WriteLine($"ID {data.Id}: {data.Message}"); // 'ID 2: Properties changed' 
+        }
+    }
+}

--- a/storedata/storedata.csproj
+++ b/storedata/storedata.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\src\Wasmtime.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="storedata.wat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/storedata/storedata.wat
+++ b/storedata/storedata.wat
@@ -1,0 +1,8 @@
+(module
+  (type $t0 (func))
+  (import "" "store_data" (func $.store_data (type $t0)))
+  (func $run
+    call $.store_data
+  )
+  (export "run" (func $run))
+)

--- a/tests/StoreDataTests.cs
+++ b/tests/StoreDataTests.cs
@@ -43,21 +43,7 @@ namespace Wasmtime.Tests
 
             Linker.DefineFunction("", "hello", ((Caller caller) =>
             {
-                var data = (StoreData)caller.GetData();
-                data.Value.Should().Be(msg);
-            }));
-        }
-
-        [Fact]
-        public void ItCorrectlyCastsTypedParameter()
-        {
-            var msg = "Hello!";
-            var data = new StoreData(msg);
-            using var store = new Store(Fixture.Engine, data);
-
-            Linker.DefineFunction("", "hello", ((Caller caller) =>
-            {
-                var data = caller.GetData<StoreData>();
+                var data = caller.GetData() as StoreData;
                 data.Value.Should().Be(msg);
             }));
         }

--- a/tests/StoreDataTests.cs
+++ b/tests/StoreDataTests.cs
@@ -58,7 +58,7 @@ namespace Wasmtime.Tests
             Linker.DefineFunction("", "hello", ((Caller caller) =>
             {
                 var data = caller.GetData();
-                data.IsNull.Should().BeTrue();
+                data.Should().BeNull();
             }));
         }
 

--- a/tests/StoreDataTests.cs
+++ b/tests/StoreDataTests.cs
@@ -62,20 +62,6 @@ namespace Wasmtime.Tests
             }));
         }
 
-        [Fact]
-        public void ItShouldReturnNullOnInvalidCast()
-        {
-            var msg = "Hello!";
-            var data = new StoreData(msg);
-            using var store = new Store(Fixture.Engine, data);
-
-            Linker.DefineFunction("", "hello", ((Caller caller) =>
-            {
-                var data = caller.GetData<int[]>();
-                data.Should().BeNull();
-            }));
-        }
-
         public void Dispose()
         {
             Linker.Dispose();

--- a/tests/StoreDataTests.cs
+++ b/tests/StoreDataTests.cs
@@ -48,6 +48,20 @@ namespace Wasmtime.Tests
             }));
         }
 
+        [Fact]
+        public void ItReturnsNullWhenNoDataWasInitialized()
+        {
+            var msg = "Hello!";
+            var data = new StoreData(msg);
+            using var store = new Store(Fixture.Engine);
+
+            Linker.DefineFunction("", "hello", ((Caller caller) =>
+            {
+                var data = caller.GetData();
+                data.IsNull.Should().BeTrue();
+            }));
+        }
+
         public void Dispose()
         {
             Linker.Dispose();

--- a/tests/StoreDataTests.cs
+++ b/tests/StoreDataTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Wasmtime.Tests
+{
+    public class StoreDataFixture : ModuleFixture
+    {
+        protected override string ModuleFileName => "hello.wat";
+    }
+
+    public class StoreDataTests : IClassFixture<StoreDataFixture>, IDisposable
+    {
+        private class StoreData
+        {
+            public object Value { get; set; }
+
+            public StoreData(object value)
+            {
+                Value = value;
+            }
+        }
+
+        private StoreDataFixture Fixture { get; }
+
+        private Linker Linker { get; set; }
+
+        private Store Store { get; set; }
+
+        public StoreDataTests(StoreDataFixture fixture)
+        {
+            Fixture = fixture;
+            Linker = new Linker(Fixture.Engine);
+        }
+
+        [Fact]
+        public void ItAddsDataToTheStore()
+        {
+            var msg = "Hello!";
+            var data = new StoreData(msg);
+            using var store = new Store(Fixture.Engine, data);
+
+            Linker.DefineFunction("", "hello", ((Caller caller) =>
+            {
+                var data = (StoreData)caller.GetData();
+                data.Value.Should().Be(msg);
+            }));
+        }
+
+        [Fact]
+        public void ItCorrectlyCastsTypedParameter()
+        {
+            var msg = "Hello!";
+            var data = new StoreData(msg);
+            using var store = new Store(Fixture.Engine, data);
+
+            Linker.DefineFunction("", "hello", ((Caller caller) =>
+            {
+                var data = caller.GetData<StoreData>();
+                data.Value.Should().Be(msg);
+            }));
+        }
+
+        [Fact]
+        public void ItShouldReturnNullOnInvalidCast()
+        {
+            var msg = "Hello!";
+            var data = new StoreData(msg);
+            using var store = new Store(Fixture.Engine, data);
+
+            Linker.DefineFunction("", "hello", ((Caller caller) =>
+            {
+                var data = caller.GetData<int[]>();
+                data.Should().BeNull();
+            }));
+        }
+
+        public void Dispose()
+        {
+            Linker.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
closes #190 

This PR adds functionality to the `Store` and `Caller` that allows users to store arbitrary data in the WASM `Store` and access it using host functions like so:

```csharp
var storeData = "Hello, World";
var engine = new Engine();
var linker = new Linker(engine);
var store = new Store(engine, storeData);

linker.DefineFunction("", "store_data", (Caller caller) => {
    var data = caller.GetData() as string;
    Console.WriteLine(data);
});
```

TODO:

- [x] Add binding for `wasmtime_context_get_data`
- [x] Add binding for `wasmtime_context_set_data`

- [x] Add storedata example
- [x] Add test for SetData()