### PR TITLE
Yet more tests

### DIFF
--- a/src/Export.cs
+++ b/src/Export.cs
@@ -154,7 +154,7 @@ namespace Wasmtime
 
             Kind = ValueType.ToKind(Global.Native.wasm_globaltype_content(type));
 
-            Mutability = (Mutability)Global.Native.wasm_globaltype_mutability(type);
+            Mutability = new Mutability(Global.Native.wasm_globaltype_mutability(type));
         }
 
         /// <summary>

--- a/src/Global.cs
+++ b/src/Global.cs
@@ -25,7 +25,9 @@ namespace Wasmtime
         internal Mutability(byte value)
         {
             if (value > 1)
+            {
                 throw new ArgumentOutOfRangeException($"Invalid Mutability value `{value}`");
+            }
 
             Value = value;
         }

--- a/src/Global.cs
+++ b/src/Global.cs
@@ -7,16 +7,68 @@ namespace Wasmtime
     /// <summary>
     /// Represents the mutability of a WebAssembly global value.
     /// </summary>
-    public enum Mutability : byte
+    public readonly struct Mutability
+        : IEquatable<Mutability>
     {
         /// <summary>
         /// The global value is immutable (i.e. constant).
         /// </summary>
-        Immutable,
+        public static readonly Mutability Immutable = new(0);
+
         /// <summary>
         /// The global value is mutable.
         /// </summary>
-        Mutable,
+        public static readonly Mutability Mutable = new(1);
+
+        internal readonly byte Value;
+
+        internal Mutability(byte value)
+        {
+            if (value > 1)
+                throw new ArgumentOutOfRangeException($"Invalid Mutability value `{value}`");
+
+            Value = value;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(Mutability other)
+        {
+            return Value == other.Value;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is Mutability other && Equals(other);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Compare a to b and return true if they are equal
+        /// </summary>
+        /// <param name="a">First item to compare</param>
+        /// <param name="b">Second item to compare</param>
+        /// <returns></returns>
+        public static bool operator ==(Mutability a, Mutability b)
+        {
+            return a.Equals(b);
+        }
+
+        /// <summary>
+        /// Compare a to b and return true if they are not equal
+        /// </summary>
+        /// <param name="a">First item to compare</param>
+        /// <param name="b">Second item to compare</param>
+        /// <returns></returns>
+        public static bool operator !=(Mutability a, Mutability b)
+        {
+            return !a.Equals(b);
+        }
     }
 
     /// <summary>
@@ -46,6 +98,11 @@ namespace Wasmtime
                 ValueType.FromKind(kind),
                 mutability
             ));
+
+            if (globalType.IsInvalid)
+            {
+                throw new InvalidOperationException("Failed to create global type, invalid ValueKind or Mutability");
+            }
 
             var value = Value.FromObject(initialValue, Kind);
             var error = Native.wasmtime_global_new(store.Context.handle, globalType, in value, out this.global);
@@ -128,7 +185,7 @@ namespace Wasmtime
             using var type = new TypeHandle(Native.wasmtime_global_type(store.Context.handle, this.global));
 
             this.Kind = ValueType.ToKind(Native.wasm_globaltype_content(type.DangerousGetHandle()));
-            this.Mutability = (Mutability)Native.wasm_globaltype_mutability(type.DangerousGetHandle());
+            this.Mutability = new Mutability(Native.wasm_globaltype_mutability(type.DangerousGetHandle()));
         }
 
         internal class TypeHandle : SafeHandleZeroOrMinusOneIsInvalid

--- a/src/Import.cs
+++ b/src/Import.cs
@@ -173,7 +173,7 @@ namespace Wasmtime
 
             Kind = ValueType.ToKind(Global.Native.wasm_globaltype_content(type));
 
