### PR TITLE
Function Wrapper Cache

### DIFF
--- a/src/Function.Wrap.cs
+++ b/src/Function.Wrap.cs
@@ -12,6 +12,8 @@ namespace Wasmtime
 {
     public partial class Function
     {
+        private object? _wrapperCache;
+
         /// <summary>
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
@@ -26,6 +28,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = Array.Empty<Type>();
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -33,15 +43,21 @@ namespace Wasmtime
 
             // Fetch a converter for each parameter type to box it
 
-            return () =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(0, Results.Count);
+
+            Action result = () =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(0, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -58,6 +74,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -66,16 +90,22 @@ namespace Wasmtime
             // Fetch a converter for each parameter type to box it
             var convT = ValueRaw.Converter<T>();
 
-            return (p0) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(1, Results.Count);
+
+            Action<T> result = (p0) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(1, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT.Box(storeContext, store, ref argsAndResults[0], p0);
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -92,6 +122,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -101,10 +139,13 @@ namespace Wasmtime
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
 
-            return (p0, p1) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(2, Results.Count);
+
+            Action<T1, T2> result = (p0, p1) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(2, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -112,6 +153,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -128,6 +172,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -138,10 +190,13 @@ namespace Wasmtime
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
 
-            return (p0, p1, p2) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(3, Results.Count);
+
+            Action<T1, T2, T3> result = (p0, p1, p2) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(3, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -150,6 +205,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -166,6 +224,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -177,10 +243,13 @@ namespace Wasmtime
             var convT3 = ValueRaw.Converter<T3>();
             var convT4 = ValueRaw.Converter<T4>();
 
-            return (p0, p1, p2, p3) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(4, Results.Count);
+
+            Action<T1, T2, T3, T4> result = (p0, p1, p2, p3) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(4, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -190,6 +259,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -206,6 +278,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -218,10 +298,13 @@ namespace Wasmtime
             var convT4 = ValueRaw.Converter<T4>();
             var convT5 = ValueRaw.Converter<T5>();
 
-            return (p0, p1, p2, p3, p4) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(5, Results.Count);
+
+            Action<T1, T2, T3, T4, T5> result = (p0, p1, p2, p3, p4) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(5, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -232,6 +315,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -248,6 +334,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -261,10 +355,13 @@ namespace Wasmtime
             var convT5 = ValueRaw.Converter<T5>();
             var convT6 = ValueRaw.Converter<T6>();
 
-            return (p0, p1, p2, p3, p4, p5) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(6, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6> result = (p0, p1, p2, p3, p4, p5) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(6, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -276,6 +373,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -292,6 +392,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -306,10 +414,13 @@ namespace Wasmtime
             var convT6 = ValueRaw.Converter<T6>();
             var convT7 = ValueRaw.Converter<T7>();
 
-            return (p0, p1, p2, p3, p4, p5, p6) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(7, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6, T7> result = (p0, p1, p2, p3, p4, p5, p6) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(7, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -322,6 +433,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -338,6 +452,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -353,10 +475,13 @@ namespace Wasmtime
             var convT7 = ValueRaw.Converter<T7>();
             var convT8 = ValueRaw.Converter<T8>();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(8, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6, T7, T8> result = (p0, p1, p2, p3, p4, p5, p6, p7) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(8, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -370,6 +495,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -386,6 +514,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -402,10 +538,13 @@ namespace Wasmtime
             var convT8 = ValueRaw.Converter<T8>();
             var convT9 = ValueRaw.Converter<T9>();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(9, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(9, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -420,6 +559,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -436,6 +578,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -453,10 +603,13 @@ namespace Wasmtime
             var convT9 = ValueRaw.Converter<T9>();
             var convT10 = ValueRaw.Converter<T10>();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(10, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(10, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -472,6 +625,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -488,6 +644,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -506,10 +670,13 @@ namespace Wasmtime
             var convT10 = ValueRaw.Converter<T10>();
             var convT11 = ValueRaw.Converter<T11>();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(11, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(11, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -526,6 +693,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -542,6 +712,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -561,10 +739,13 @@ namespace Wasmtime
             var convT11 = ValueRaw.Converter<T11>();
             var convT12 = ValueRaw.Converter<T12>();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(12, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(12, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -582,6 +763,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -598,6 +782,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -618,10 +810,13 @@ namespace Wasmtime
             var convT12 = ValueRaw.Converter<T12>();
             var convT13 = ValueRaw.Converter<T13>();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(13, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(13, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -640,6 +835,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -656,6 +854,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -677,10 +883,13 @@ namespace Wasmtime
             var convT13 = ValueRaw.Converter<T13>();
             var convT14 = ValueRaw.Converter<T14>();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(14, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(14, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -700,6 +909,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -716,6 +928,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -738,10 +958,13 @@ namespace Wasmtime
             var convT14 = ValueRaw.Converter<T14>();
             var convT15 = ValueRaw.Converter<T15>();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(15, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(15, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -762,6 +985,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -778,6 +1004,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), typeof(T16), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
                 return null;
@@ -801,10 +1035,13 @@ namespace Wasmtime
             var convT15 = ValueRaw.Converter<T15>();
             var convT16 = ValueRaw.Converter<T16>();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(16, Results.Count);
+
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(16, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -826,6 +1063,9 @@ namespace Wasmtime
 
                 InvokeWithoutReturn(argsAndResults, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -842,6 +1082,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = Array.Empty<Type>();
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -852,15 +1100,21 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return () =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(0, Results.Count);
+
+            Func<TResult?> result = () =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(0, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -877,6 +1131,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -888,16 +1150,22 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(1, Results.Count);
+
+            Func<T, TResult?> result = (p0) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(1, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT.Box(storeContext, store, ref argsAndResults[0], p0);
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -914,6 +1182,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -926,10 +1202,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(2, Results.Count);
+
+            Func<T1, T2, TResult?> result = (p0, p1) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(2, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -937,6 +1216,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -953,6 +1235,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -966,10 +1256,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(3, Results.Count);
+
+            Func<T1, T2, T3, TResult?> result = (p0, p1, p2) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(3, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -978,6 +1271,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -994,6 +1290,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1008,10 +1312,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(4, Results.Count);
+
+            Func<T1, T2, T3, T4, TResult?> result = (p0, p1, p2, p3) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(4, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1021,6 +1328,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1037,6 +1347,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1052,10 +1370,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(5, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, TResult?> result = (p0, p1, p2, p3, p4) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(5, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1066,6 +1387,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1082,6 +1406,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1098,10 +1430,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(6, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, TResult?> result = (p0, p1, p2, p3, p4, p5) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(6, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1113,6 +1448,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1129,6 +1467,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1146,10 +1492,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5, p6) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(7, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, T7, TResult?> result = (p0, p1, p2, p3, p4, p5, p6) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(7, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1162,6 +1511,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1178,6 +1530,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1196,10 +1556,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(8, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult?> result = (p0, p1, p2, p3, p4, p5, p6, p7) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(8, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1213,6 +1576,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1229,6 +1595,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1248,10 +1622,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(9, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult?> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(9, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1266,6 +1643,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1282,6 +1662,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1302,10 +1690,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(10, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult?> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(10, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1321,6 +1712,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1337,6 +1731,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1358,10 +1760,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(11, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult?> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(11, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1378,6 +1783,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1394,6 +1802,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1416,10 +1832,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(12, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult?> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(12, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1437,6 +1856,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1453,6 +1875,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1476,10 +1906,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(13, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult?> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(13, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1498,6 +1931,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1514,6 +1950,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1538,10 +1982,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(14, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult?> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(14, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1561,6 +2008,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1577,6 +2027,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1602,10 +2060,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(15, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult?> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(15, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1626,6 +2087,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
         /// <summary>
@@ -1642,6 +2106,14 @@ namespace Wasmtime
             // Check that the requested type signature is compatible
             var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), typeof(T16), };
             
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult?> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
                 return null;
@@ -1668,10 +2140,13 @@ namespace Wasmtime
             // Create a factory for the return type
             var factory = IReturnTypeFactory<TResult>.Create();
 
-            return (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) =>
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(16, Results.Count);
+
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult?> result = (p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(16, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
                 convT1.Box(storeContext, store, ref argsAndResults[0], p0);
@@ -1693,6 +2168,9 @@ namespace Wasmtime
 
                 return InvokeWithReturn(argsAndResults, factory, storeContext);
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
     }

--- a/src/Function.Wrap.cs
+++ b/src/Function.Wrap.cs
@@ -25,9 +25,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = Array.Empty<Type>();
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action cached)
@@ -35,6 +32,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = Array.Empty<Type>();
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -71,9 +71,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T> cached)
@@ -81,6 +78,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -119,9 +119,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2> cached)
@@ -129,6 +126,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -169,9 +169,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3> cached)
@@ -179,6 +176,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -221,9 +221,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4> cached)
@@ -231,6 +228,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -275,9 +275,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5> cached)
@@ -285,6 +282,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -331,9 +331,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6> cached)
@@ -341,6 +338,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -389,9 +389,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7> cached)
@@ -399,6 +396,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -449,9 +449,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8> cached)
@@ -459,6 +456,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -511,9 +511,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> cached)
@@ -521,6 +518,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -575,9 +575,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> cached)
@@ -585,6 +582,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -641,9 +641,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> cached)
@@ -651,6 +648,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -709,9 +709,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> cached)
@@ -719,6 +716,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -779,9 +779,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> cached)
@@ -789,6 +786,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -851,9 +851,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> cached)
@@ -861,6 +858,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -925,9 +925,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> cached)
@@ -935,6 +932,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -1001,9 +1001,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), typeof(T16), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> cached)
@@ -1011,6 +1008,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), typeof(T16), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(default(Type), parameterTypes))
             {
@@ -1079,9 +1079,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = Array.Empty<Type>();
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<TResult?> cached)
@@ -1089,6 +1086,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = Array.Empty<Type>();
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1128,9 +1128,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T, TResult?> cached)
@@ -1138,6 +1135,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1179,9 +1179,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, TResult?> cached)
@@ -1189,6 +1186,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1232,9 +1232,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, TResult?> cached)
@@ -1242,6 +1239,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1287,9 +1287,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, TResult?> cached)
@@ -1297,6 +1294,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1344,9 +1344,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, TResult?> cached)
@@ -1354,6 +1351,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1403,9 +1403,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, TResult?> cached)
@@ -1413,6 +1410,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1464,9 +1464,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, TResult?> cached)
@@ -1474,6 +1471,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1527,9 +1527,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult?> cached)
@@ -1537,6 +1534,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1592,9 +1592,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult?> cached)
@@ -1602,6 +1599,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1659,9 +1659,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult?> cached)
@@ -1669,6 +1666,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1728,9 +1728,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult?> cached)
@@ -1738,6 +1735,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1799,9 +1799,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult?> cached)
@@ -1809,6 +1806,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1872,9 +1872,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult?> cached)
@@ -1882,6 +1879,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -1947,9 +1947,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult?> cached)
@@ -1957,6 +1954,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -2024,9 +2024,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult?> cached)
@@ -2034,6 +2031,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {
@@ -2103,9 +2103,6 @@ namespace Wasmtime
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), typeof(T16), };
-            
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult?> cached)
@@ -2113,6 +2110,9 @@ namespace Wasmtime
                 return cached;
             }
 
+            // Check that the requested type signature is compatible
+            var parameterTypes = new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), typeof(T16), };
+            
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(typeof(TResult), parameterTypes))
             {

--- a/src/Function.Wrap.cs
+++ b/src/Function.Wrap.cs
@@ -27,9 +27,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action cached)
+            if (_wrapperCache?.GetType() == typeof(Action))
             {
-                return cached;
+                return (Action)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -73,9 +73,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T>))
             {
-                return cached;
+                return (Action<T>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -121,9 +121,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2>))
             {
-                return cached;
+                return (Action<T1, T2>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -171,9 +171,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3>))
             {
-                return cached;
+                return (Action<T1, T2, T3>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -223,9 +223,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -277,9 +277,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -333,9 +333,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -391,9 +391,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6, T7>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6, T7>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -451,9 +451,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6, T7, T8>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6, T7, T8>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -513,9 +513,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6, T7, T8, T9>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -577,9 +577,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -643,9 +643,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -711,9 +711,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -781,9 +781,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -853,9 +853,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -927,9 +927,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1003,9 +1003,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> cached)
+            if (_wrapperCache?.GetType() == typeof(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>))
             {
-                return cached;
+                return (Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1081,9 +1081,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<TResult?>))
             {
-                return cached;
+                return (Func<TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1130,9 +1130,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T, TResult?>))
             {
-                return cached;
+                return (Func<T, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1181,9 +1181,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1234,9 +1234,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1289,9 +1289,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1346,9 +1346,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1405,9 +1405,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1466,9 +1466,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, T7, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, T7, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1529,9 +1529,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1594,9 +1594,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1661,9 +1661,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1730,9 +1730,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1801,9 +1801,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1874,9 +1874,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -1949,9 +1949,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -2026,9 +2026,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible
@@ -2105,9 +2105,9 @@ namespace Wasmtime
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult?> cached)
+            if (_wrapperCache?.GetType() == typeof(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult?>))
             {
-                return cached;
+                return (Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult?>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible

--- a/src/Function.Wrap.tt
+++ b/src/Function.Wrap.tt
@@ -48,9 +48,9 @@ foreach (var (_, returnTypeCount, parameterCount, methodGenerics, delegateType, 
 
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
-            if (_wrapperCache is <#= delegateType #> cached)
+            if (_wrapperCache?.GetType() == typeof(<#= delegateType #>))
             {
-                return cached;
+                return (<#= delegateType #>)_wrapperCache;
             }
 
             // Check that the requested type signature is compatible

--- a/src/Function.Wrap.tt
+++ b/src/Function.Wrap.tt
@@ -46,19 +46,19 @@ foreach (var (_, returnTypeCount, parameterCount, methodGenerics, delegateType, 
                 throw new InvalidOperationException("Cannot wrap a null function reference.");
             }
 
-            // Check that the requested type signature is compatible
-            <# if (callbackParameterTypeExpressions.Length == 0) { #>
-var parameterTypes = Array.Empty<Type>();
-            <# } else { #>
-var parameterTypes = new Type[] { <#= callbackParameterTypeExpressions #>};
-            <# } #>
-
             // Try to retrieve it from the cache. if it's cached it must have passed the type
             // signature check already, so it's safe to do this before CheckTypeSignature.
             if (_wrapperCache is <#= delegateType #> cached)
             {
                 return cached;
             }
+
+            // Check that the requested type signature is compatible
+            <# if (callbackParameterTypeExpressions.Length == 0) { #>
+var parameterTypes = Array.Empty<Type>();
+            <# } else { #>
+var parameterTypes = new Type[] { <#= callbackParameterTypeExpressions #>};
+            <# } #>
 
             // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(<#= callbackReturnTypeExpression #>, parameterTypes))

--- a/src/Function.Wrap.tt
+++ b/src/Function.Wrap.tt
@@ -23,6 +23,8 @@ namespace Wasmtime
 {
     public partial class Function
     {
+        private object? _wrapperCache;
+
 <#
 // Generate overloads of WrapAction/WrapFunc for up to 16 parameters and up to one return type
 // (2 * 17 overloads).
@@ -51,6 +53,14 @@ var parameterTypes = Array.Empty<Type>();
 var parameterTypes = new Type[] { <#= callbackParameterTypeExpressions #>};
             <# } #>
 
+            // Try to retrieve it from the cache. if it's cached it must have passed the type
+            // signature check already, so it's safe to do this before CheckTypeSignature.
+            if (_wrapperCache is <#= delegateType #> cached)
+            {
+                return cached;
+            }
+
+            // Check if the requested type signature is compatible with the function being wrapped
             if (!CheckTypeSignature(<#= callbackReturnTypeExpression #>, parameterTypes))
             {
                 return null;
@@ -68,7 +78,10 @@ var parameterTypes = new Type[] { <#= callbackParameterTypeExpressions #>};
 <# 
     } 
 #>
-            return (<#
+            // Determine how much space to allocate for params/results
+            var allocCount = Math.Max(<#= parameterCount.ToString(CultureInfo.InvariantCulture) #>, Results.Count);
+
+            <#= delegateType #> result = (<#
     for (int x = 0; x < parameterCount; x++)
     {
         if (x >= 1)
@@ -82,7 +95,7 @@ var parameterTypes = new Type[] { <#= callbackParameterTypeExpressions #>};
 #>) =>
             {
                 // Allocate space for both the arguments and the results.
-                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[Math.Max(<#= parameterCount.ToString(CultureInfo.InvariantCulture) #>, Results.Count)];
+                Span<ValueRaw> argsAndResults = stackalloc ValueRaw[allocCount];
                 var storeContext = store.Context;
 
 <#
@@ -110,6 +123,9 @@ var parameterTypes = new Type[] { <#= callbackParameterTypeExpressions #>};
     }
 #>
             };
+
+            _wrapperCache = result;
+            return result;
         }
 
 <#

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -124,6 +124,27 @@ namespace Wasmtime.Tests
         private FunctionsFixture Fixture { get; }
 
         [Fact]
+        public void WrappedFunctionIsNotCovariant()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var func = instance.GetFunction("return_funcref")!;
+
+            // This function returns `Function`, not `externref`, so this should be null
+            func.WrapFunc<object>().Should().BeNull();
+
+            // Wrap it as returning a `Function`, which should return as we expect
+            func.WrapFunc<Function>().Should().NotBeNull();
+
+            // Check that the cache does not give us back that function
+            func.WrapFunc<object>().Should().BeNull();
+
+            // Check that the cache still works
+            var a = func.WrapFunc<Function>();
+            var b = func.WrapFunc<Function>();
+            a.Should().BeSameAs(b);
+        }
+
+        [Fact]
         public void ItBindsImportMethodsAndCallsThemCorrectly()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);

--- a/tests/Modules/Functions.wat
+++ b/tests/Modules/Functions.wat
@@ -44,6 +44,11 @@
  )
  (data (i32.const 0) "Hello World")
 
+ (func $return_funcref (result funcref)
+    unreachable
+ )
+ (export "return_funcref" (func $return_funcref)) 
+
  (func (export "noop"))
  (func $echo_i32 (param i32) (result i32) local.get 0)
  (export "$echo_i32" (func $echo_i32))


### PR DESCRIPTION
Added a cache to `Function` which stores wrapped function. This allows Wrap to be called multiple times without lots of allocations of the same thing.

This will work well with #235 - a `Caller` can ask for a `Function` object (cached) and then wrap it (cached) and then call it, all without allocating anything 🥳 