### PR TITLE
Ref struct caller

### DIFF
--- a/src/Delegates.cs
+++ b/src/Delegates.cs
@@ -1,0 +1,132 @@
+﻿namespace Wasmtime;
+
+/// <summary>
+/// Action accepting a caller
+/// </summary>
+public delegate void CallerAction(Caller caller);
+
+/// <summary>
+/// Action accepting a caller and 1 parameter
+/// </summary>
+public delegate void CallerAction<in T>(Caller caller, T arg);
+
+/// <summary>
+/// Action accepting a caller and 2 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2>(Caller caller, T1 arg1, T2 arg2);
+
+/// <summary>
+/// Action accepting a caller and 3 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2, in T3>(Caller caller, T1 arg1, T2 arg2, T3 arg3);
+
+/// <summary>
+/// Action accepting a caller and 4 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2, in T3, in T4>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4);
+
+/// <summary>
+/// Action accepting a caller and 5 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2, in T3, in T4, in T5>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5);
+
+/// <summary>
+/// Action accepting a caller and 6 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2, in T3, in T4, in T5, in T6>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6);
+
+/// <summary>
+/// Action accepting a caller and 7 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7);
+
+/// <summary>
+/// Action accepting a caller and 8 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8);
+
+/// <summary>
+/// Action accepting a caller and 9 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9);
+
+/// <summary>
+/// Action accepting a caller and 10 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10);
+
+/// <summary>
+/// Action accepting a caller and 11 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11);
+
+/// <summary>
+/// Action accepting a caller and 12 parameters
+/// </summary>
+public delegate void CallerAction<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12);
+
+/// <summary>
+/// Func accepting a caller
+/// </summary>
+public delegate TResult CallerFunc<out TResult>(Caller caller);
+
+/// <summary>
+/// Func accepting a caller and 1 parameter
+/// </summary>
+public delegate TResult CallerFunc<in T, out TResult>(Caller caller, T arg);
+
+/// <summary>
+/// Func accepting a caller and 2 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, out TResult>(Caller caller, T1 arg1, T2 arg2);
+
+/// <summary>
+/// Func accepting a caller and 3 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, in T3, out TResult>(Caller caller, T1 arg1, T2 arg2, T3 arg3);
+
+/// <summary>
+/// Func accepting a caller and 4 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, in T3, in T4, out TResult>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4);
+
+/// <summary>
+/// Func accepting a caller and 5 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, in T3, in T4, in T5, out TResult>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5);
+
+/// <summary>
+/// Func accepting a caller and 6 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, in T3, in T4, in T5, in T6, out TResult>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6);
+
+/// <summary>
+/// Func accepting a caller and 7 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, out TResult>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7);
+
+/// <summary>
+/// Func accepting a caller and 8 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, out TResult>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8);
+
+/// <summary>
+/// Func accepting a caller and 9 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, out TResult>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9);
+
+/// <summary>
+/// Func accepting a caller and 10 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, out TResult>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10);
+
+/// <summary>
+/// Func accepting a caller and 11 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, out TResult>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11);
+
+/// <summary>
+/// Func accepting a caller and 12 parameters
+/// </summary>
+public delegate TResult CallerFunc<in T1, in T2, in T3, in T4, in T5, in T6, in T7, in T8, in T9, in T10, in T11, in T12, out TResult>(Caller caller, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12);
+

