### PR TITLE
Caller Function Cache

### DIFF
--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -97,7 +97,7 @@ namespace Wasmtime
                         return null;
                     }
 
-                    return new Memory(store, item.of.memory);
+                    return store.GetCachedExtern(item.of.memory);
                 }
             }
         }

--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -82,9 +82,9 @@ namespace Wasmtime
         {
             unsafe
             {
-                var bytes = Encoding.UTF8.GetBytes(name);
+                using var bytes = name.ToUTF8(stackalloc byte[Math.Min(64, name.Length * 2)]);
 
-                fixed (byte* ptr = bytes)
+                fixed (byte* ptr = bytes.Span)
                 {
                     if (!Native.wasmtime_caller_export_get(handle, ptr, (UIntPtr)bytes.Length, out var item))
                     {
@@ -111,9 +111,9 @@ namespace Wasmtime
         {
             unsafe
             {
-                var bytes = Encoding.UTF8.GetBytes(name);
+                using var bytes = name.ToUTF8(stackalloc byte[Math.Min(64, name.Length * 2)]);
 
-                fixed (byte* ptr = bytes)
+                fixed (byte* ptr = bytes.Span)
                 {
                     if (!Native.wasmtime_caller_export_get(handle, ptr, (UIntPtr)bytes.Length, out var item))
                     {
@@ -126,7 +126,7 @@ namespace Wasmtime
                         return null;
                     }
 
-                    return new Function(store, item.of.func);
+                    return store.GetCachedExtern(item.of.func);
                 }
             }
         }

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -524,7 +524,7 @@ namespace Wasmtime
 
             GC.KeepAlive(_store);
 
-            return new Function(_store, ext.of.func);
+            return _store.GetCachedExtern(ext.of.func);
         }
 
         /// <summary>

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -557,9 +557,7 @@ namespace Wasmtime
                 return null;
             }
 
-            GC.KeepAlive(_store);
-
-            return new Memory(_store, ext.of.memory);
+            return _store.GetCachedExtern(ext.of.memory);
         }
 
         /// <summary>

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -557,6 +557,8 @@ namespace Wasmtime
                 return null;
             }
 
+            GC.KeepAlive(_store);
+
             return _store.GetCachedExtern(ext.of.memory);
         }
 

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -289,7 +289,7 @@ namespace Wasmtime
                         throw WasmtimeException.FromOwnedError(error);
                     }
 
-                    return new Function(store, func);
+                    return store.GetCachedExtern(func);
                 }
             }
         }
@@ -316,7 +316,7 @@ namespace Wasmtime
 
             GC.KeepAlive(store);
 
-            return new Function(store, ext.of.func);
+            return store.GetCachedExtern(ext.of.func);
         }
 
         /// <summary>

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -364,6 +364,8 @@ namespace Wasmtime
                 return null;
             }
 
+            GC.KeepAlive(store);
+
             return store.GetCachedExtern(ext.of.memory);
         }
 

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -364,9 +364,7 @@ namespace Wasmtime
                 return null;
             }
 
-            GC.KeepAlive(store);
-
-            return new Memory(store, ext.of.memory);
+            return store.GetCachedExtern(ext.of.memory);
         }
 
         /// <summary>

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -164,9 +163,6 @@ namespace Wasmtime
         /// </summary>
         public void GC()
         {
-            _funcCache.Clear();
-            _memCache.Clear();
-
             Context.GC();
             System.GC.KeepAlive(this);
         }

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -306,32 +306,32 @@ namespace Wasmtime
 
         private static readonly Native.Finalizer Finalizer = (p) => GCHandle.FromIntPtr(p).Free();
 
-        private readonly ConcurrentDictionary<(ulong store, nuint index), Function> _funcCache = new();
+        private readonly ConcurrentDictionary<(ExternKind kind, ulong store, nuint index), object> _externCache = new();
+
         internal Function GetCachedExtern(ExternFunc @extern)
         {
-            var key = (@extern.store, @extern.index);
+            var key = (ExternKind.Func, @extern.store, @extern.index);
 
-            if (!_funcCache.TryGetValue(key, out var func))
+            if (!_externCache.TryGetValue(key, out var func))
             {
                 func = new Function(this, @extern);
-                func = _funcCache.GetOrAdd(key, func);
+                func = _externCache.GetOrAdd(key, func);
             }
 
-            return func;
+            return (Function)func;
         }
 
