### PR TITLE
Move allocating the `Caller` into the `try` block (follow-up to #188)

### DIFF
--- a/src/Function.FromCallback.cs
+++ b/src/Function.FromCallback.cs
@@ -55,11 +55,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             );
 
@@ -128,11 +128,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT.Unbox(storeContext, caller, args_and_results[0]));
 
@@ -203,11 +203,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]));
@@ -281,11 +281,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -362,11 +362,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -446,11 +446,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -533,11 +533,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -623,11 +623,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -716,11 +716,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -812,11 +812,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -911,11 +911,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1013,11 +1013,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1118,11 +1118,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1202,11 +1202,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             );
 
@@ -1278,11 +1278,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT.Unbox(storeContext, caller, args_and_results[0]));
 
@@ -1356,11 +1356,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]));
@@ -1437,11 +1437,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1521,11 +1521,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1608,11 +1608,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1698,11 +1698,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1791,11 +1791,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1887,11 +1887,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1986,11 +1986,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2088,11 +2088,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2193,11 +2193,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2301,11 +2301,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2388,11 +2388,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             );
 
@@ -2467,11 +2467,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT.Unbox(storeContext, caller, args_and_results[0]));
 
@@ -2548,11 +2548,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]));
@@ -2632,11 +2632,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2719,11 +2719,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2809,11 +2809,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2902,11 +2902,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2998,11 +2998,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3097,11 +3097,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3199,11 +3199,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3304,11 +3304,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3412,11 +3412,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3523,11 +3523,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3613,11 +3613,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             );
 
@@ -3695,11 +3695,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT.Unbox(storeContext, caller, args_and_results[0]));
 
@@ -3779,11 +3779,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]));
@@ -3866,11 +3866,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3956,11 +3956,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4049,11 +4049,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4145,11 +4145,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4244,11 +4244,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4346,11 +4346,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4451,11 +4451,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4559,11 +4559,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4670,11 +4670,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4784,11 +4784,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4877,11 +4877,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             );
 
@@ -4962,11 +4962,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT.Unbox(storeContext, caller, args_and_results[0]));
 
@@ -5049,11 +5049,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]));
@@ -5139,11 +5139,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5232,11 +5232,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5328,11 +5328,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5427,11 +5427,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5529,11 +5529,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5634,11 +5634,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5742,11 +5742,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5853,11 +5853,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5967,11 +5967,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -6084,11 +6084,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -6167,11 +6167,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller);
 
@@ -6236,11 +6236,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT.Unbox(storeContext, caller, args_and_results[0]));
@@ -6307,11 +6307,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -6380,11 +6380,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -6455,11 +6455,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -6532,11 +6532,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -6611,11 +6611,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -6692,11 +6692,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -6775,11 +6775,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -6860,11 +6860,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -6947,11 +6947,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7036,11 +7036,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7127,11 +7127,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7208,11 +7208,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller);
 
@@ -7279,11 +7279,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT.Unbox(storeContext, caller, args_and_results[0]));
@@ -7352,11 +7352,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7427,11 +7427,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7504,11 +7504,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7583,11 +7583,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7664,11 +7664,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7747,11 +7747,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7832,11 +7832,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7919,11 +7919,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8008,11 +8008,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8099,11 +8099,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8192,11 +8192,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8275,11 +8275,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller);
 
@@ -8348,11 +8348,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT.Unbox(storeContext, caller, args_and_results[0]));
@@ -8423,11 +8423,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8500,11 +8500,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8579,11 +8579,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8660,11 +8660,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8743,11 +8743,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8828,11 +8828,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8915,11 +8915,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9004,11 +9004,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9095,11 +9095,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9188,11 +9188,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9283,11 +9283,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9368,11 +9368,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller);
 
@@ -9443,11 +9443,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT.Unbox(storeContext, caller, args_and_results[0]));
@@ -9520,11 +9520,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9599,11 +9599,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9680,11 +9680,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9763,11 +9763,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9848,11 +9848,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9935,11 +9935,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10024,11 +10024,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10115,11 +10115,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10208,11 +10208,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10303,11 +10303,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10400,11 +10400,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10487,11 +10487,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller);
 
