### PR TITLE
`Caller.TryCallFunction`

### DIFF
--- a/tests/CallerTests.cs
+++ b/tests/CallerTests.cs
@@ -142,6 +142,59 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
     }
 
     [Fact]
+    public void ItCanTryCallFunctionFromCaller()
+    {
+        Linker.DefineFunction("env", "callback", (Caller c) =>
+        {
+            var parameters = new ValueBox[] { 1, 2 };
+            var results = new ValueBox[1];
+
+            c.TryCallFunction("add", parameters, results).Should().BeTrue();
+
+            results[0].AsInt32().Should().Be(3);
+        });
+
+        var instance = Linker.Instantiate(Store, Fixture.Module);
+        var callback = instance.GetFunction("call_callback")!;
+
+        callback.Invoke();
+    }
+
+    [Fact]
+    public void ItCanTryCallFunctionFromCallerWithIncorrectParameterCount()
+    {
+        Linker.DefineFunction("env", "callback", (Caller c) =>
+        {
+            var parameters = new ValueBox[] { 1, 2, 3 };
+            var results = new ValueBox[1];
+
+            c.TryCallFunction("add", parameters, results).Should().BeFalse();
+        });
+
+        var instance = Linker.Instantiate(Store, Fixture.Module);
+        var callback = instance.GetFunction("call_callback")!;
+
+        Assert.Throws<WasmtimeException>(() => { callback.Invoke(); });
+    }
+
+    [Fact]
+    public void ItCanTryCallFunctionFromCallerWithIncorrectResultCount()
+    {
+        Linker.DefineFunction("env", "callback", (Caller c) =>
+        {
+            var parameters = new ValueBox[] { 1, 2 };
+            var results = new ValueBox[2];
+
+            c.TryCallFunction("add", parameters, results).Should().BeFalse();
+        });
+
+        var instance = Linker.Instantiate(Store, Fixture.Module);
+        var callback = instance.GetFunction("call_callback")!;
+
+        Assert.Throws<WasmtimeException>(() => { callback.Invoke(); });
+    }
+
+    [Fact]
     public void ItReturnsNullForNonExistantFunction()
     {
         Linker.DefineFunction("env", "callback", (Caller c) =>


### PR DESCRIPTION
Added `TryCallFunction` methods to `Caller`. This allows functions to be called without allocating a `Function` object. An alternative solution would be to convert `Function` into a struct, but this is a much larger change!

The main shortcoming with this is that `ValueBox` cannot be stack allocated. So this API is really just passing the buck on allocating anything - the caller _can_ avoid allocations (rent an array) but it's not very ergonomic. See the unit tests for example.

Another implementation could have generic arguments for all possible call/return combinations (and then use `ValueBox.Converter<T>().Box(value)`). This would be a fairly nice API to use, but would require generating yet more huge blobs of code.

I'm open to other suggestions on a better way to pass arguments and results.