-        private readonly ConcurrentDictionary<(ulong store, nuint index), Memory> _memCache = new();
         internal Memory GetCachedExtern(ExternMemory @extern)
         {
-            var key = (@extern.store, @extern.index);
+            var key = (ExternKind.Memory, @extern.store, @extern.index);
 
-            if (!_memCache.TryGetValue(key, out var mem))
+            if (!_externCache.TryGetValue(key, out var mem))
             {
                 mem = new Memory(this, @extern);
-                mem = _memCache.GetOrAdd(key, mem);
+                mem = _externCache.GetOrAdd(key, mem);
             }
 
-            return mem;
+            return (Memory)mem;
         }
     }
 }

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -314,7 +314,7 @@ namespace Wasmtime
             if (!_funcCache.TryGetValue(@extern.index, out var func))
             {
                 func = new Function(this, @extern);
-                _funcCache.TryAdd(@extern.index, func);
+                func = _funcCache.GetOrAdd(@extern.index, func);
             }
 
             return func;

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -306,25 +306,29 @@ namespace Wasmtime
 
         private static readonly Native.Finalizer Finalizer = (p) => GCHandle.FromIntPtr(p).Free();
 
-        private readonly ConcurrentDictionary<nuint, Function> _funcCache = new();
+        private readonly ConcurrentDictionary<(ulong store, nuint index), Function> _funcCache = new();
         internal Function GetCachedExtern(ExternFunc @extern)
         {
-            if (!_funcCache.TryGetValue(@extern.index, out var func))
+            var key = (@extern.store, @extern.index);
+
+            if (!_funcCache.TryGetValue(key, out var func))
             {
                 func = new Function(this, @extern);
-                func = _funcCache.GetOrAdd(@extern.index, func);
+                func = _funcCache.GetOrAdd(key, func);
             }
 
             return func;
         }
 
-        private readonly ConcurrentDictionary<nuint, Memory> _memCache = new();
+        private readonly ConcurrentDictionary<(ulong store, nuint index), Memory> _memCache = new();
         internal Memory GetCachedExtern(ExternMemory @extern)
         {
-            if (!_memCache.TryGetValue(@extern.index, out var mem))
+            var key = (@extern.store, @extern.index);
+
+            if (!_memCache.TryGetValue(key, out var mem))
             {
                 mem = new Memory(this, @extern);
-                mem = _memCache.GetOrAdd(@extern.index, mem);
+                mem = _memCache.GetOrAdd(key, mem);
             }
 
             return mem;

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -353,7 +353,7 @@ namespace Wasmtime
                     return ResolveExternRef();
 
                 case ValueKind.FuncRef:
-                    return new Function(store, of.funcref);
+                    return store.GetCachedExtern(of.funcref);
 
                 default:
                     throw new NotSupportedException("Unsupported value kind.");

--- a/src/ValueBox.cs
+++ b/src/ValueBox.cs
@@ -84,8 +84,8 @@ namespace Wasmtime
         public Function AsFunction(Store store)
         {
             ThrowIfNotOfCorrectKind(ValueKind.FuncRef);
-
-            return new Function(store, Union.funcref);
+            
+            return store.GetCachedExtern(Union.funcref);
         }
 
         /// <summary>
@@ -390,7 +390,7 @@ namespace Wasmtime
 
         public Function Unbox(Store store, ValueBox value)
         {
-            return new Function(store, value.Union.funcref);
+            return store.GetCachedExtern(value.Union.funcref);
         }
     }
 

--- a/src/ValueRaw.cs
+++ b/src/ValueRaw.cs
@@ -201,7 +201,7 @@ namespace Wasmtime
                 Function.Native.wasmtime_func_from_raw(storeContext.handle, valueRaw.funcref, out funcref);
             }
 
-            return new Function(store!, funcref);
+            return store.GetCachedExtern(funcref);
         }
 
         public void Box(StoreContext storeContext, Store store, ref ValueRaw valueRaw, Function? value)

