### PR TITLE
Keep the `Store` alive until its `StoreContext` is no longer used

### DIFF
--- a/src/Engine.cs
+++ b/src/Engine.cs
@@ -41,7 +41,7 @@ namespace Wasmtime
         /// </summary>
         public void IncrementEpoch()
         {
-            Native.wasmtime_engine_increment_epoch(handle.DangerousGetHandle());
+            Native.wasmtime_engine_increment_epoch(handle);
         }
 
         internal Handle NativeHandle
@@ -84,7 +84,7 @@ namespace Wasmtime
             public static extern void wasm_engine_delete(IntPtr engine);
 
             [DllImport(LibraryName)]
-            public static extern void wasmtime_engine_increment_epoch(IntPtr engine);
+            public static extern void wasmtime_engine_increment_epoch(Handle engine);
         }
 
         private readonly Handle handle;

--- a/src/Function.FromCallback.cs
+++ b/src/Function.FromCallback.cs
@@ -81,6 +81,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -153,6 +155,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -229,6 +233,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -308,6 +314,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -390,6 +398,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -475,6 +485,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -563,6 +575,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -654,6 +668,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -748,6 +764,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -845,6 +863,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -945,6 +965,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -1048,6 +1070,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -1155,6 +1179,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -1228,6 +1254,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -1304,6 +1332,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -1383,6 +1413,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -1465,6 +1497,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -1550,6 +1584,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -1638,6 +1674,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -1729,6 +1767,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -1823,6 +1863,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -1920,6 +1962,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -2020,6 +2064,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -2123,6 +2169,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -2229,6 +2277,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -2339,6 +2389,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -2415,6 +2467,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -2494,6 +2548,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -2576,6 +2632,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -2661,6 +2719,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -2749,6 +2809,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -2840,6 +2902,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -2934,6 +2998,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -3031,6 +3097,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -3131,6 +3199,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -3234,6 +3304,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -3340,6 +3412,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -3449,6 +3523,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -3562,6 +3638,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -3641,6 +3719,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -3723,6 +3803,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -3808,6 +3890,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -3896,6 +3980,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -3987,6 +4073,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -4081,6 +4169,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -4178,6 +4268,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -4278,6 +4370,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -4381,6 +4475,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -4487,6 +4583,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -4596,6 +4694,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -4708,6 +4808,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -4824,6 +4926,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -4906,6 +5010,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -4991,6 +5097,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -5079,6 +5187,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -5170,6 +5280,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -5264,6 +5376,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -5361,6 +5475,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -5461,6 +5577,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -5564,6 +5682,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -5670,6 +5790,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -5779,6 +5901,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -5891,6 +6015,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6006,6 +6132,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6125,6 +6253,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -6192,6 +6322,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6262,6 +6394,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6334,6 +6468,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6408,6 +6544,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6484,6 +6622,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6562,6 +6702,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6642,6 +6784,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6724,6 +6868,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6808,6 +6954,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6894,6 +7042,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -6982,6 +7132,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7072,6 +7224,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7165,6 +7319,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -7234,6 +7390,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7306,6 +7464,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7380,6 +7540,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7456,6 +7618,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7534,6 +7698,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7614,6 +7780,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7696,6 +7864,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7780,6 +7950,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7866,6 +8038,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -7954,6 +8128,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8044,6 +8220,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8136,6 +8314,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8231,6 +8411,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -8302,6 +8484,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8376,6 +8560,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8452,6 +8638,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8530,6 +8718,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8610,6 +8800,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8692,6 +8884,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8776,6 +8970,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8862,6 +9058,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -8950,6 +9148,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9040,6 +9240,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9132,6 +9334,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9226,6 +9430,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9323,6 +9529,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -9396,6 +9604,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9472,6 +9682,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9550,6 +9762,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9630,6 +9844,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9712,6 +9928,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9796,6 +10014,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9882,6 +10102,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -9970,6 +10192,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -10060,6 +10284,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -10152,6 +10378,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -10246,6 +10474,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -10342,6 +10572,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -10441,6 +10673,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -10516,6 +10750,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -10594,6 +10830,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -10674,6 +10912,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -10756,6 +10996,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -10840,6 +11082,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -10926,6 +11170,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -11014,6 +11260,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -11104,6 +11352,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -11196,6 +11446,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -11290,6 +11542,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -11386,6 +11640,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -11484,6 +11740,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
@@ -11584,6 +11842,8 @@ namespace Wasmtime
                     Finalizer,
                     out var externFunc
                 );
