### PR TITLE
Extern define

### DIFF
--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -66,7 +66,7 @@ namespace Wasmtime
             var nameBytes = nameLength <= StackallocThreshold ? stackalloc byte[nameLength] : new byte[nameLength];
             Encoding.UTF8.GetBytes(name, nameBytes);
 
-            var moduleLength = Encoding.UTF8.GetByteCount(name);
+            var moduleLength = Encoding.UTF8.GetByteCount(module);
             var moduleBytes = moduleLength <= StackallocThreshold ? stackalloc byte[moduleLength] : new byte[moduleLength];
             Encoding.UTF8.GetBytes(module, moduleBytes);
 


### PR DESCRIPTION
 - Added public `Define` methods for all externs.
 - Removed method which accepted an `object` parameter and dynamically checked that it was an extern.

As discussed in https://github.com/bytecodealliance/wasmtime-dotnet/pull/224#issuecomment-1433591490