### PR TITLE
Fix Inconsistent Line Endings

### DIFF
--- a/src/FunctionCallbackOverloadTemplates.t4
+++ b/src/FunctionCallbackOverloadTemplates.t4
@@ -1,5 +1,5 @@
 ﻿<#
-// This file contains the functions used in Function.FromCallback.ts and Linker.DefineFunction.ts
+// This file contains the functions used in Function.FromCallback.tt and Linker.DefineFunction.tt
 // in order to generate overloads with different parameter and result types for Action<...>/Func<...>.
 
 // Suppress the "not used" warning when this file is referenced but the function is not called.
@@ -258,9 +258,9 @@ IEnumerable<(
                     delegateType.ToString(),
                     callbackParameterTypeExpressions.ToString(),
                     callbackReturnTypeExpression,
-                    parameterConverters.ToString(),
-                    resultConverters.ToString(),
-                    converterRequiresStoreCode.ToString()
+                    parameterConverters.ToString().Replace("\r\n", "\n"),
+                    resultConverters.ToString().Replace("\r\n", "\n"),
+                    converterRequiresStoreCode.ToString().Replace("\r\n", "\n")
                 );
             }
         }


### PR DESCRIPTION
Since the T4 templates were introduced I've been getting warnings from Visual Studio/Unity about inconsistent line endings. This seems to be because the `StringBuilder` in `FunctionCallbackOverloadTemplates.t4` is using `\r\n` (the correct line ending for Windows) but the t4 file itself is written with `\n` line endings.

For now I've modified the template to replace all generated `\r\n` with `\n` for consistency. But I'm not sure that's ultimately the right approach, can anyone suggest any better alternatives (e.g. can t4 be made to normalize things)?