+
+                GC.KeepAlive(store);
 
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }

--- a/src/Function.FromCallback.tt
+++ b/src/Function.FromCallback.tt
@@ -90,6 +90,8 @@ foreach (var (hasCaller, resultCount, parameterCount, methodGenerics, delegateTy
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -54,6 +54,8 @@ namespace Wasmtime
                     out var externFunc
                 );
 
+                GC.KeepAlive(store);
+
                 return new Function(store, externFunc, parameterKinds, resultKinds);
             }
         }
@@ -359,6 +361,7 @@ namespace Wasmtime
             fixed (Value* resultsPtr = resultsOut)
             {
                 error = Native.wasmtime_func_call(context.handle, func, argsPtr, (nuint)Parameters.Count, resultsPtr, (nuint)Results.Count, out trap);
+                GC.KeepAlive(store);
             }
 
             if (error != IntPtr.Zero)
@@ -389,6 +392,7 @@ namespace Wasmtime
             fixed (ValueRaw* argsAndResultsPtr = argumentsAndResults)
             {
                 error = Native.wasmtime_func_call_unchecked(storeContext.handle, func, argsAndResultsPtr, out trap);
+                GC.KeepAlive(store);
             }
 
             if (error != IntPtr.Zero)
@@ -428,6 +432,7 @@ namespace Wasmtime
             if (!this.IsNull)
             {
                 using var type = new TypeHandle(Native.wasmtime_func_type(store.Context.handle, this.func));
+                GC.KeepAlive(store);
 
                 unsafe
                 {

--- a/src/Global.cs
+++ b/src/Global.cs
@@ -49,6 +49,8 @@ namespace Wasmtime
 
             var value = Value.FromObject(initialValue, Kind);
             var error = Native.wasmtime_global_new(store.Context.handle, globalType, in value, out this.global);
+            GC.KeepAlive(store);
+
             value.Dispose();
 
             if (error != IntPtr.Zero)
@@ -65,6 +67,8 @@ namespace Wasmtime
         {
             var context = store.Context;
             Native.wasmtime_global_get(context.handle, this.global, out var v);
+            GC.KeepAlive(store);
+
             var val = v.ToObject(store);
             v.Dispose();
             return val;
@@ -83,6 +87,8 @@ namespace Wasmtime
 
             var v = Value.FromObject(value, Kind);
             Native.wasmtime_global_set(store.Context.handle, this.global, in v);
+            GC.KeepAlive(store);
+
             v.Dispose();
         }
 
@@ -126,6 +132,7 @@ namespace Wasmtime
             this.store = store;
 
             using var type = new TypeHandle(Native.wasmtime_global_type(store.Context.handle, this.global));
+            GC.KeepAlive(store);
 
             this.Kind = ValueType.ToKind(Native.wasm_globaltype_content(type.DangerousGetHandle()));
             this.Mutability = (Mutability)Native.wasm_globaltype_mutability(type.DangerousGetHandle());
@@ -212,6 +219,7 @@ namespace Wasmtime
             {
                 var context = _store.Context;
                 Native.wasmtime_global_get(context.handle, _global.global, out var v);
+                GC.KeepAlive(_store);
 
                 var result = _converter.Unbox(_store, v.ToValueBox());
                 v.Dispose();
@@ -234,6 +242,7 @@ namespace Wasmtime
                 {
                     var context = _store.Context;
                     Native.wasmtime_global_set(context.handle, _global.global, in v);
+                    GC.KeepAlive(_store);
                 }
             }
 

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -49,6 +49,7 @@ namespace Wasmtime
                 }
 
                 var error = Native.wasmtime_instance_new(store.Context.handle, module.NativeHandle, externs, (UIntPtr)imports.Length, out this.instance, out var trap);
+                GC.KeepAlive(store);
 
                 if (error != IntPtr.Zero)
                 {
@@ -521,6 +522,8 @@ namespace Wasmtime
                 return null;
             }
 
+            GC.KeepAlive(_store);
+
             return new Function(_store, ext.of.func);
         }
 
