### PR TITLE
Replaced `class Caller` with `struct Caller`. Internally a `CallerCon…

### DIFF
--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -7,17 +8,32 @@ namespace Wasmtime
     /// <summary>
     /// Represents caller information for a function.
     /// </summary>
-    public class Caller : IStore, IDisposable
+    public readonly struct Caller
+        : IDisposable
     {
         internal Caller(IntPtr handle)
         {
-            if (handle == IntPtr.Zero)
-            {
-                throw new InvalidOperationException();
-            }
-
-            this.handle = handle;
+            _context = CallerContext.Get(handle);
+            _epoch = _context.Epoch;
         }
+
+        /// <summary>
+        /// Dispose this Caller. All other calls after this will throw ObjectDisposedException.
+        /// </summary>
+        void IDisposable.Dispose()
+        {
+            if (_context?.Epoch == _epoch)
+            {
+                _context.Recycle();
+            }
+        }
+
+        internal IStore AsStore()
+        {
+            return _context.GetStore(_epoch);
+        }
+
+        private StoreContext StoreContext => new(Native.wasmtime_caller_context(_context.GetHandle(_epoch)));
 
         /// <summary>
         /// Gets an exported memory of the caller by the given name.
@@ -28,11 +44,12 @@ namespace Wasmtime
         {
             unsafe
             {
+                //todo:try to avoid this allocation if possible (e.g. stackalloc/ArrayPool)
                 var bytes = Encoding.UTF8.GetBytes(name);
 
                 fixed (byte* ptr = bytes)
                 {
-                    if (!Native.wasmtime_caller_export_get(NativeHandle, ptr, (UIntPtr)bytes.Length, out var item))
+                    if (!Native.wasmtime_caller_export_get(_context.GetHandle(_epoch), ptr, (UIntPtr)bytes.Length, out var item))
                     {
                         return null;
                     }
@@ -43,7 +60,7 @@ namespace Wasmtime
                         return null;
                     }
 
-                    return new Memory(this, item.of.memory);
+                    return new Memory(AsStore(), item.of.memory);
                 }
             }
         }
@@ -57,11 +74,12 @@ namespace Wasmtime
         {
             unsafe
             {
+                //todo:try to avoid this allocation if possible (e.g. stackalloc/ArrayPool)
                 var bytes = Encoding.UTF8.GetBytes(name);
 
                 fixed (byte* ptr = bytes)
                 {
-                    if (!Native.wasmtime_caller_export_get(NativeHandle, ptr, (UIntPtr)bytes.Length, out var item))
+                    if (!Native.wasmtime_caller_export_get(_context.GetHandle(_epoch), ptr, (UIntPtr)bytes.Length, out var item))
                     {
                         return null;
                     }
@@ -72,37 +90,16 @@ namespace Wasmtime
                         return null;
                     }
 
-                    return new Function(this, item.of.func);
+                    return new Function(AsStore(), item.of.func);
                 }
             }
         }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            this.handle = IntPtr.Zero;
-        }
-
-        private IntPtr NativeHandle
-        {
-            get
-            {
-                if (this.handle == IntPtr.Zero)
-                {
-                    throw new ObjectDisposedException(typeof(Caller).FullName);
-                }
-
-                return this.handle;
-            }
-        }
-
-        StoreContext IStore.Context => new StoreContext(Native.wasmtime_caller_context(NativeHandle));
 
         /// <summary>
         /// Adds fuel to this store for WebAssembly code to consume while executing.
         /// </summary>
         /// <param name="fuel">The fuel to add to the store.</param>
-        public void AddFuel(ulong fuel) => ((IStore)this).Context.AddFuel(fuel);
+        public void AddFuel(ulong fuel) => StoreContext.AddFuel(fuel);
 
         /// <summary>
         /// Synthetically consumes fuel from this store.
@@ -119,35 +116,126 @@ namespace Wasmtime
         /// <param name="fuel">The fuel to consume from the store.</param>
         /// <returns>Returns the remaining amount of fuel.</returns>
         /// <exception cref="WasmtimeException">Thrown if more fuel is consumed than the store currently has.</exception>
-        public ulong ConsumeFuel(ulong fuel) => ((IStore)this).Context.ConsumeFuel(fuel);
+        public ulong ConsumeFuel(ulong fuel) => StoreContext.ConsumeFuel(fuel);
 
         /// <summary>
         /// Gets the fuel consumed by the executing WebAssembly code.
         /// </summary>
         /// <returns>Returns the fuel consumed by the executing WebAssembly code or 0 if fuel consumption was not enabled.</returns>
-        public ulong GetConsumedFuel() => ((IStore)this).Context.GetConsumedFuel();
+        public ulong GetConsumedFuel() => StoreContext.GetConsumedFuel();
 
         /// <summary>
         /// Gets the user-defined data from the Store's Context. 
         /// </summary>
         /// <returns>An object represeting the user defined data from this Store</returns>
-        public object? GetData() => ((IStore)this).Context.GetData();
+        public object? GetData() => StoreContext.GetData();
 
         /// <summary>
         /// Replaces the user-defined data in the Store's Context 
         /// </summary>
-        public void SetData(object? data) => ((IStore)this).Context.SetData(data);
+        public void SetData(object? data) => StoreContext.SetData(data);
 
         internal static class Native
         {
             [DllImport(Engine.LibraryName)]
             [return: MarshalAs(UnmanagedType.I1)]
-            public static unsafe extern bool wasmtime_caller_export_get(IntPtr caller, byte* name, UIntPtr len, out Extern item);
+            public static extern unsafe bool wasmtime_caller_export_get(IntPtr caller, byte* name, UIntPtr len, out Extern item);
 
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasmtime_caller_context(IntPtr caller);
         }
 
-        private IntPtr handle;
+        private readonly uint _epoch;
+        private readonly CallerContext _context;
+    }
+
+    /// <summary>
+    /// An impementation of IStore with a lifetime tied to a CallerContext
+    /// </summary>
+    internal class CallerStore
+        : IStore
+    {
+        private readonly uint _epoch;
+        private readonly CallerContext _context;
+
+        public CallerStore(CallerContext context, uint epoch)
+        {
+            _context = context;
+            _epoch = epoch;
+        }
+
+        public StoreContext Context => new(Caller.Native.wasmtime_caller_context(_context.GetHandle(_epoch)));
+    }
+
+    /// <summary>
+    /// Internal representation of caller information. Public wrappers compare the "epoch" to check if they have been disposed.
+    /// </summary>
+    internal class CallerContext
+    {
+        public static CallerContext Get(IntPtr handle)
+        {
+            if (handle == IntPtr.Zero)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if (!_pool.TryTake(out var ctx))
+                ctx = new CallerContext();
+
+            ctx.Epoch++;
+            ctx._handle = handle;
+
+            return ctx;
+        }
+
+        public void Recycle()
+        {
+            Epoch++;
+            _handle = IntPtr.Zero;
+            _store = null;
+
+            // Do not recycle if epoch is getting near max limit
+            if (Epoch > uint.MaxValue - 10)
+            {
+                return;
+            }
+
+            if (_pool.Count < PoolMaxSize)
+            {
+                _pool.Add(this);
+            }
+        }
+
+        internal IntPtr GetHandle(uint epoch)
+        {
+            if (epoch != Epoch)
+            {
+                throw new ObjectDisposedException(typeof(Caller).FullName);
+            }
+
+            return _handle;
+        }
+
+        internal CallerStore GetStore(uint epoch)
+        {
+            if (epoch != Epoch)
+            {
+                throw new ObjectDisposedException(typeof(Caller).FullName);
+            }
+
+            if (_store == null)
+            {
+                _store = new CallerStore(this, epoch);
+            }
+
+            return _store;
+        }
+
+        internal uint Epoch { get; private set; }
+        private IntPtr _handle;
+        private CallerStore? _store;
+
+        private const int PoolMaxSize = 64;
+        private static readonly ConcurrentBag<CallerContext> _pool = new();
     }
 }

--- a/src/Function.FromCallback.cs
+++ b/src/Function.FromCallback.cs
@@ -58,7 +58,9 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             );
@@ -133,10 +135,12 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
                         
                         return IntPtr.Zero;
@@ -210,11 +214,13 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
                         
                         return IntPtr.Zero;
@@ -290,12 +296,14 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
                         
                         return IntPtr.Zero;
@@ -373,13 +381,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
                         
                         return IntPtr.Zero;
@@ -459,14 +469,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
                         
                         return IntPtr.Zero;
@@ -548,15 +560,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
                         
                         return IntPtr.Zero;
@@ -640,16 +654,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
                         
                         return IntPtr.Zero;
@@ -735,17 +751,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
                         
                         return IntPtr.Zero;
@@ -833,18 +851,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
                         
                         return IntPtr.Zero;
@@ -934,19 +954,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
                         
                         return IntPtr.Zero;
@@ -1038,20 +1060,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
                         
                         return IntPtr.Zero;
@@ -1145,21 +1169,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
                         
                         return IntPtr.Zero;
@@ -1231,12 +1257,14 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             );
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1309,12 +1337,14 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1389,13 +1419,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1472,14 +1504,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1558,15 +1592,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1647,16 +1683,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1739,17 +1777,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1834,18 +1874,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1932,19 +1974,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2033,20 +2077,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2137,21 +2183,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2244,22 +2292,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2354,23 +2404,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2443,13 +2495,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             );
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -2524,13 +2578,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -2607,14 +2663,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -2693,15 +2751,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -2782,16 +2842,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -2874,17 +2936,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -2969,18 +3033,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3067,19 +3133,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3168,20 +3236,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3272,21 +3342,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3379,22 +3451,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3489,23 +3563,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3602,24 +3678,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3694,14 +3772,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             );
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -3778,14 +3858,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -3864,15 +3946,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -3953,16 +4037,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4045,17 +4131,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4140,18 +4228,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4238,19 +4328,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4339,20 +4431,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4443,21 +4537,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4550,22 +4646,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4660,23 +4758,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4773,24 +4873,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4889,25 +4991,27 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4984,15 +5088,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             );
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5071,15 +5177,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5160,16 +5268,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5252,17 +5362,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5347,18 +5459,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5445,19 +5559,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5546,20 +5662,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5650,21 +5768,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5757,22 +5877,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5867,23 +5989,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5980,24 +6104,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6096,25 +6222,27 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6215,26 +6343,28 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6293,6 +6423,9 @@ namespace Wasmtime
             }
 
 
+            var converterRequiresStore =
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -6300,7 +6433,9 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller);
@@ -6364,6 +6499,10 @@ namespace Wasmtime
 
             var convT = ValueRaw.Converter<T>();
 
+            var converterRequiresStore =
+                convT.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -6371,11 +6510,13 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
                         
                         return IntPtr.Zero;
@@ -6437,6 +6578,11 @@ namespace Wasmtime
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -6444,12 +6590,14 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
                         
                         return IntPtr.Zero;
@@ -6512,6 +6660,12 @@ namespace Wasmtime
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -6519,13 +6673,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
                         
                         return IntPtr.Zero;
@@ -6589,6 +6745,13 @@ namespace Wasmtime
             var convT3 = ValueRaw.Converter<T3>();
             var convT4 = ValueRaw.Converter<T4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -6596,14 +6759,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
                         
                         return IntPtr.Zero;
@@ -6668,6 +6833,14 @@ namespace Wasmtime
             var convT4 = ValueRaw.Converter<T4>();
             var convT5 = ValueRaw.Converter<T5>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -6675,15 +6848,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
                         
                         return IntPtr.Zero;
@@ -6749,6 +6924,15 @@ namespace Wasmtime
             var convT5 = ValueRaw.Converter<T5>();
             var convT6 = ValueRaw.Converter<T6>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -6756,16 +6940,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
                         
                         return IntPtr.Zero;
@@ -6832,6 +7018,16 @@ namespace Wasmtime
             var convT6 = ValueRaw.Converter<T6>();
             var convT7 = ValueRaw.Converter<T7>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -6839,17 +7035,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
                         
                         return IntPtr.Zero;
@@ -6917,6 +7115,17 @@ namespace Wasmtime
             var convT7 = ValueRaw.Converter<T7>();
             var convT8 = ValueRaw.Converter<T8>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -6924,18 +7133,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
                         
                         return IntPtr.Zero;
@@ -7004,6 +7215,18 @@ namespace Wasmtime
             var convT8 = ValueRaw.Converter<T8>();
             var convT9 = ValueRaw.Converter<T9>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7011,19 +7234,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
                         
                         return IntPtr.Zero;
@@ -7093,6 +7318,19 @@ namespace Wasmtime
             var convT9 = ValueRaw.Converter<T9>();
             var convT10 = ValueRaw.Converter<T10>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7100,20 +7338,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
                         
                         return IntPtr.Zero;
@@ -7184,6 +7424,20 @@ namespace Wasmtime
             var convT10 = ValueRaw.Converter<T10>();
             var convT11 = ValueRaw.Converter<T11>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7191,21 +7445,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
                         
                         return IntPtr.Zero;
@@ -7277,6 +7533,21 @@ namespace Wasmtime
             var convT11 = ValueRaw.Converter<T11>();
             var convT12 = ValueRaw.Converter<T12>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convT12.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7284,22 +7555,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
                         
                         return IntPtr.Zero;
@@ -7360,6 +7633,10 @@ namespace Wasmtime
 
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7367,12 +7644,14 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller);
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -7433,6 +7712,11 @@ namespace Wasmtime
             var convT = ValueRaw.Converter<T>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7440,13 +7724,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -7508,6 +7794,12 @@ namespace Wasmtime
             var convT2 = ValueRaw.Converter<T2>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7515,14 +7807,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -7585,6 +7879,13 @@ namespace Wasmtime
             var convT3 = ValueRaw.Converter<T3>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7592,15 +7893,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -7664,6 +7967,14 @@ namespace Wasmtime
             var convT4 = ValueRaw.Converter<T4>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7671,16 +7982,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -7745,6 +8058,15 @@ namespace Wasmtime
             var convT5 = ValueRaw.Converter<T5>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7752,17 +8074,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -7828,6 +8152,16 @@ namespace Wasmtime
             var convT6 = ValueRaw.Converter<T6>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7835,18 +8169,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -7913,6 +8249,17 @@ namespace Wasmtime
             var convT7 = ValueRaw.Converter<T7>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7920,19 +8267,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -8000,6 +8349,18 @@ namespace Wasmtime
             var convT8 = ValueRaw.Converter<T8>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8007,20 +8368,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -8089,6 +8452,19 @@ namespace Wasmtime
             var convT9 = ValueRaw.Converter<T9>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8096,21 +8472,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -8180,6 +8558,20 @@ namespace Wasmtime
             var convT10 = ValueRaw.Converter<T10>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8187,22 +8579,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -8273,6 +8667,21 @@ namespace Wasmtime
             var convT11 = ValueRaw.Converter<T11>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8280,23 +8689,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -8368,6 +8779,22 @@ namespace Wasmtime
             var convT12 = ValueRaw.Converter<T12>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convT12.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8375,24 +8802,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -8453,6 +8882,11 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8460,13 +8894,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller);
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -8528,6 +8964,12 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8535,14 +8977,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -8605,6 +9049,13 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8612,15 +9063,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -8684,6 +9137,14 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8691,16 +9152,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -8765,6 +9228,15 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8772,17 +9244,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -8848,6 +9322,16 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8855,18 +9339,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -8933,6 +9419,17 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8940,19 +9437,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -9020,6 +9519,18 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9027,20 +9538,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -9109,6 +9622,19 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9116,21 +9642,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -9200,6 +9728,20 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9207,22 +9749,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -9293,6 +9837,21 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9300,23 +9859,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -9388,6 +9949,22 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9395,24 +9972,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -9485,6 +10064,23 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convT12.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9492,25 +10088,27 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -9572,6 +10170,12 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9579,14 +10183,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller);
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -9649,6 +10255,13 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9656,15 +10269,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -9728,6 +10343,14 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9735,16 +10358,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -9809,6 +10434,15 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9816,17 +10450,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -9892,6 +10528,16 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9899,18 +10545,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -9977,6 +10625,17 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9984,19 +10643,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -10064,6 +10725,18 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10071,20 +10744,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -10153,6 +10828,19 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10160,21 +10848,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -10244,6 +10934,20 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10251,22 +10955,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -10337,6 +11043,21 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10344,23 +11065,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -10432,6 +11155,22 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10439,24 +11178,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -10529,6 +11270,23 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10536,25 +11294,27 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -10628,6 +11388,24 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convT12.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10635,26 +11413,28 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -10717,6 +11497,13 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10724,15 +11511,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller);
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -10796,6 +11585,14 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10803,16 +11600,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -10877,6 +11676,15 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10884,17 +11692,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -10960,6 +11770,16 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10967,18 +11787,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -11045,6 +11867,17 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11052,19 +11885,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -11132,6 +11967,18 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11139,20 +11986,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -11221,6 +12070,19 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11228,21 +12090,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -11312,6 +12176,20 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11319,22 +12197,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -11405,6 +12285,21 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11412,23 +12307,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -11500,6 +12397,22 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11507,24 +12420,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -11597,6 +12512,23 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11604,25 +12536,27 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -11696,6 +12630,24 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11703,26 +12655,28 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -11797,6 +12751,25 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convT12.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11804,27 +12777,29 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -576,6 +576,7 @@ namespace Wasmtime
             try
             {
                 using var caller = new Caller(callerPtr);
+                var store = caller.AsStore();
 
                 var offset = passCaller ? 1 : 0;
                 var invokeArgs = new object?[nargs + offset];
@@ -588,7 +589,7 @@ namespace Wasmtime
                 var invokeArgsSpan = new Span<object?>(invokeArgs, offset, nargs);
                 for (int i = 0; i < invokeArgsSpan.Length; ++i)
                 {
-                    invokeArgsSpan[i] = args[i].ToObject(caller);
+                    invokeArgsSpan[i] = args[i].ToObject(store);
                 }
 
                 // NOTE: reflection is extremely slow for invoking methods. in the future, perhaps this could be replaced with

--- a/src/FunctionCallbackOverloadTemplates.t4
+++ b/src/FunctionCallbackOverloadTemplates.t4
@@ -10,7 +10,9 @@ void GenerateCallbackContent(bool hasCaller, int resultCount, int parameterCount
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = <#= hasCaller ? "" : "!converterRequiresStore ? null : " #>new Caller(callerPtr);
+
+                        using var caller = <#= hasCaller ? "" : "!converterRequiresStore ? default : " #>new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         <#= resultCount > 0 ? "var result = " : "" #>callback(
                             <#
@@ -34,7 +36,7 @@ void GenerateCallbackContent(bool hasCaller, int resultCount, int parameterCount
             genericType += (i + 1).ToString(CultureInfo.InvariantCulture);
         }
 
-        #>conv<#= genericType #>.Unbox(storeContext, caller, args_and_results[<#= i.ToString(CultureInfo.InvariantCulture) #>])<#
+        #>conv<#= genericType #>.Unbox(storeContext, store, args_and_results[<#= i.ToString(CultureInfo.InvariantCulture) #>])<#
 
         if (i + 1 < parameterCount)
         {
@@ -60,7 +62,7 @@ void GenerateCallbackContent(bool hasCaller, int resultCount, int parameterCount
             tupleAccessor = ".Item" + (i + 1).ToString(CultureInfo.InvariantCulture);
         }
 
-        #>conv<#= genericType #>.Box(storeContext, caller, ref args_and_results[<#= i.ToString(CultureInfo.InvariantCulture) #>], result<#= tupleAccessor #>);
+        #>conv<#= genericType #>.Box(storeContext, store, ref args_and_results[<#= i.ToString(CultureInfo.InvariantCulture) #>], result<#= tupleAccessor #>);
                         <#
     }
     #>
@@ -220,35 +222,33 @@ IEnumerable<(
                 }
 
                 // Generate a bool value that specifies whether any of the converters needs the IStore.
-                if (!hasCaller)
+                converterRequiresStoreCode.AppendLine();
+                converterRequiresStoreCode.AppendLine($"            var converterRequiresStore =");
+
+                for (int x = 0; x < parameterCount; x++)
                 {
-                    converterRequiresStoreCode.AppendLine();
-                    converterRequiresStoreCode.AppendLine($"            var converterRequiresStore =");
-
-                    for (int x = 0; x < parameterCount; x++)
+                    string genericType = "T";
+                    if (parameterCount > 1)
                     {
-                        string genericType = "T";
-                        if (parameterCount > 1)
-                        {
-                            genericType += (x + 1).ToString(CultureInfo.InvariantCulture);
-                        }
-
-                        converterRequiresStoreCode.AppendLine($"                conv{genericType}.RequiresStore(forBoxing: false) ||");
+                        genericType += (x + 1).ToString(CultureInfo.InvariantCulture);
                     }
 
-                    for (int x = 0; x < resultCount; x++)
-                    {
-                        string genericType = "TResult";
-                        if (resultCount > 1)
-                        {
-                            genericType += (x + 1).ToString(CultureInfo.InvariantCulture);
-                        }
-
-                        converterRequiresStoreCode.AppendLine($"                conv{genericType}.RequiresStore(forBoxing: true) ||");
-                    }
-
-                    converterRequiresStoreCode.AppendLine($"                false;");
+                    converterRequiresStoreCode.AppendLine($"                conv{genericType}.RequiresStore(forBoxing: false) ||");
                 }
+
+                for (int x = 0; x < resultCount; x++)
+                {
+                    string genericType = "TResult";
+                    if (resultCount > 1)
+                    {
+                        genericType += (x + 1).ToString(CultureInfo.InvariantCulture);
+                    }
+
+                    converterRequiresStoreCode.AppendLine($"                conv{genericType}.RequiresStore(forBoxing: true) ||");
+                }
+
+                converterRequiresStoreCode.AppendLine($"                false;");
+                
                 
                 yield return (
                     hasCaller,

--- a/src/Linker.DefineFunction.cs
+++ b/src/Linker.DefineFunction.cs
@@ -67,7 +67,9 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             );
@@ -159,10 +161,12 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
                         
                         return IntPtr.Zero;
@@ -253,11 +257,13 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
                         
                         return IntPtr.Zero;
@@ -350,12 +356,14 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
                         
                         return IntPtr.Zero;
@@ -450,13 +458,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
                         
                         return IntPtr.Zero;
@@ -553,14 +563,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
                         
                         return IntPtr.Zero;
@@ -659,15 +671,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
                         
                         return IntPtr.Zero;
@@ -768,16 +782,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
                         
                         return IntPtr.Zero;
@@ -880,17 +896,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
                         
                         return IntPtr.Zero;
@@ -995,18 +1013,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
                         
                         return IntPtr.Zero;
@@ -1113,19 +1133,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
                         
                         return IntPtr.Zero;
@@ -1234,20 +1256,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
                         
                         return IntPtr.Zero;
@@ -1358,21 +1382,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
                         
                         return IntPtr.Zero;
@@ -1461,12 +1487,14 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             );
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1556,12 +1584,14 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1653,13 +1683,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1753,14 +1785,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1856,15 +1890,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -1962,16 +1998,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2071,17 +2109,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2183,18 +2223,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2298,19 +2340,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2416,20 +2460,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2537,21 +2583,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2661,22 +2709,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2788,23 +2838,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -2894,13 +2946,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             );
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -2992,13 +3046,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3092,14 +3148,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3195,15 +3253,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3301,16 +3361,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3410,17 +3472,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3522,18 +3586,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3637,19 +3703,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3755,20 +3823,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -3876,21 +3946,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -4000,22 +4072,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -4127,23 +4201,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -4257,24 +4333,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -4366,14 +4444,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             );
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4467,14 +4547,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4570,15 +4652,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4676,16 +4760,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4785,17 +4871,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -4897,18 +4985,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -5012,19 +5102,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -5130,20 +5222,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -5251,21 +5345,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -5375,22 +5471,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -5502,23 +5600,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -5632,24 +5732,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -5765,25 +5867,27 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -5877,15 +5981,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             );
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -5981,15 +6087,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6087,16 +6195,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6196,17 +6306,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6308,18 +6420,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6423,19 +6537,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6541,20 +6657,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6662,21 +6780,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6786,22 +6906,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -6913,23 +7035,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -7043,24 +7167,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -7176,25 +7302,27 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -7312,26 +7440,28 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        using var caller = !converterRequiresStore ? null : new Caller(callerPtr);
+
+                        using var caller = !converterRequiresStore ? default : new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -7407,6 +7537,9 @@ namespace Wasmtime
             }
 
 
+            var converterRequiresStore =
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7414,7 +7547,9 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller);
@@ -7495,6 +7630,10 @@ namespace Wasmtime
 
             var convT = ValueRaw.Converter<T>();
 
+            var converterRequiresStore =
+                convT.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7502,11 +7641,13 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
                         
                         return IntPtr.Zero;
@@ -7585,6 +7726,11 @@ namespace Wasmtime
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7592,12 +7738,14 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
                         
                         return IntPtr.Zero;
@@ -7677,6 +7825,12 @@ namespace Wasmtime
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7684,13 +7838,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
                         
                         return IntPtr.Zero;
@@ -7771,6 +7927,13 @@ namespace Wasmtime
             var convT3 = ValueRaw.Converter<T3>();
             var convT4 = ValueRaw.Converter<T4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7778,14 +7941,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
                         
                         return IntPtr.Zero;
@@ -7867,6 +8032,14 @@ namespace Wasmtime
             var convT4 = ValueRaw.Converter<T4>();
             var convT5 = ValueRaw.Converter<T5>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7874,15 +8047,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
                         
                         return IntPtr.Zero;
@@ -7965,6 +8140,15 @@ namespace Wasmtime
             var convT5 = ValueRaw.Converter<T5>();
             var convT6 = ValueRaw.Converter<T6>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -7972,16 +8156,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
                         
                         return IntPtr.Zero;
@@ -8065,6 +8251,16 @@ namespace Wasmtime
             var convT6 = ValueRaw.Converter<T6>();
             var convT7 = ValueRaw.Converter<T7>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8072,17 +8268,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
                         
                         return IntPtr.Zero;
@@ -8167,6 +8365,17 @@ namespace Wasmtime
             var convT7 = ValueRaw.Converter<T7>();
             var convT8 = ValueRaw.Converter<T8>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8174,18 +8383,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
                         
                         return IntPtr.Zero;
@@ -8271,6 +8482,18 @@ namespace Wasmtime
             var convT8 = ValueRaw.Converter<T8>();
             var convT9 = ValueRaw.Converter<T9>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8278,19 +8501,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
                         
                         return IntPtr.Zero;
@@ -8377,6 +8602,19 @@ namespace Wasmtime
             var convT9 = ValueRaw.Converter<T9>();
             var convT10 = ValueRaw.Converter<T10>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8384,20 +8622,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
                         
                         return IntPtr.Zero;
@@ -8485,6 +8725,20 @@ namespace Wasmtime
             var convT10 = ValueRaw.Converter<T10>();
             var convT11 = ValueRaw.Converter<T11>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8492,21 +8746,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
                         
                         return IntPtr.Zero;
@@ -8595,6 +8851,21 @@ namespace Wasmtime
             var convT11 = ValueRaw.Converter<T11>();
             var convT12 = ValueRaw.Converter<T12>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convT12.RequiresStore(forBoxing: false) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8602,22 +8873,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
                         
                         return IntPtr.Zero;
@@ -8695,6 +8968,10 @@ namespace Wasmtime
 
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8702,12 +8979,14 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller);
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -8785,6 +9064,11 @@ namespace Wasmtime
             var convT = ValueRaw.Converter<T>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8792,13 +9076,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -8877,6 +9163,12 @@ namespace Wasmtime
             var convT2 = ValueRaw.Converter<T2>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8884,14 +9176,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -8971,6 +9265,13 @@ namespace Wasmtime
             var convT3 = ValueRaw.Converter<T3>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -8978,15 +9279,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -9067,6 +9370,14 @@ namespace Wasmtime
             var convT4 = ValueRaw.Converter<T4>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9074,16 +9385,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -9165,6 +9478,15 @@ namespace Wasmtime
             var convT5 = ValueRaw.Converter<T5>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9172,17 +9494,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -9265,6 +9589,16 @@ namespace Wasmtime
             var convT6 = ValueRaw.Converter<T6>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9272,18 +9606,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -9367,6 +9703,17 @@ namespace Wasmtime
             var convT7 = ValueRaw.Converter<T7>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9374,19 +9721,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -9471,6 +9820,18 @@ namespace Wasmtime
             var convT8 = ValueRaw.Converter<T8>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9478,20 +9839,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -9577,6 +9940,19 @@ namespace Wasmtime
             var convT9 = ValueRaw.Converter<T9>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9584,21 +9960,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -9685,6 +10063,20 @@ namespace Wasmtime
             var convT10 = ValueRaw.Converter<T10>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9692,22 +10084,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -9795,6 +10189,21 @@ namespace Wasmtime
             var convT11 = ValueRaw.Converter<T11>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9802,23 +10211,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -9907,6 +10318,22 @@ namespace Wasmtime
             var convT12 = ValueRaw.Converter<T12>();
             var convTResult = ValueRaw.Converter<TResult>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convT12.RequiresStore(forBoxing: false) ||
+                convTResult.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -9914,24 +10341,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult.Box(storeContext, caller, ref args_and_results[0], result);
+                        convTResult.Box(storeContext, store, ref args_and_results[0], result);
                         
                         return IntPtr.Zero;
                     }
@@ -10009,6 +10438,11 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10016,13 +10450,15 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller);
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -10101,6 +10537,12 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10108,14 +10550,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -10195,6 +10639,13 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10202,15 +10653,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -10291,6 +10744,14 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10298,16 +10759,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -10389,6 +10852,15 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10396,17 +10868,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -10489,6 +10963,16 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10496,18 +10980,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -10591,6 +11077,17 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10598,19 +11095,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -10695,6 +11194,18 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10702,20 +11213,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -10801,6 +11314,19 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10808,21 +11334,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -10909,6 +11437,20 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -10916,22 +11458,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -11019,6 +11563,21 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11026,23 +11585,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -11131,6 +11692,22 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11138,24 +11715,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -11245,6 +11824,23 @@ namespace Wasmtime
             var convTResult1 = ValueRaw.Converter<TResult1>();
             var convTResult2 = ValueRaw.Converter<TResult2>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convT12.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11252,25 +11848,27 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
                         
                         return IntPtr.Zero;
                     }
@@ -11349,6 +11947,12 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11356,14 +11960,16 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller);
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -11443,6 +12049,13 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11450,15 +12063,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -11539,6 +12154,14 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11546,16 +12169,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -11637,6 +12262,15 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11644,17 +12278,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -11737,6 +12373,16 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11744,18 +12390,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -11839,6 +12487,17 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11846,19 +12505,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -11943,6 +12604,18 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -11950,20 +12623,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -12049,6 +12724,19 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -12056,21 +12744,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -12157,6 +12847,20 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -12164,22 +12868,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -12267,6 +12973,21 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -12274,23 +12995,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -12379,6 +13102,22 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -12386,24 +13125,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -12493,6 +13234,23 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -12500,25 +13258,27 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -12609,6 +13369,24 @@ namespace Wasmtime
             var convTResult2 = ValueRaw.Converter<TResult2>();
             var convTResult3 = ValueRaw.Converter<TResult3>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convT12.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -12616,26 +13394,28 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
                         
                         return IntPtr.Zero;
                     }
@@ -12715,6 +13495,13 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -12722,15 +13509,17 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller);
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -12811,6 +13600,14 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -12818,16 +13615,18 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT.Unbox(storeContext, caller, args_and_results[0]));
+                            convT.Unbox(storeContext, store, args_and_results[0]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -12909,6 +13708,15 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -12916,17 +13724,19 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -13009,6 +13819,16 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -13016,18 +13836,20 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -13111,6 +13933,17 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -13118,19 +13951,21 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -13215,6 +14050,18 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -13222,20 +14069,22 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -13321,6 +14170,19 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -13328,21 +14190,23 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -13429,6 +14293,20 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -13436,22 +14314,24 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -13539,6 +14419,21 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -13546,23 +14441,25 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -13651,6 +14548,22 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -13658,24 +14571,26 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -13765,6 +14680,23 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -13772,25 +14704,27 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -13881,6 +14815,24 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -13888,26 +14840,28 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }
@@ -13999,6 +14953,25 @@ namespace Wasmtime
             var convTResult3 = ValueRaw.Converter<TResult3>();
             var convTResult4 = ValueRaw.Converter<TResult4>();
 
+            var converterRequiresStore =
+                convT1.RequiresStore(forBoxing: false) ||
+                convT2.RequiresStore(forBoxing: false) ||
+                convT3.RequiresStore(forBoxing: false) ||
+                convT4.RequiresStore(forBoxing: false) ||
+                convT5.RequiresStore(forBoxing: false) ||
+                convT6.RequiresStore(forBoxing: false) ||
+                convT7.RequiresStore(forBoxing: false) ||
+                convT8.RequiresStore(forBoxing: false) ||
+                convT9.RequiresStore(forBoxing: false) ||
+                convT10.RequiresStore(forBoxing: false) ||
+                convT11.RequiresStore(forBoxing: false) ||
+                convT12.RequiresStore(forBoxing: false) ||
+                convTResult1.RequiresStore(forBoxing: true) ||
+                convTResult2.RequiresStore(forBoxing: true) ||
+                convTResult3.RequiresStore(forBoxing: true) ||
+                convTResult4.RequiresStore(forBoxing: true) ||
+                false;
+
             unsafe
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
@@ -14006,27 +14979,29 @@ namespace Wasmtime
                     try
                     {
                         var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
+
                         using var caller = new Caller(callerPtr);
+                        var store = converterRequiresStore ? caller.AsStore() : default;
 
                         var result = callback(
                             caller,
-                            convT1.Unbox(storeContext, caller, args_and_results[0]),
-                            convT2.Unbox(storeContext, caller, args_and_results[1]),
-                            convT3.Unbox(storeContext, caller, args_and_results[2]),
-                            convT4.Unbox(storeContext, caller, args_and_results[3]),
-                            convT5.Unbox(storeContext, caller, args_and_results[4]),
-                            convT6.Unbox(storeContext, caller, args_and_results[5]),
-                            convT7.Unbox(storeContext, caller, args_and_results[6]),
-                            convT8.Unbox(storeContext, caller, args_and_results[7]),
-                            convT9.Unbox(storeContext, caller, args_and_results[8]),
-                            convT10.Unbox(storeContext, caller, args_and_results[9]),
-                            convT11.Unbox(storeContext, caller, args_and_results[10]),
-                            convT12.Unbox(storeContext, caller, args_and_results[11]));
+                            convT1.Unbox(storeContext, store, args_and_results[0]),
+                            convT2.Unbox(storeContext, store, args_and_results[1]),
+                            convT3.Unbox(storeContext, store, args_and_results[2]),
+                            convT4.Unbox(storeContext, store, args_and_results[3]),
+                            convT5.Unbox(storeContext, store, args_and_results[4]),
+                            convT6.Unbox(storeContext, store, args_and_results[5]),
+                            convT7.Unbox(storeContext, store, args_and_results[6]),
+                            convT8.Unbox(storeContext, store, args_and_results[7]),
+                            convT9.Unbox(storeContext, store, args_and_results[8]),
+                            convT10.Unbox(storeContext, store, args_and_results[9]),
+                            convT11.Unbox(storeContext, store, args_and_results[10]),
+                            convT12.Unbox(storeContext, store, args_and_results[11]));
 
-                        convTResult1.Box(storeContext, caller, ref args_and_results[0], result.Item1);
-                        convTResult2.Box(storeContext, caller, ref args_and_results[1], result.Item2);
-                        convTResult3.Box(storeContext, caller, ref args_and_results[2], result.Item3);
-                        convTResult4.Box(storeContext, caller, ref args_and_results[3], result.Item4);
+                        convTResult1.Box(storeContext, store, ref args_and_results[0], result.Item1);
+                        convTResult2.Box(storeContext, store, ref args_and_results[1], result.Item2);
+                        convTResult3.Box(storeContext, store, ref args_and_results[2], result.Item3);
+                        convTResult4.Box(storeContext, store, ref args_and_results[3], result.Item4);
                         
                         return IntPtr.Zero;
                     }

--- a/tests/CallerTests.cs
+++ b/tests/CallerTests.cs
@@ -258,7 +258,7 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
     [Fact]
     public void ItCannotBeAccessedAfterDisposal()
     {
-        Caller stash = null!;
+        Caller stash = default;
 
         Linker.DefineFunction("env", "callback", (Caller c) =>
         {


### PR DESCRIPTION
This PR replaces the Caller class with a Caller struct, removing a potential source of a _lot_ of allocation churn. The original idea (#208) was to use a `ref struct` to properly represent the true lifetime of a caller. However, that approach was very difficult to fit into the current system and would have required extensive rewrites. Instead this system throws an `ObjectDisposedException` if you try to use things beyond their lifetime (same as the old system).

The new API is very similar to the old one and should be mostly source compatible. Two breaking changes:
1. `Caller` no longer implements `IStore`. Internally we can call `AsStore()`, but externally it's simply no longer possible. I can make that `public` if you think it's necessary, but `IStore` seems like something that shouldn't really be used externally anyway.
2. `IDisposable` is implemented explicitly. Disposal is handled internally and calling `Dispose()` is not necessary. Implementing it explicitly hides it from intellisense, but means that any using statements around a `Caller` will continue to compile.

### Future Work

At the moment getting a `Memory` from a `Caller` will allocate a `CallerStore` and `Memory`. I plan to do followup PRs to provide a workaround for this but haven't decided on the best approach yet (for example I could add `Caller.GetMemorySpan(string name, long address, int length)`).