### PR TITLE
Remove fields from `ExternUnion` that were removed in the C API

### DIFF
--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -60,12 +60,6 @@ namespace Wasmtime
 
         [FieldOffset(0)]
         public ExternMemory memory;
-
-        [FieldOffset(0)]
-        public ExternInstance instance;
-
-        [FieldOffset(0)]
-        public IntPtr module;
     }
 
     [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
Remove fields from `ExternUnion` that were removed in the C API with bytecodealliance/wasmtime#3958.

This is a follow-up to #98.