@@ -537,6 +540,8 @@ namespace Wasmtime
                 return null;
             }
 
+            GC.KeepAlive(_store);
+
             return new Table(_store, ext.of.table);
         }
 
@@ -551,6 +556,8 @@ namespace Wasmtime
             {
                 return null;
             }
+
+            GC.KeepAlive(_store);
 
             return new Memory(_store, ext.of.memory);
         }
@@ -567,6 +574,8 @@ namespace Wasmtime
             {
                 return null;
             }
+
+            GC.KeepAlive(_store);
 
             return new Global(_store, ext.of.global);
         }

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -123,6 +123,8 @@ namespace Wasmtime
                 fixed (byte* namePtr = nameBytes)
                 {
                     var error = Native.wasmtime_linker_define_instance(handle, store.Context.handle, namePtr, (UIntPtr)nameBytes.Length, instance.instance);
+                    GC.KeepAlive(store);
+
                     if (error != IntPtr.Zero)
                     {
                         throw WasmtimeException.FromOwnedError(error);
@@ -150,6 +152,8 @@ namespace Wasmtime
             }
 
             var error = Native.wasmtime_linker_instantiate(handle, store.Context.handle, module.NativeHandle, out var instance, out var trap);
+            GC.KeepAlive(store);
+
             if (error != IntPtr.Zero)
             {
                 throw WasmtimeException.FromOwnedError(error);
@@ -186,6 +190,8 @@ namespace Wasmtime
                 fixed (byte* namePtr = nameBytes)
                 {
                     var error = Native.wasmtime_linker_module(handle, store.Context.handle, namePtr, (UIntPtr)nameBytes.Length, module.NativeHandle);
+                    GC.KeepAlive(store);
+
                     if (error != IntPtr.Zero)
                     {
                         throw WasmtimeException.FromOwnedError(error);
@@ -220,6 +226,8 @@ namespace Wasmtime
                 fixed (byte* namePtr = nameBytes)
                 {
                     var error = Native.wasmtime_linker_get_default(handle, context.handle, namePtr, (UIntPtr)nameBytes.Length, out var func);
+                    GC.KeepAlive(store);
+
                     if (error != IntPtr.Zero)
                     {
                         throw WasmtimeException.FromOwnedError(error);
@@ -250,6 +258,8 @@ namespace Wasmtime
                 return null;
             }
 
+            GC.KeepAlive(store);
+
             return new Function(store, ext.of.func);
         }
 
@@ -272,6 +282,8 @@ namespace Wasmtime
             {
                 return null;
             }
+
+            GC.KeepAlive(store);
 
             return new Table(store, ext.of.table);
         }
@@ -296,6 +308,8 @@ namespace Wasmtime
                 return null;
             }
 
+            GC.KeepAlive(store);
+
             return new Memory(store, ext.of.memory);
         }
 
@@ -318,6 +332,8 @@ namespace Wasmtime
             {
                 return null;
             }
+
+            GC.KeepAlive(store);
 
             return new Global(store, ext.of.global);
         }

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -48,6 +48,8 @@ namespace Wasmtime
             using var type = new TypeHandle(Native.wasmtime_memorytype_new((ulong)minimum, maximum is not null, (ulong)(maximum ?? 0), is64Bit));
 
             var error = Native.wasmtime_memory_new(store.Context.handle, type, out this.memory);
