### PR TITLE
Better temporary memory

### DIFF
--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -66,7 +66,7 @@ namespace Wasmtime
             var nameBytes = nameLength <= StackallocThreshold ? stackalloc byte[nameLength] : new byte[nameLength];
             Encoding.UTF8.GetBytes(name, nameBytes);
 
-            var moduleLength = Encoding.UTF8.GetByteCount(name);
+            var moduleLength = Encoding.UTF8.GetByteCount(module);
             var moduleBytes = moduleLength <= StackallocThreshold ? stackalloc byte[moduleLength] : new byte[moduleLength];
             Encoding.UTF8.GetBytes(module, moduleBytes);
 

--- a/src/TemporaryAllocation.cs
+++ b/src/TemporaryAllocation.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Buffers;
+using System.Text;
+
+namespace Wasmtime
+{
+    internal static class StringExtensions
+    {
+        public static TemporaryAllocation ToUTF8(this string value, Span<byte> bytes)
+        {
+            return TemporaryAllocation.FromString(value, bytes);
+        }
+    }
+
+    internal readonly ref struct TemporaryAllocation
+    {
+        public readonly Span<byte> Span;
+        private readonly byte[]? _rented;
+
+        public int Length => Span.Length;
+
+        private TemporaryAllocation(Span<byte> span, byte[]? rented)
+        {
+            Span = span;
+            _rented = rented;
+        }
+
+        public static TemporaryAllocation FromString(string str, Span<byte> output)
+        {
+            var length = Encoding.UTF8.GetByteCount(str);
+
+            if (length <= output.Length)
+            {
+                Encoding.UTF8.GetBytes(str, output);
+                return new TemporaryAllocation(output[..length], null);
+            }
+
+            var rented = ArrayPool<byte>.Shared.Rent(length);
+            Encoding.UTF8.GetBytes(str, rented);
+            return new TemporaryAllocation(rented[..length], rented);
+        }
+
+        /// <summary>
+        /// Recycle rented memory
+        /// </summary>
+        public void Dispose()
+        {
+            if (_rented != null)
+            {
+                ArrayPool<byte>.Shared.Return(_rented);
+            }
+        }
+    }
+}


### PR DESCRIPTION
~~Builds on #228, review/merge that first!~~ (That has been merged now).

While working on #228 I came up with this idea for replacing the ad-hoc approaches to string->UTF8 conversions that we have around the place at the moment.

Currently we're either doing this simple approach that always allocates:

```csharp
Encoding.UTF8.GetBytes(a_string); // Always allocates
```

Or this slightly more complex approach that sometimes allocates:

```csharp
var nameLength = Encoding.UTF8.GetByteCount(name);
var nameBytes = nameLength <= StackallocThreshold ? stackalloc byte[nameLength] : new byte[nameLength]; // Sometimes allocates
Encoding.UTF8.GetBytes(name, nameBytes);
```

Or even this (😱) approach which never allocates:

```csharp
byte[]? nameBytesBuffer = null;
var nameLength = Encoding.UTF8.GetByteCount(name);
Span<byte> nameBytes = nameLength <= StackallocThreshold ? stackalloc byte[nameLength] : (nameBytesBuffer = ArrayPool<byte>.Shared.Rent(nameLength)).AsSpan()[..nameLength];
Encoding.UTF8.GetBytes(name, nameBytes);

try
{
    // code goes here
}
finally
{
    if (nameBytesBuffer is not null)
    {
        ArrayPool<byte>.Shared.Return(nameBytesBuffer);
    }
}
```

Ideally we'd always use the last approach, but no one is proposing that (outside of generated code) because it's just too horrible to look at!

---

This PR introduces a new system:

```csharp
using var nameBytes = name.ToUTF8(stackalloc byte[128]);
```

This will use the provided `stackalloc` byte span if possible and will fall back to renting from the `ArrayPool<byte>` if not. When the struct is disposed it returns the rented array to the pool.

The only disadvantage of this approach is it _always_ allocates on the stack, wheras the techniques above only allocate on the stack if necessary. I don't think this is a problem since the worst case is the same.