--- a/src/Function.FromCallback.cs
+++ b/src/Function.FromCallback.cs
@@ -39,8 +39,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             );
@@ -103,8 +104,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
@@ -168,8 +170,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -235,8 +238,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -304,8 +308,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -375,8 +380,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -448,8 +454,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -523,8 +530,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -600,8 +608,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -679,8 +688,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -760,8 +770,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -843,8 +854,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -928,8 +940,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1003,8 +1016,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             );
@@ -1069,8 +1083,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
@@ -1136,8 +1151,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1205,8 +1221,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1276,8 +1293,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1349,8 +1367,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1424,8 +1443,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1501,8 +1521,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1580,8 +1601,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1661,8 +1683,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1744,8 +1767,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1829,8 +1853,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1916,8 +1941,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1993,8 +2019,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             );
@@ -2061,8 +2088,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
@@ -2130,8 +2158,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2201,8 +2230,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2274,8 +2304,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2349,8 +2380,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2426,8 +2458,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2505,8 +2538,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2586,8 +2620,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2669,8 +2704,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2754,8 +2790,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2841,8 +2878,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2930,8 +2968,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3009,8 +3048,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             );
@@ -3079,8 +3119,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
@@ -3150,8 +3191,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3223,8 +3265,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3298,8 +3341,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3375,8 +3419,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3454,8 +3499,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3535,8 +3581,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3618,8 +3665,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3703,8 +3751,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3790,8 +3839,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3879,8 +3929,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3970,8 +4021,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4051,8 +4103,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             );
@@ -4123,8 +4176,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
@@ -4196,8 +4250,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4271,8 +4326,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4348,8 +4404,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4427,8 +4484,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4508,8 +4566,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4591,8 +4650,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4676,8 +4736,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4763,8 +4824,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4852,8 +4914,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4943,8 +5006,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -5036,8 +5100,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -5094,7 +5159,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback(Store store, Action<Caller> callback)
+        public static Function FromCallback(Store store, CallerAction callback)
         {
             if (store is null)
             {
@@ -5114,9 +5179,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller);
@@ -5158,7 +5223,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T>(Store store, Action<Caller, T?> callback)
+        public static Function FromCallback<T>(Store store, CallerAction<T?> callback)
         {
             if (store is null)
             {
@@ -5179,9 +5244,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5224,7 +5289,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2>(Store store, Action<Caller, T1?, T2?> callback)
+        public static Function FromCallback<T1, T2>(Store store, CallerAction<T1?, T2?> callback)
         {
             if (store is null)
             {
@@ -5246,9 +5311,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5292,7 +5357,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3>(Store store, Action<Caller, T1?, T2?, T3?> callback)
+        public static Function FromCallback<T1, T2, T3>(Store store, CallerAction<T1?, T2?, T3?> callback)
         {
             if (store is null)
             {
@@ -5315,9 +5380,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5362,7 +5427,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4>(Store store, Action<Caller, T1?, T2?, T3?, T4?> callback)
+        public static Function FromCallback<T1, T2, T3, T4>(Store store, CallerAction<T1?, T2?, T3?, T4?> callback)
         {
             if (store is null)
             {
@@ -5386,9 +5451,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5434,7 +5499,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5>(Store store, Action<Caller, T1?, T2?, T3?, T4?, T5?> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?> callback)
         {
             if (store is null)
             {
@@ -5459,9 +5524,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5508,7 +5573,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6>(Store store, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?> callback)
         {
             if (store is null)
             {
@@ -5534,9 +5599,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5584,7 +5649,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7>(Store store, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
         {
             if (store is null)
             {
@@ -5611,9 +5676,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5662,7 +5727,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8>(Store store, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
         {
             if (store is null)
             {
@@ -5690,9 +5755,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5742,7 +5807,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Store store, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
         {
             if (store is null)
             {
@@ -5771,9 +5836,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5824,7 +5889,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Store store, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
         {
             if (store is null)
             {
@@ -5854,9 +5919,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5908,7 +5973,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Store store, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
         {
             if (store is null)
             {
@@ -5939,9 +6004,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -5994,7 +6059,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Store store, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
         {
             if (store is null)
             {
@@ -6026,9 +6091,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -6082,7 +6147,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<TResult>(Store store, Func<Caller, TResult> callback)
+        public static Function FromCallback<TResult>(Store store, CallerFunc<TResult> callback)
         {
             if (store is null)
             {
@@ -6103,9 +6168,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller);
@@ -6148,7 +6213,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T, TResult>(Store store, Func<Caller, T?, TResult> callback)
+        public static Function FromCallback<T, TResult>(Store store, CallerFunc<T?, TResult> callback)
         {
             if (store is null)
             {
@@ -6170,9 +6235,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -6216,7 +6281,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, TResult>(Store store, Func<Caller, T1?, T2?, TResult> callback)
+        public static Function FromCallback<T1, T2, TResult>(Store store, CallerFunc<T1?, T2?, TResult> callback)
         {
             if (store is null)
             {
@@ -6239,9 +6304,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -6286,7 +6351,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, TResult>(Store store, Func<Caller, T1?, T2?, T3?, TResult> callback)
+        public static Function FromCallback<T1, T2, T3, TResult>(Store store, CallerFunc<T1?, T2?, T3?, TResult> callback)
         {
             if (store is null)
             {
@@ -6310,9 +6375,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -6358,7 +6423,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, TResult>(Store store, Func<Caller, T1?, T2?, T3?, T4?, TResult> callback)
+        public static Function FromCallback<T1, T2, T3, T4, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, TResult> callback)
         {
             if (store is null)
             {
@@ -6383,9 +6448,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -6432,7 +6497,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, TResult>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, TResult> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, TResult> callback)
         {
             if (store is null)
             {
@@ -6458,9 +6523,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -6508,7 +6573,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
         {
             if (store is null)
             {
@@ -6535,9 +6600,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -6586,7 +6651,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
         {
             if (store is null)
             {
@@ -6614,9 +6679,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -6666,7 +6731,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
         {
             if (store is null)
             {
@@ -6695,9 +6760,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -6748,7 +6813,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
         {
             if (store is null)
             {
@@ -6778,9 +6843,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -6832,7 +6897,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
         {
             if (store is null)
             {
@@ -6863,9 +6928,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -6918,7 +6983,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
         {
             if (store is null)
             {
@@ -6950,9 +7015,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7006,7 +7071,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
         {
             if (store is null)
             {
@@ -7039,9 +7104,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7096,7 +7161,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<TResult1, TResult2>(Store store, Func<Caller, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<TResult1, TResult2>(Store store, CallerFunc<ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7118,9 +7183,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller);
@@ -7164,7 +7229,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T, TResult1, TResult2>(Store store, Func<Caller, T?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T, TResult1, TResult2>(Store store, CallerFunc<T?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7187,9 +7252,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7234,7 +7299,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7258,9 +7323,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7306,7 +7371,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, T3, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7331,9 +7396,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7380,7 +7445,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7406,9 +7471,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7456,7 +7521,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7483,9 +7548,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7534,7 +7599,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7562,9 +7627,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7614,7 +7679,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7643,9 +7708,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7696,7 +7761,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7726,9 +7791,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7780,7 +7845,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7811,9 +7876,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7866,7 +7931,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7898,9 +7963,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -7954,7 +8019,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -7987,9 +8052,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8044,7 +8109,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
             {
@@ -8078,9 +8143,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8136,7 +8201,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<TResult1, TResult2, TResult3>(Store store, Func<Caller, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<TResult1, TResult2, TResult3>(Store store, CallerFunc<ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8159,9 +8224,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller);
@@ -8206,7 +8271,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T, TResult1, TResult2, TResult3>(Store store, Func<Caller, T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T, TResult1, TResult2, TResult3>(Store store, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8230,9 +8295,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8278,7 +8343,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8303,9 +8368,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8352,7 +8417,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8378,9 +8443,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8428,7 +8493,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8455,9 +8520,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8506,7 +8571,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8534,9 +8599,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8586,7 +8651,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8615,9 +8680,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8668,7 +8733,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8698,9 +8763,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8752,7 +8817,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8783,9 +8848,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8838,7 +8903,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8870,9 +8935,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -8926,7 +8991,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -8959,9 +9024,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9016,7 +9081,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -9050,9 +9115,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9108,7 +9173,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
             {
@@ -9143,9 +9208,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9202,7 +9267,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -9226,9 +9291,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller);
@@ -9274,7 +9339,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -9299,9 +9364,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9348,7 +9413,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -9374,9 +9439,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9424,7 +9489,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -9451,9 +9516,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9502,7 +9567,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -9530,9 +9595,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9582,7 +9647,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -9611,9 +9676,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9664,7 +9729,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -9694,9 +9759,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9748,7 +9813,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -9779,9 +9844,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9834,7 +9899,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -9866,9 +9931,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9922,7 +9987,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -9955,9 +10020,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10012,7 +10077,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -10046,9 +10111,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10104,7 +10169,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -10139,9 +10204,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10198,7 +10263,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(Store store, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
             {
@@ -10234,9 +10299,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -614,7 +614,7 @@ namespace Wasmtime
         {
             try
             {
-                using var caller = new Caller(callerPtr);
+                var caller = new Caller(callerPtr);
 
                 // Rent ValueBox arrays from the array pool (as it's not possible to
                 // stackalloc a managed type).

--- a/src/FunctionCallbackOverloadTemplates.t4
+++ b/src/FunctionCallbackOverloadTemplates.t4
@@ -9,11 +9,9 @@ void GenerateCallbackContent(bool hasCaller, int resultCount, int parameterCount
 #>
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-<# if (hasCaller) { #>
-                        using var caller = new Caller(callerPtr);
-<# } #>
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         <#= resultCount > 0 ? "var result = " : "" #>callback(
                             <#
@@ -95,29 +93,21 @@ IEnumerable<(
             for (int parameterCount = 0; parameterCount <= maxParameterCount; parameterCount++)
             {
                 var methodGenerics = new StringBuilder();
-                var delegateType = new StringBuilder(resultCount == 0 ? "Action" : "Func");
                 var delegateReturnType = new StringBuilder();
                 var parameterConverters = new StringBuilder();
                 var resultConverters = new StringBuilder();
         
+                var delegateType = new StringBuilder(hasCaller ? "Caller" : "");
+                delegateType.Append(resultCount == 0 ? "Action" : "Func");
+
                 if (parameterCount > 0 || resultCount > 0)
                 {
                     methodGenerics.Append('<');
                 }
 
-                if (parameterCount > 0 || resultCount > 0 || hasCaller)
+                if (parameterCount > 0 || resultCount > 0)
                 {
                     delegateType.Append('<');
-                }
-
-                if (hasCaller)
-                {
-                    delegateType.Append("Caller");
-
-                    if (parameterCount + resultCount > 0)
-                    {
-                        delegateType.Append(", ");
-                    }
                 }
 
                 for (int x = 0; x < parameterCount; x++)
@@ -193,7 +183,7 @@ IEnumerable<(
                     methodGenerics.Append('>');
                 }
 
-                if (parameterCount > 0 || resultCount > 0 || hasCaller)
+                if (parameterCount > 0 || resultCount > 0)
                 {
                     delegateType.Append(">");
                 }

--- a/src/Linker.DefineFunction.cs
+++ b/src/Linker.DefineFunction.cs
@@ -48,8 +48,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             );
@@ -147,8 +148,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
@@ -247,8 +249,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -349,8 +352,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -453,8 +457,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -559,8 +564,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -667,8 +673,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -777,8 +784,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -889,8 +897,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1003,8 +1012,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1119,8 +1129,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1237,8 +1248,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1357,8 +1369,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1467,8 +1480,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             );
@@ -1568,8 +1582,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
@@ -1670,8 +1685,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1774,8 +1790,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1880,8 +1897,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -1988,8 +2006,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2098,8 +2117,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2210,8 +2230,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2324,8 +2345,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2440,8 +2462,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2558,8 +2581,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2678,8 +2702,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2800,8 +2825,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -2912,8 +2938,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             );
@@ -3015,8 +3042,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
@@ -3119,8 +3147,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3225,8 +3254,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3333,8 +3363,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3443,8 +3474,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3555,8 +3587,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3669,8 +3702,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3785,8 +3819,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -3903,8 +3938,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4023,8 +4059,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4145,8 +4182,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4269,8 +4307,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4383,8 +4422,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             );
@@ -4488,8 +4528,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
@@ -4594,8 +4635,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4702,8 +4744,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4812,8 +4855,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -4924,8 +4968,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -5038,8 +5083,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -5154,8 +5200,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -5272,8 +5319,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -5392,8 +5440,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -5514,8 +5563,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -5638,8 +5688,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -5764,8 +5815,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -5880,8 +5932,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             );
@@ -5987,8 +6040,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
@@ -6095,8 +6149,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -6205,8 +6260,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -6317,8 +6373,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -6431,8 +6488,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -6547,8 +6605,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -6665,8 +6724,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -6785,8 +6845,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -6907,8 +6968,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -7031,8 +7093,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -7157,8 +7220,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -7285,8 +7349,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
@@ -7373,7 +7438,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction(string module, string name, Action<Caller> callback)
+        public void DefineFunction(string module, string name, CallerAction callback)
         {
             if (module is null)
             {
@@ -7398,9 +7463,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller);
@@ -7472,7 +7537,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T>(string module, string name, Action<Caller, T?> callback)
+        public void DefineFunction<T>(string module, string name, CallerAction<T?> callback)
         {
             if (module is null)
             {
@@ -7498,9 +7563,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -7573,7 +7638,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2>(string module, string name, Action<Caller, T1?, T2?> callback)
+        public void DefineFunction<T1, T2>(string module, string name, CallerAction<T1?, T2?> callback)
         {
             if (module is null)
             {
@@ -7600,9 +7665,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -7676,7 +7741,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3>(string module, string name, Action<Caller, T1?, T2?, T3?> callback)
+        public void DefineFunction<T1, T2, T3>(string module, string name, CallerAction<T1?, T2?, T3?> callback)
         {
             if (module is null)
             {
@@ -7704,9 +7769,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -7781,7 +7846,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4>(string module, string name, Action<Caller, T1?, T2?, T3?, T4?> callback)
+        public void DefineFunction<T1, T2, T3, T4>(string module, string name, CallerAction<T1?, T2?, T3?, T4?> callback)
         {
             if (module is null)
             {
@@ -7810,9 +7875,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -7888,7 +7953,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5>(string module, string name, Action<Caller, T1?, T2?, T3?, T4?, T5?> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?> callback)
         {
             if (module is null)
             {
@@ -7918,9 +7983,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -7997,7 +8062,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6>(string module, string name, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?> callback)
         {
             if (module is null)
             {
@@ -8028,9 +8093,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -8108,7 +8173,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7>(string module, string name, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
         {
             if (module is null)
             {
@@ -8140,9 +8205,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -8221,7 +8286,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8>(string module, string name, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
         {
             if (module is null)
             {
@@ -8254,9 +8319,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -8336,7 +8401,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string module, string name, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
         {
             if (module is null)
             {
@@ -8370,9 +8435,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -8453,7 +8518,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string module, string name, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
         {
             if (module is null)
             {
@@ -8488,9 +8553,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -8572,7 +8637,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string module, string name, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
         {
             if (module is null)
             {
@@ -8608,9 +8673,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -8693,7 +8758,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string module, string name, Action<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
         {
             if (module is null)
             {
@@ -8730,9 +8795,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         callback(
                             caller,
@@ -8816,7 +8881,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<TResult>(string module, string name, Func<Caller, TResult> callback)
+        public void DefineFunction<TResult>(string module, string name, CallerFunc<TResult> callback)
         {
             if (module is null)
             {
@@ -8842,9 +8907,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller);
@@ -8917,7 +8982,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T, TResult>(string module, string name, Func<Caller, T?, TResult> callback)
+        public void DefineFunction<T, TResult>(string module, string name, CallerFunc<T?, TResult> callback)
         {
             if (module is null)
             {
@@ -8944,9 +9009,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9020,7 +9085,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, TResult>(string module, string name, Func<Caller, T1?, T2?, TResult> callback)
+        public void DefineFunction<T1, T2, TResult>(string module, string name, CallerFunc<T1?, T2?, TResult> callback)
         {
             if (module is null)
             {
@@ -9048,9 +9113,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9125,7 +9190,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, TResult>(string module, string name, Func<Caller, T1?, T2?, T3?, TResult> callback)
+        public void DefineFunction<T1, T2, T3, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, TResult> callback)
         {
             if (module is null)
             {
@@ -9154,9 +9219,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9232,7 +9297,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, TResult>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, TResult> callback)
+        public void DefineFunction<T1, T2, T3, T4, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, TResult> callback)
         {
             if (module is null)
             {
@@ -9262,9 +9327,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9341,7 +9406,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, TResult>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, TResult> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, TResult> callback)
         {
             if (module is null)
             {
@@ -9372,9 +9437,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9452,7 +9517,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
         {
             if (module is null)
             {
@@ -9484,9 +9549,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9565,7 +9630,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
         {
             if (module is null)
             {
@@ -9598,9 +9663,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9680,7 +9745,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
         {
             if (module is null)
             {
@@ -9714,9 +9779,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9797,7 +9862,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
         {
             if (module is null)
             {
@@ -9832,9 +9897,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -9916,7 +9981,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
         {
             if (module is null)
             {
@@ -9952,9 +10017,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10037,7 +10102,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
         {
             if (module is null)
             {
@@ -10074,9 +10139,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10160,7 +10225,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
         {
             if (module is null)
             {
@@ -10198,9 +10263,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10285,7 +10350,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<TResult1, TResult2>(string module, string name, Func<Caller, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<TResult1, TResult2>(string module, string name, CallerFunc<ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -10312,9 +10377,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller);
@@ -10388,7 +10453,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T, TResult1, TResult2>(string module, string name, Func<Caller, T?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T, TResult1, TResult2>(string module, string name, CallerFunc<T?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -10416,9 +10481,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10493,7 +10558,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -10522,9 +10587,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10600,7 +10665,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, T3, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -10630,9 +10695,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10709,7 +10774,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -10740,9 +10805,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10820,7 +10885,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -10852,9 +10917,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -10933,7 +10998,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -10966,9 +11031,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -11048,7 +11113,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -11082,9 +11147,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -11165,7 +11230,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -11200,9 +11265,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -11284,7 +11349,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -11320,9 +11385,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -11405,7 +11470,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -11442,9 +11507,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -11528,7 +11593,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -11566,9 +11631,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -11653,7 +11718,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
             {
@@ -11692,9 +11757,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -11780,7 +11845,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<TResult1, TResult2, TResult3>(string module, string name, Func<Caller, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<TResult1, TResult2, TResult3>(string module, string name, CallerFunc<ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -11808,9 +11873,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller);
@@ -11885,7 +11950,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -11914,9 +11979,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -11992,7 +12057,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -12022,9 +12087,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -12101,7 +12166,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -12132,9 +12197,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -12212,7 +12277,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -12244,9 +12309,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -12325,7 +12390,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -12358,9 +12423,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -12440,7 +12505,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -12474,9 +12539,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -12557,7 +12622,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -12592,9 +12657,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -12676,7 +12741,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -12712,9 +12777,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -12797,7 +12862,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -12834,9 +12899,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -12920,7 +12985,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -12958,9 +13023,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -13045,7 +13110,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -13084,9 +13149,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -13172,7 +13237,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
             {
@@ -13212,9 +13277,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -13301,7 +13366,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -13330,9 +13395,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller);
@@ -13408,7 +13473,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -13438,9 +13503,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -13517,7 +13582,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -13548,9 +13613,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -13628,7 +13693,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -13660,9 +13725,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -13741,7 +13806,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -13774,9 +13839,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -13856,7 +13921,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -13890,9 +13955,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -13973,7 +14038,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -14008,9 +14073,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -14092,7 +14157,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -14128,9 +14193,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -14213,7 +14278,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -14250,9 +14315,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -14336,7 +14401,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -14374,9 +14439,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -14461,7 +14526,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -14500,9 +14565,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -14588,7 +14653,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -14628,9 +14693,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,
@@ -14717,7 +14782,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
-        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<Caller, T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
+        public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
             {
@@ -14758,9 +14823,9 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var storeContext = new StoreContext(Caller.Native.wasmtime_caller_context(callerPtr));
-                        var store = storeContext.Store;
-                        using var caller = new Caller(callerPtr);
+                        var caller = new Caller(callerPtr);
+                        var storeContext = caller.context;
+                        var store = caller.store;
 
                         var result = callback(
                             caller,

--- a/tests/CallerTests.cs
+++ b/tests/CallerTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using FluentAssertions;
 using Xunit;
 
@@ -254,30 +253,10 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
         callback.Invoke();
     }
 
-
-    [Fact]
-    public void ItCannotBeAccessedAfterDisposal()
-    {
-        Caller stash = null!;
-
-        Linker.DefineFunction("env", "callback", (Caller c) =>
-        {
-            stash = c;
-        });
-
-        var instance = Linker.Instantiate(Store, Fixture.Module);
-        var callback = instance.GetFunction("call_callback")!;
-
-        callback.Invoke();
-
-        var act = () => stash.GetMemory("memory");
-        act.Should().Throw<ObjectDisposedException>();
-    }
-
     [Fact]
     public void ItCannotBeConstructedFromNullPointer()
     {
-        var act = () => new Caller(IntPtr.Zero);
+        Action act = () => new Caller(IntPtr.Zero);
         act.Should().Throw<InvalidOperationException>();
     }
 


### PR DESCRIPTION
~~**This builds on #213, merge that first**~~

Third time lucky?

Replaced `Caller` with a `ref struct`. With the reflection path stripped out and the removal of `IStore` this was a fairly simple change.

A few notable changes:
 - Can't leak `Caller`, any breakage here is probably uncovering a bug.
 - `Caller` is no longer disposable (we could add an empty `Dispose()` method and mark it `[Obsolete]`?).

Also this test:

```
[Fact]
public void ItCannotBeConstructedFromNullPointer()
{
    var act = () => new Caller(IntPtr.Zero);
    act.Should().Throw<InvalidOperationException>();
}
```

~~Did not compile because `act` is now a `CallerAction` instead of an `Action`, which is surprising change of `var` inference. Fixed by changing `var` to `Action`.~~ Never mind, see comment by kpreisser below.

## Benchmark

Unlike my previous epoch based approach in #212 (which was 90ns slower) this benchmarks at exactly the same speed as the `class Caller` approach.