+            GC.KeepAlive(store);
+
             if (error != IntPtr.Zero)
             {
                 throw WasmtimeException.FromOwnedError(error);
@@ -83,7 +85,9 @@ namespace Wasmtime
         /// <returns>Returns the current size of the memory, in WebAssembly page units.</returns>
         public long GetSize()
         {
-            return (long)Native.wasmtime_memory_size(store.Context.handle, this.memory);
+            var size = (long)Native.wasmtime_memory_size(store.Context.handle, this.memory);
+            GC.KeepAlive(store);
+            return size;
         }
 
         /// <summary>
@@ -92,7 +96,9 @@ namespace Wasmtime
         /// <returns>Returns the current length of the memory, in bytes.</returns>
         public long GetLength()
         {
-            return checked((long)Native.wasmtime_memory_data_size(store.Context.handle, this.memory));
+            var length = checked((long)Native.wasmtime_memory_data_size(store.Context.handle, this.memory));
+            GC.KeepAlive(store);
+            return length;
         }
 
         /// <summary>
@@ -115,6 +121,7 @@ namespace Wasmtime
         public unsafe IntPtr GetPointer()
         {
             var data = Native.wasmtime_memory_data(store.Context.handle, this.memory);
+            GC.KeepAlive(store);
             return (nint)data;
         }
 
@@ -231,6 +238,8 @@ namespace Wasmtime
 
             var context = store.Context;
             var data = Native.wasmtime_memory_data(context.handle, this.memory);
+            GC.KeepAlive(store);
+
             var memoryLength = this.GetLength();
 
             // Note: A Span<T> can span more than 2 GiB bytes if sizeof(T) > 1.
@@ -512,6 +521,8 @@ namespace Wasmtime
             }
 
             var error = Native.wasmtime_memory_grow(store.Context.handle, this.memory, (ulong)delta, out var prev);
+            GC.KeepAlive(store);
+
             if (error != IntPtr.Zero)
             {
                 throw WasmtimeException.FromOwnedError(error);
@@ -534,6 +545,7 @@ namespace Wasmtime
             this.store = store;
 
             using var type = new TypeHandle(Native.wasmtime_memory_type(store.Context.handle, this.memory));
+            GC.KeepAlive(store);
 
             Minimum = (long)Native.wasmtime_memorytype_minimum(type.DangerousGetHandle());
 

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -138,6 +138,12 @@ namespace Wasmtime
         /// <summary>
         /// Gets the context of the store.
         /// </summary>
+        /// <remarks>
+        /// Note: Generally, you must keep the <see cref="IStore"/> alive (by using
+        /// <see cref="GC.KeepAlive(object)"/>) until the <see cref="StoreContext"/> is no longer
+        /// used, to prevent the the Store.Handle finalizer from prematurely deleting the handle 
+        /// in the GC finalizer thread while the <see cref="StoreContext"/> is still in use.
+        /// </remarks>
         StoreContext Context { get; }
     }
 
@@ -178,13 +184,21 @@ namespace Wasmtime
         /// <summary>
         /// Perform garbage collection within the given store.
         /// </summary>
-        public void GC() => ((IStore)this).Context.GC();
+        public void GC()
+        {
+            ((IStore)this).Context.GC();
+            System.GC.KeepAlive(this);
+        }
 
         /// <summary>
         /// Adds fuel to this store for WebAssembly code to consume while executing.
         /// </summary>
         /// <param name="fuel">The fuel to add to the store.</param>
-        public void AddFuel(ulong fuel) => ((IStore)this).Context.AddFuel(fuel);
+        public void AddFuel(ulong fuel)
+        {
+            ((IStore)this).Context.AddFuel(fuel);
+            System.GC.KeepAlive(this);
+        }
 
         /// <summary>
         /// Synthetically consumes fuel from this store.