--- a/tests/CallerTests.cs
+++ b/tests/CallerTests.cs
@@ -50,7 +50,7 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
     [Fact]
     public void ItCanGetCachedMemoryFromCaller()
     {
-        var memories = new HashSet<Memory>();
+        var memories = new HashSet<Memory>(ReferenceEqualityComparer.Instance);
 
         Linker.DefineFunction("env", "callback", (Caller c) =>
         {
@@ -196,7 +196,7 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
     [Fact]
     public void ItCanGetCachedFunctionFromCaller()
     {
-        var functions = new HashSet<Function>();
+        var functions = new HashSet<Function>(ReferenceEqualityComparer.Instance);
 
         Linker.DefineFunction("env", "callback", (Caller c) =>
         {

--- a/tests/CallerTests.cs
+++ b/tests/CallerTests.cs
@@ -48,6 +48,29 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
     }
 
     [Fact]
+    public void ItCanGetCachedMemoryFromCaller()
+    {
+        var memories = new HashSet<Memory>();
+
+        Linker.DefineFunction("env", "callback", (Caller c) =>
+        {
+            memories.Add(c.GetMemory("memory"));
+        });
+
+        var instance = Linker.Instantiate(Store, Fixture.Module);
+        var callback = instance.GetFunction("call_callback")!;
+
+        callback.Invoke();
+        callback.Invoke();
+        callback.Invoke();
+        callback.Invoke();
+        callback.Invoke();
+
+        // Check that it retrieved the exact same `Memory` object for all calls
+        memories.Count.Should().Be(1);
+    }
+
+    [Fact]
     public void ItReturnsNullForNonExistantMemory()
     {
         Linker.DefineFunction("env", "callback", (Caller c) =>
@@ -167,6 +190,29 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
         var callback = instance.GetFunction("call_callback")!;
 
         callback.Invoke();
+    }
+
+    [Fact]
+    public void ItCanGetCachedFunctionFromCaller()
+    {
+        var memories = new HashSet<Function>();
+
+        Linker.DefineFunction("env", "callback", (Caller c) =>
+        {
+            memories.Add(c.GetFunction("add"));
+        });
+
+        var instance = Linker.Instantiate(Store, Fixture.Module);
+        var callback = instance.GetFunction("call_callback")!;
+
+        callback.Invoke();
+        callback.Invoke();
+        callback.Invoke();
+        callback.Invoke();
+        callback.Invoke();
+
+        // Check that it retrieved the exact same `Function` object for all calls
+        memories.Count.Should().Be(1);
     }
 
     [Fact]

--- a/tests/CallerTests.cs
+++ b/tests/CallerTests.cs
@@ -195,11 +195,15 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
     [Fact]
     public void ItCanGetCachedFunctionFromCaller()
     {
-        var memories = new HashSet<Function>();
+        var functions = new HashSet<Function>();
 
         Linker.DefineFunction("env", "callback", (Caller c) =>
         {
-            memories.Add(c.GetFunction("add"));
+            var add = c.GetFunction("add");
+            var call = c.GetFunction("call_callback");
+
+            add.Should().NotBe(call);
+            functions.Add(add);
         });
 
         var instance = Linker.Instantiate(Store, Fixture.Module);
@@ -212,7 +216,7 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
         callback.Invoke();
 
         // Check that it retrieved the exact same `Function` object for all calls
-        memories.Count.Should().Be(1);
+        functions.Count.Should().Be(1);
     }
 
     [Fact]

--- a/tests/CallerTests.cs
+++ b/tests/CallerTests.cs
@@ -62,11 +62,39 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
     }
 
     [Fact]
+    public void ItReturnsNoSpanForNonExistantMemory()
+    {
+        Linker.DefineFunction("env", "callback", (Caller c) =>
+        {
+            c.TryGetMemorySpan<byte>("idontexist", 0, 1, out var span).Should().BeFalse();
+        });
+
+        var instance = Linker.Instantiate(Store, Fixture.Module);
+        var callback = instance.GetFunction("call_callback")!;
+
+        callback.Invoke();
+    }
+
+    [Fact]
     public void ItReturnsNullForNonMemoryExport()
     {
         Linker.DefineFunction("env", "callback", (Caller c) =>
         {
             c.GetMemory("call_callback").Should().BeNull();
+        });
+
+        var instance = Linker.Instantiate(Store, Fixture.Module);
+        var callback = instance.GetFunction("call_callback")!;
+
+        callback.Invoke();
+    }
+
+    [Fact]
+    public void ItReturnsNoSpanForNonMemoryExport()
+    {
+        Linker.DefineFunction("env", "callback", (Caller c) =>
+        {
+            c.TryGetMemorySpan<byte>("call_callback", 0, 1, out var span).Should().BeFalse();
         });
 
         var instance = Linker.Instantiate(Store, Fixture.Module);

--- a/tests/CallerTests.cs
+++ b/tests/CallerTests.cs
@@ -55,6 +55,7 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
         Linker.DefineFunction("env", "callback", (Caller c) =>
         {
             memories.Add(c.GetMemory("memory"));
+            c.GetMemory("none").Should().BeNull();
         });
 
         var instance = Linker.Instantiate(Store, Fixture.Module);


### PR DESCRIPTION
Added caching to the `Store` for `Function` and `Memory` objects. The `Caller` uses this to retrieve `Function`/`Memory` objects, this saves allocating lots of objects in caller contexts.

This is an alternative to #233 and #224. I prefer this approach to #233 since it gives access to the entire `Function` API, instead of a tiny subset exposed through the `Caller`. I prefer it to #224 since the `Memory` object remains a class instead of becoming a struct, which is more idiomatic.