@@ -10564,11 +10564,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT.Unbox(storeContext, caller, args_and_results[0]));
@@ -10643,11 +10643,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10724,11 +10724,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10807,11 +10807,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10892,11 +10892,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10979,11 +10979,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11068,11 +11068,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11159,11 +11159,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11252,11 +11252,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11347,11 +11347,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11444,11 +11444,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11543,11 +11543,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -42,8 +42,7 @@ namespace Wasmtime
             {
                 Native.WasmtimeFuncCallback func = (env, callerPtr, args, nargs, results, nresults) =>
                 {
-                    using var caller = new Caller(callerPtr);
-                    return InvokeCallback(callback, callbackInvokeMethod, caller, hasCaller, args, (int)nargs, results, (int)nresults, resultKinds, returnsTuple);
+                    return InvokeCallback(callback, callbackInvokeMethod, callerPtr, hasCaller, args, (int)nargs, results, (int)nresults, resultKinds, returnsTuple);
                 };
 
                 Native.wasmtime_func_new(
@@ -1918,10 +1917,12 @@ namespace Wasmtime
             return new Function.TypeHandle(Function.Native.wasm_functype_new(new ValueTypeArray(parameters), new ValueTypeArray(results)));
         }
 
-        internal unsafe static IntPtr InvokeCallback(Delegate callback, MethodInfo callbackInvokeMethod, Caller caller, bool passCaller, Value* args, int nargs, Value* results, int nresults, IReadOnlyList<ValueKind> resultKinds, bool returnsTuple)
+        internal unsafe static IntPtr InvokeCallback(Delegate callback, MethodInfo callbackInvokeMethod, IntPtr callerPtr, bool passCaller, Value* args, int nargs, Value* results, int nresults, IReadOnlyList<ValueKind> resultKinds, bool returnsTuple)
         {
             try
             {
+                using var caller = new Caller(callerPtr);
+
                 var offset = passCaller ? 1 : 0;
                 var invokeArgs = new object?[nargs + offset];
 

--- a/src/FunctionCallbackOverloadTemplates.t4
+++ b/src/FunctionCallbackOverloadTemplates.t4
@@ -4,11 +4,11 @@
 
 void GenerateCallbackContent(bool hasCaller, int resultCount, int parameterCount) {
 #>
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = <#= hasCaller ? "" : "!converterRequiresStore ? null : " #>new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = <#= hasCaller ? "" : "!converterRequiresStore ? null : " #>new Caller(callerPtr);
+
                         <#= resultCount > 0 ? "var result = " : "" #>callback(
                             <#
     if (hasCaller)

--- a/src/Linker.DefineFunction.cs
+++ b/src/Linker.DefineFunction.cs
@@ -64,11 +64,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             );
 
@@ -156,11 +156,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT.Unbox(storeContext, caller, args_and_results[0]));
 
@@ -250,11 +250,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]));
@@ -347,11 +347,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -447,11 +447,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -550,11 +550,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -656,11 +656,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -765,11 +765,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -877,11 +877,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -992,11 +992,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1110,11 +1110,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1231,11 +1231,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1355,11 +1355,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1458,11 +1458,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             );
 
@@ -1553,11 +1553,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT.Unbox(storeContext, caller, args_and_results[0]));
 
@@ -1650,11 +1650,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]));
@@ -1750,11 +1750,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1853,11 +1853,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -1959,11 +1959,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2068,11 +2068,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2180,11 +2180,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2295,11 +2295,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2413,11 +2413,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2534,11 +2534,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2658,11 +2658,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2785,11 +2785,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -2891,11 +2891,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             );
 
@@ -2989,11 +2989,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT.Unbox(storeContext, caller, args_and_results[0]));
 
@@ -3089,11 +3089,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]));
@@ -3192,11 +3192,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3298,11 +3298,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3407,11 +3407,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3519,11 +3519,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3634,11 +3634,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3752,11 +3752,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3873,11 +3873,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -3997,11 +3997,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4124,11 +4124,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4254,11 +4254,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4363,11 +4363,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             );
 
@@ -4464,11 +4464,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT.Unbox(storeContext, caller, args_and_results[0]));
 
@@ -4567,11 +4567,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]));
@@ -4673,11 +4673,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4782,11 +4782,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -4894,11 +4894,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5009,11 +5009,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5127,11 +5127,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5248,11 +5248,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5372,11 +5372,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5499,11 +5499,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5629,11 +5629,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5762,11 +5762,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -5874,11 +5874,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             );
 