@@ -201,30 +215,53 @@ namespace Wasmtime
         /// <param name="fuel">The fuel to consume from the store.</param>
         /// <returns>Returns the remaining amount of fuel.</returns>
         /// <exception cref="WasmtimeException">Thrown if more fuel is consumed than the store currently has.</exception>
-        public ulong ConsumeFuel(ulong fuel) => ((IStore)this).Context.ConsumeFuel(fuel);
+        public ulong ConsumeFuel(ulong fuel)
+        {
+            var result = ((IStore)this).Context.ConsumeFuel(fuel);
+            System.GC.KeepAlive(this);
+            return result;
+        }
 
         /// <summary>
         /// Gets the fuel consumed by the executing WebAssembly code.
         /// </summary>
         /// <returns>Returns the fuel consumed by the executing WebAssembly code or 0 if fuel consumption was not enabled.</returns>
-        public ulong GetConsumedFuel() => ((IStore)this).Context.GetConsumedFuel();
+        public ulong GetConsumedFuel()
+        {
+            var result = ((IStore)this).Context.GetConsumedFuel();
+            System.GC.KeepAlive(this);
+            return result;
+        }
 
         /// <summary>
         /// Configures WASI within the store.
         /// </summary>
         /// <param name="config">The WASI configuration to use.</param>
-        public void SetWasiConfiguration(WasiConfiguration config) => ((IStore)this).Context.SetWasiConfiguration(config);
+        public void SetWasiConfiguration(WasiConfiguration config)
+        {
+            ((IStore)this).Context.SetWasiConfiguration(config);
+            System.GC.KeepAlive(this);
+        }
 
         /// <summary>
         /// Configures the relative deadline at which point WebAssembly code will trap.
         /// </summary>
         /// <param name="ticksBeyondCurrent"></param>
-        public void SetEpochDeadline(ulong ticksBeyondCurrent) => ((IStore)this).Context.SetEpochDeadline(ticksBeyondCurrent);
+        public void SetEpochDeadline(ulong ticksBeyondCurrent)
+        {
+            ((IStore)this).Context.SetEpochDeadline(ticksBeyondCurrent);
+            System.GC.KeepAlive(this);
+        }
 
         /// <summary>
         /// Retrieves the data stored in the Store context
         /// </summary>
-        public object? GetData() => ((IStore)this).Context.GetData();
+        public object? GetData()
+        {
+            var result = ((IStore)this).Context.GetData();
+            System.GC.KeepAlive(this);
+            return result;
+        }
 
         /// <summary>
         /// Replaces the data stored in the Store context 
@@ -232,6 +269,7 @@ namespace Wasmtime
         public void SetData(object? data)
         {
             ((IStore)this).Context.SetData(data);
+            System.GC.KeepAlive(this);
         }
 
         StoreContext IStore.Context => new StoreContext(Native.wasmtime_store_context(NativeHandle));

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -50,6 +50,7 @@ namespace Wasmtime
 
             var value = Value.FromObject(initialValue, Kind);
             var error = Native.wasmtime_table_new(store.Context.handle, tableType, in value, out this.table);
+            GC.KeepAlive(store);
             value.Dispose();
 
             if (error != IntPtr.Zero)
@@ -87,6 +88,8 @@ namespace Wasmtime
                 throw new IndexOutOfRangeException();
             }
 
+            GC.KeepAlive(store);
+
             var val = v.ToObject(store);
             v.Dispose();
             return val;