-            Mutability = (Mutability)Global.Native.wasm_globaltype_mutability(type);
+            Mutability = new Mutability(Global.Native.wasm_globaltype_mutability(type));
         }
 
         /// <summary>

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -501,11 +501,6 @@ namespace Wasmtime
         /// <remarks>This method will invalidate previously returned values from `GetSpan`.</remarks>
         public long Grow(long delta)
         {
-            if (store is null)
-            {
-                throw new ArgumentNullException(nameof(store));
-            }
-
             if (delta < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(delta));

--- a/tests/FunctionExportsTests.cs
+++ b/tests/FunctionExportsTests.cs
@@ -13,9 +13,15 @@ namespace Wasmtime.Tests
 
     public class FunctionExportsTests : IClassFixture<FunctionExportsFixture>
     {
+        private Store Store { get; set; }
+
+        private Linker Linker { get; set; }
+
         public FunctionExportsTests(FunctionExportsFixture fixture)
         {
             Fixture = fixture;
+            Store = new Store(Fixture.Engine);
+            Linker = new Linker(Fixture.Engine);
         }
 
         private FunctionExportsFixture Fixture { get; set; }
@@ -34,6 +40,24 @@ namespace Wasmtime.Tests
         public void ItHasTheExpectedNumberOfExportedFunctions()
         {
             GetFunctionExports().Count().Should().Be(Fixture.Module.Exports.Count(e => e is FunctionExport));
+        }
+
+        [Fact]
+        public void ItReturnsNullForNonExistantFunction()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+
+            var i32 = instance.GetFunction("no_such_func");
+            i32.Should().BeNull();
+        }
+
+        [Fact]
+        public void ItReturnsNullForWrongTypeSignature()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+
+            var i32 = instance.GetFunction("one_i32_param_no_results", typeof(float));
+            i32.Should().BeNull();
         }
 
         public static IEnumerable<object[]> GetFunctionExports()

--- a/tests/GlobalExportsTests.cs
+++ b/tests/GlobalExportsTests.cs
@@ -120,6 +120,15 @@ namespace Wasmtime.Tests
                 .WithMessage("The global is immutable and cannot be changed.");
         }
 