@@ -5978,11 +5978,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT.Unbox(storeContext, caller, args_and_results[0]));
 
@@ -6084,11 +6084,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]));
@@ -6193,11 +6193,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -6305,11 +6305,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -6420,11 +6420,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -6538,11 +6538,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -6659,11 +6659,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -6783,11 +6783,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -6910,11 +6910,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -7040,11 +7040,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -7173,11 +7173,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -7309,11 +7309,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
                         var result = callback(
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
                             convT2.Unbox(storeContext, caller, args_and_results[1]),
@@ -7411,11 +7411,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller);
 
@@ -7499,11 +7499,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT.Unbox(storeContext, caller, args_and_results[0]));
@@ -7589,11 +7589,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7681,11 +7681,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7775,11 +7775,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7871,11 +7871,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -7969,11 +7969,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8069,11 +8069,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8171,11 +8171,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8275,11 +8275,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8381,11 +8381,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8489,11 +8489,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8599,11 +8599,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8699,11 +8699,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller);
 
@@ -8789,11 +8789,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT.Unbox(storeContext, caller, args_and_results[0]));
@@ -8881,11 +8881,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -8975,11 +8975,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9071,11 +9071,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9169,11 +9169,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9269,11 +9269,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9371,11 +9371,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9475,11 +9475,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9581,11 +9581,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9689,11 +9689,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9799,11 +9799,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -9911,11 +9911,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10013,11 +10013,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller);
 
@@ -10105,11 +10105,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT.Unbox(storeContext, caller, args_and_results[0]));
@@ -10199,11 +10199,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10295,11 +10295,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10393,11 +10393,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10493,11 +10493,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10595,11 +10595,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10699,11 +10699,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10805,11 +10805,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -10913,11 +10913,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11023,11 +11023,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11135,11 +11135,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11249,11 +11249,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11353,11 +11353,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller);
 
@@ -11447,11 +11447,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT.Unbox(storeContext, caller, args_and_results[0]));
@@ -11543,11 +11543,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11641,11 +11641,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11741,11 +11741,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11843,11 +11843,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -11947,11 +11947,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -12053,11 +12053,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -12161,11 +12161,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -12271,11 +12271,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -12383,11 +12383,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -12497,11 +12497,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -12613,11 +12613,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -12719,11 +12719,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller);
 
@@ -12815,11 +12815,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT.Unbox(storeContext, caller, args_and_results[0]));
@@ -12913,11 +12913,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -13013,11 +13013,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -13115,11 +13115,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -13219,11 +13219,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -13325,11 +13325,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -13433,11 +13433,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -13543,11 +13543,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -13655,11 +13655,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -13769,11 +13769,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -13885,11 +13885,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),
@@ -14003,11 +14003,11 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-                    var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                    using var caller = new Caller(callerPtr);
-
                     try
                     {
+                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+                        using var caller = new Caller(callerPtr);
+
                         var result = callback(
                             caller,
                             convT1.Unbox(storeContext, caller, args_and_results[0]),

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -362,8 +362,7 @@ namespace Wasmtime
             {
                 Function.Native.WasmtimeFuncCallback func = (env, callerPtr, args, nargs, results, nresults) =>
                 {
-                    using var caller = new Caller(callerPtr);
-                    return Function.InvokeCallback(callback, callbackInvokeMethod, caller, hasCaller, args, (int)nargs, results, (int)nresults, resultKinds, returnsTuple);
+                    return Function.InvokeCallback(callback, callbackInvokeMethod, callerPtr, hasCaller, args, (int)nargs, results, (int)nresults, resultKinds, returnsTuple);
                 };
 
                 var moduleBytes = Encoding.UTF8.GetBytes(module);


### PR DESCRIPTION
In #188, I missed that allocating the `Caller` was done outside of the `try` block, and that could potentially throw an `OutOfMemoryException` when the system is low on memory.

This PR moves allocating the `Caller` into the `try` block, to prevent the .NET Runtime on Windows unwinding the stack to the next .NET exception handler in case the allocation threw an OOME (which would be incompatible with Wasmtime) and instead attempts to convert it into a `wasm_trap_t*`.

Thanks!