@@ -101,6 +104,7 @@ namespace Wasmtime
         {
             var v = Value.FromObject(value, Kind);
             var error = Native.wasmtime_table_set(store.Context.handle, this.table, index, v);
+            GC.KeepAlive(store);
             v.Dispose();
 
             if (error != IntPtr.Zero)
@@ -115,7 +119,9 @@ namespace Wasmtime
         /// <value>Returns the current size of the table.</value>
         public uint GetSize()
         {
-            return Native.wasmtime_table_size(store.Context.handle, this.table);
+            var result = Native.wasmtime_table_size(store.Context.handle, this.table);
+            GC.KeepAlive(store);
+            return result;
         }
 
         /// <summary>
@@ -129,6 +135,7 @@ namespace Wasmtime
             var v = Value.FromObject(initialValue, Kind);
 
             var error = Native.wasmtime_table_grow(store.Context.handle, this.table, delta, v, out var prev);
+            GC.KeepAlive(store);
             v.Dispose();
 
             if (error != IntPtr.Zero)
@@ -145,6 +152,7 @@ namespace Wasmtime
             this.table = table;
 
             using var type = new TypeHandle(Native.wasmtime_table_type(store.Context.handle, this.table));
+            GC.KeepAlive(store);
 
             this.Kind = ValueType.ToKind(Native.wasm_tabletype_element(type.DangerousGetHandle()));
 


### PR DESCRIPTION
Keep the `Store` alive until its `StoreContext` is no longer used.

As noted in https://github.com/bytecodealliance/wasmtime-dotnet/issues/200#issuecomment-1355191511, this is required (to handle the case when you forget to dispose the `Store`) as otherwise it could theoretically happen that the `Store` handle is deleted (with `wasmtime_store_delete`) in the GC finalizer thread even when at the same time a native call using the `StoreContext` handle is still executing in another thread, in case the `Store` object is no longer reachable.

For native methods taking a handle parameter that is passed as `SafeHandle`, this is not required as the `SafeHandle` is already kept alive during the call.
An exception is if you use `SafeHandle.DangerousGetHandle()` to retrieve the handle as pointer value and pass it; in that case you must also keep the `SafeHandle` alive.

This commit also fixes an instance of the above noted issue in `Engine.IncrementEpoch()`, where `wasmtime_engine_increment_epoch` was declared as taking an `IntPtr` handle, and `Engine.IncrementEpoch()` used `SafeHandle.DangerousGetHandle()` without keeping the SafeHandle alive (this appears to have been introduced with #118).

Note that I also added the `GC.KeepAlive(store)` if the store is used in method calls after that, because otherwise it is not guaranteed that the following call will actually keep the store alive (the call could be inlined, and if then doesn't read the `Store`, it would still be eligible for GC); additionally, this would cause a "code debt" if you edit the code in the future, as e.g. when you would change/remove the code after the call using the `StoreContext`, you would have to remember to add the `GC.KeepAlive(store)` call.

---

**Note:** A general question that came to my mind, is whether `Wasmtime` actually has a thread-safe resource management, i.e. whether it supports that one thread may be freeing a resource, while at the same time another thread is calling a native method that uses another value that internally might contain a reference to the resource freed by the first thread.

For example, there is the `Engine` object (`wasm_engine_t`) that you need to create first, and then you can create a `Store` (`wasmtime_store_t*`) from the `Engine` (as `wasmtime_store_new()` takes a `wasm_engine_t*` parameter), from which I understand that internally, the returned `wasmtime_store_t` may contain a reference to the `wasm_engine_t`.
(So, if you call `wasm_engine_delete` to delete the engine while a store still exists, this will not actually free the `wasm_engine_t` but just decrements its reference count. If you later delete the `wasmtime_store_t`, then it and the referenced engine will actually be freed.)

However, if in .NET code you create an `Engine`, and then create a `Store` from the `Engine` and then throw the `Engine` away (and you forget to use a `using` block or to call `Engine.Dispose()` afterwards), and later you call `Store.Dispose()`, it can happen that `wasm_engine_delete()` is called from the GC finalizer thread, while at the same time your main thread is calling `wasmtime_store_delete()`. Is this supported by `Wasmtime`?

(If not, them I'm wondering whether the apporach of releasing handles in finalizers can actually be supported at all by `wasmtime-dotnet`.)

What do you think?

Thanks!