### PR TITLE
Fix the .NET API for recent Wasmtime C API changes.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '7.0.x'
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
       run: dotnet clean Wasmtime.sln && dotnet nuget locals all --clear

--- a/benchmarks/simple/simple.csproj
+++ b/benchmarks/simple/simple.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/consumefuel/consumefuel.csproj
+++ b/examples/consumefuel/consumefuel.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/externref/externref.csproj
+++ b/examples/externref/externref.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/funcref/funcref.csproj
+++ b/examples/funcref/funcref.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/global/global.csproj
+++ b/examples/global/global.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/hello/hello.csproj
+++ b/examples/hello/hello.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/examples/memory/memory.csproj
+++ b/examples/memory/memory.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/storedata/storedata.csproj
+++ b/examples/storedata/storedata.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/examples/table/table.csproj
+++ b/examples/table/table.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -439,6 +439,8 @@ namespace Wasmtime
             };
         }
 
+        Store? IExternal.Store => store;
+
         internal Function()
         {
             this.store = null;

--- a/src/Global.cs
+++ b/src/Global.cs
@@ -185,6 +185,8 @@ namespace Wasmtime
             };
         }
 
+        Store? IExternal.Store => store;
+
         internal Global(Store store, ExternGlobal global)
         {
             this.global = global;
@@ -309,6 +311,8 @@ namespace Wasmtime
             {
                 return ((IExternal)_global).AsExtern();
             }
+
+            Store? IExternal.Store => _store;
         }
     }
 }

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -541,6 +541,9 @@ namespace Wasmtime
                 of = new ExternUnion { memory = this.memory }
             };
         }
+
+        Store? IExternal.Store => store;
+
         internal Memory(Store store, ExternMemory memory)
         {
             this.memory = memory;

--- a/src/Module.cs
+++ b/src/Module.cs
@@ -28,6 +28,8 @@ namespace Wasmtime
     internal interface IExternal
     {
         Extern AsExtern();
+
+        Store? Store { get; }
     }
 
     /// <summary>

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -173,6 +173,8 @@ namespace Wasmtime
             };
         }
 
+        Store? IExternal.Store => store;
+
         internal class TypeHandle : SafeHandleZeroOrMinusOneIsInvalid
         {
             public TypeHandle(IntPtr handle)

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net7.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>

--- a/tests/Wasmtime.Tests.csproj
+++ b/tests/Wasmtime.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR fixes the definition of `wasmtime_linker_define` to match what is currently expected upstream.

As a result, items passed to `Linker.Define` must be associated with a store.

The internal `IExternal` interface was updated to expose the store associated with the item for `LinkerDefine` to use.

Also update the target framework to 7.0 (still `netstandard2.1` as well).