### PR TITLE
Improved Test Coverage.

### DIFF
--- a/src/Engine.cs
+++ b/src/Engine.cs
@@ -84,7 +84,7 @@ namespace Wasmtime
             public static extern void wasm_engine_delete(IntPtr engine);
 
             [DllImport(LibraryName)]
-            public static extern IntPtr wasmtime_engine_increment_epoch(IntPtr engine);
+            public static extern void wasmtime_engine_increment_epoch(IntPtr engine);
         }
 
         private readonly Handle handle;

--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using FluentAssertions;
 using Xunit;
 
@@ -17,6 +18,15 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItFailsSettingNonexistantCompilerStrategy()
+        {
+            var config = new Config();
+
+            var act = () => { config.WithCompilerStrategy((CompilerStrategy)123); };
+            act.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
         public void ItSetsProfilingStrategy()
         {
             var config = new Config();
@@ -27,6 +37,15 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItFailsSettingNonexistantProfilingStrategy()
+        {
+            var config = new Config();
+
+            var act = () => { config.WithProfilingStrategy((ProfilingStrategy)123); };
+            act.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
         public void ItSetsOptimizationLevel()
         {
             var config = new Config();
@@ -34,6 +53,15 @@ namespace Wasmtime.Tests
             config.WithOptimizationLevel(OptimizationLevel.Speed);
 
             using var engine = new Engine(config);
+        }
+
+        [Fact]
+        public void ItFailsSettingNonexistantOptimizationLevel()
+        {
+            var config = new Config();
+
+            var act = () => { config.WithOptimizationLevel((OptimizationLevel)123); };
+            act.Should().Throw<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -54,6 +82,72 @@ namespace Wasmtime.Tests
             config.WithEpochInterruption(true);
 
             using var engine = new Engine(config);
+        }
+
+        [Fact]
+        public void ItSetsDebugInfo()
+        {
+            var config = new Config();
+
+            config.WithDebugInfo(true);
+
+            using var engine = new Engine(config);
+        }
+
+        [Fact]
+        public void ItSetsThreads()
+        {
+            var config = new Config();
+            config.WithWasmThreads(true);
+
+            using var engine = new Engine(config);
+            using var module = Module.FromTextFile(engine, Path.Combine("Modules", "SharedMemory.wat"));
+        }
+
+        [Fact]
+        public void ItSetsSIMD()
+        {
+            var config = new Config();
+            config.WithSIMD(false);
+
+            Action act = () =>
+            {
+                using var engine = new Engine(config);
+                using var module = Module.FromTextFile(engine, Path.Combine("Modules", "SIMD.wat"));
+            };
+
+            act.Should().Throw<WasmtimeException>();
+        }
+
+        [Fact]
+        public void ItSetsBulkMemory()
+        {
+            var config = new Config();
+            config.WithBulkMemory(false);
+            config.WithReferenceTypes(false);
+
+            Action act = () =>
+            {
+                using var engine = new Engine(config);
+                using var module = Module.FromTextFile(engine, Path.Combine("Modules", "BulkMemory.wat"));
+            };
+
+            act.Should().Throw<WasmtimeException>();
+        }
+
+        [Fact]
+        public void ItSetsMultiValue()
+        {
+            var config = new Config();
+            config.WithMultiValue(false);
+
+            Action act = () =>
+            {
+                using var engine = new Engine(config);
+                using var module = Module.FromTextFile(engine, Path.Combine("Modules", "MultiValue.wat"));
+            };
+
+            act.Should().Throw<WasmtimeException>();
         }
     }
 }

--- a/tests/GlobalImportBindingTests.cs
+++ b/tests/GlobalImportBindingTests.cs
@@ -107,6 +107,24 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItFailsBindingGlobalsWithWrongType()
+        {
+            var global_i32_mut = new Global(Store, ValueKind.Int32, 0, Mutability.Mutable);
+
+            global_i32_mut.Wrap<float>().Should().BeNull();
+            global_i32_mut.Wrap<double>().Should().BeNull();
+            global_i32_mut.Wrap<uint>().Should().BeNull();
+        }
+
+        [Fact]
+        public void ItFailsMutatingImmutableGlobal()
+        {
+            var global_i32_mut = new Global(Store, ValueKind.Int32, 0, Mutability.Immutable);
+            Action action = () => global_i32_mut.Wrap<int>()!.SetValue(3);
+            action.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
         public void ItBindsTheGlobalsCorrectly()
         {
             var global_i32_mut = new Global(Store, ValueKind.Int32, 0, Mutability.Mutable).Wrap<int>();

--- a/tests/Modules/BulkMemory.wat
+++ b/tests/Modules/BulkMemory.wat
@@ -1,0 +1,9 @@
+﻿(module
+  (func (param $dst i32) (param $src i32) (param $size i32) (result i32)
+	  local.get $dst
+	  local.get $src
+	  local.get $size
+	  memory.copy
+	  local.get $dst
+  )
+)

--- a/tests/Modules/MultiValue.wat
+++ b/tests/Modules/MultiValue.wat
@@ -1,0 +1,4 @@
+﻿(module
+  (func $echo_tuple2 (result i32 i32) i32.const 1 i32.const 2)
+  (export "$echo_tuple2" (func $echo_tuple2))
+)

--- a/tests/Modules/SIMD.wat
+++ b/tests/Modules/SIMD.wat
@@ -1,0 +1,4 @@
+﻿(module
+  (func $echo_v128 (param v128) (result v128) local.get 0)
+  (export "$echo_v128" (func $echo_v128))
+)

--- a/tests/Modules/SharedMemory.wat
+++ b/tests/Modules/SharedMemory.wat
@@ -1,0 +1,3 @@
+﻿(module
+  (memory 1 1 shared)
+)


### PR DESCRIPTION
Added some more tests and fixed one small issue in the process:
 - Modified `wasmtime_engine_increment_epoch` to return `void` instead of `IntPtr`. Based on signature from these docs: https://docs.wasmtime.dev/c-api/engine_8h.html

## Proposal

While writing the tests for the config I also came across an awkward error to do with disabling bulk memory. As documented [here](https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_bulk_memory) if `Bulk memory = false` then it is required that `Reference Type = false`. If that is not the case then creating the engine throws this exception: `System.Runtime.InteropServices.SEHException: 'External component has thrown an exception.'`, with absolutely no indication of what is wrong.

I would like to modify `WithBulkMemory` to look like this:

```csharp
public Config WithBulkMemory(bool enable)
{
    Native.wasmtime_config_wasm_bulk_memory_set(handle, enable);
    return WithReferenceTypes(false);
}
```

i.e. disabling bulk memory automatically disables reference types.