### PR TITLE
Fixed bug in linker TryGetExtern method

### DIFF
--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -393,7 +393,7 @@ namespace Wasmtime
         {
             unsafe
             {
-                var moduleBytes = Encoding.UTF8.GetBytes(name);
+                var moduleBytes = Encoding.UTF8.GetBytes(module);
                 var nameBytes = Encoding.UTF8.GetBytes(name);
                 fixed (byte* modulePtr = moduleBytes, namePtr = nameBytes)
                 {

--- a/tests/LinkerFunctionsTests.cs
+++ b/tests/LinkerFunctionsTests.cs
@@ -166,6 +166,24 @@ namespace Wasmtime.Tests
             result.Should().Be(V128.AllBitsSet);
         }
 
+        [Fact]
+        public void ItFetchesDefinedFunctions()
+        {
+            var func = Linker.GetFunction(Store, "env", "add")!;
+
+            func.Should().NotBeNull();
+            func.Parameters.Should().HaveCount(2);
+            func.Results.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void ItReturnsNullForUndefinedFunctions()
+        {
+            var func = Linker.GetFunction(Store, "nosuch", "function")!;
+
+            func.Should().BeNull();
+        }
+
         public void Dispose()
         {
             Store.Dispose();


### PR DESCRIPTION
Fix passing `name` as `module` in `TryGetExtern`