### PR TITLE
Add a Retries="10" attribute to the `DownloadFile` task

### DIFF
--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -151,6 +151,7 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       SourceUrl="$(ReleaseURLBase)/$(ReleaseFileNameBase)-%(Wasmtime.Arch)-%(Wasmtime.OS)-c-api.%(Wasmtime.FileExtension)"
       DestinationFolder="$(BaseIntermediateOutputPath)"
       SkipUnchangedFiles="true"
+      Retries="5"
     />
 
     <!-- Workaround for https://github.com/msys2/MSYS2-packages/issues/1548 -->


### PR DESCRIPTION
Add a `Retries="10"` attribute to the `DownloadFile` task, to check whether it can avoid the failed download issue in the Windows CI runner.

**Edit:** Unfortunately it seems `IsRetriable` returns false, so the task doesn't attempt to retry the download.