+        [Fact]
+        public void ItReturnsNullForNonExistantGlobal()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+
+            var i32 = instance.GetGlobal("no_such_global");
+            i32.Should().BeNull();
+        }
+
         public static IEnumerable<object[]> GetGlobalExports()
         {
             yield return new object[] {

--- a/tests/GlobalImportBindingTests.cs
+++ b/tests/GlobalImportBindingTests.cs
@@ -25,6 +25,20 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItFailsWithNullStore()
+        {
+            var act = () => new Global(null!, ValueKind.Int64, 0, Mutability.Mutable);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ItFailsWithInvalidValueKind()
+        {
+            var act = () => new Global(Store, (ValueKind)byte.MaxValue, 0, Mutability.Mutable);
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
         public void ItFailsToInstantiateWithMissingImport()
         {
             Action action = () => { Linker.Instantiate(Store, Fixture.Module); };

--- a/tests/LinkerFunctionsTests.cs
+++ b/tests/LinkerFunctionsTests.cs
@@ -184,6 +184,20 @@ namespace Wasmtime.Tests
             func.Should().BeNull();
         }
 
+        [Fact]
+        public void ItBindsComplexFunction()
+        {
+            using var store = new Store(Fixture.Engine);
+
+            Linker.DefineFunction("", "complex", ((Caller caller) =>
+            {
+                return (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
+            }));
+
+            var func = Linker.GetFunction(store, "", "complex");
+            func.Should().NotBeNull();
+        }
+
         public void Dispose()
         {
             Store.Dispose();

--- a/tests/MemoryAccessTests.cs
+++ b/tests/MemoryAccessTests.cs
@@ -26,6 +26,39 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItGrows()
+        {
+            var memory = new Memory(Store, 1, 4);
+            memory.GetSize().Should().Be(1);
+            memory.Grow(1);
+            memory.GetSize().Should().Be(2);
+            memory.Grow(2);
+            memory.GetSize().Should().Be(4);
+        }
+
+        [Fact]
+        public void ItFailsToShrink()
+        {
+            var memory = new Memory(Store, 1, 4);
+            memory.GetSize().Should().Be(1);
+            memory.Grow(1);
+            memory.GetSize().Should().Be(2);
+
+            var act = () => { memory.Grow(-1); };
+            act.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void ItFailsToGrowOverLimit()
+        {
+            var memory = new Memory(Store, 1, 4);
+            memory.GetSize().Should().Be(1);
+
+            var act = () => { memory.Grow(10); };
+            act.Should().Throw<WasmtimeException>();
+        }
+
+        [Fact]
         public unsafe void ItCanAccessMemoryWith65536Pages()
         {
             var memoryExport = Fixture.Module.Exports.OfType<MemoryExport>().Single();

--- a/tests/MemoryExportsTests.cs
+++ b/tests/MemoryExportsTests.cs
@@ -39,6 +39,15 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItReturnsNullForNonExistantMemory()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+
+            var i32 = instance.GetMemory("no_such_mem");
+            i32.Should().BeNull();
+        }
+
+        [Fact]
         public void ItHasTheExpectedNumberOfExportedTables()
         {
             GetMemoryExports().Count().Should().Be(Fixture.Module.Exports.Count(e => e is MemoryExport));

--- a/tests/MemoryImportBindingTests.cs
+++ b/tests/MemoryImportBindingTests.cs
@@ -36,6 +36,63 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItFailsToInstantiateWithNullStore()
+        {
+            Action action = () => { new Memory(null!, 0, 1); };
+
+            action
+               .Should()
+               .Throw<ArgumentNullException>()
+               .WithMessage("Value cannot be null. (Parameter 'store')");
+        }
+
+        [Fact]
+        public void ItFailsToInstantiateWithDisposedStore()
+        {
+            var store = new Store(Fixture.Engine);
+            store.Dispose();
+
+            Action action = () => { new Memory(store, 0, 1); };
+
+            action
+               .Should()
+               .Throw<ObjectDisposedException>();
+        }
+
+        [Fact]
+        public void ItFailsToInstantiateWithNegativeMinimum()
+        {
+            Action action = () => { new Memory(Store, -1, 1); };
+
+            action
+               .Should()
+               .Throw<ArgumentOutOfRangeException>()
+               .WithMessage("Specified argument was out of the range of valid values. (Parameter 'minimum')");
+        }
+
+        [Fact]
+        public void ItFailsToInstantiateWithNegativeMaximum()
+        {
+            Action action = () => { new Memory(Store, 0, -1); };
+
+            action
+               .Should()
+               .Throw<ArgumentOutOfRangeException>()
+               .WithMessage("Specified argument was out of the range of valid values. (Parameter 'maximum')");
+        }
+
+        [Fact]
+        public void ItFailsToInstantiateWithMaximumLessThanMinimum()
+        {
+            Action action = () => { new Memory(Store, 20, 10); };
+
+            action
+               .Should()
+               .Throw<ArgumentException>()
+               .WithMessage("The maximum cannot be less than the minimum. (Parameter 'maximum')");
+        }
+
+        [Fact]
         public void ItBindsTheGlobalsCorrectly()
         {
             var mem = new Memory(Store, 1);

--- a/tests/TableExportsTests.cs
+++ b/tests/TableExportsTests.cs
@@ -67,6 +67,15 @@ namespace Wasmtime.Tests
             table3.Maximum.Should().Be(1000);
         }
 
+        [Fact]
+        public void ItReturnsNullForNonExistantTable()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+
+            var table1 = instance.GetTable("no_such_table");
+            table1.Should().BeNull();
+        }
+
         public static IEnumerable<object[]> GetTableExports()
         {
             yield return new object[] {

--- a/tests/ValueBoxTests.cs
+++ b/tests/ValueBoxTests.cs
@@ -153,6 +153,14 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItFailsToConvertLongByteSpanToV128()
+        {
+            var b = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+            var act = () => new V128(b.AsSpan());
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
         public void ItConvertsExternRef()
         {
             var o = new object();


### PR DESCRIPTION
Added a number of tests.

In particular found one test which would crash the entire test runner (seems to be due to an access violation exception):

```csharp
[Fact]
public void ItFailsWithInvalidMutability()
{
    var act = () => new Global(Store, ValueKind.Int64, 0, (Mutability)13);
    act.Should().Throw<InvalidOperationException>();
}
```

This was caused by two things:
 - Immediate problem was a missing check if the returned value is `IntPtr.zero` in this one particular case (added that check).
 - Casting numbers into Mutability should not be possible. Replaced `Mutability` with a struct which has two predefined values (Mutable and Immutable). This should be _almost_ source compatible with the old enum - the only thing it does not allow is casting numbers into `Mutability`.