### PR TITLE
Added a cache of `Global` objects in the `Store`

### DIFF
--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -577,7 +577,7 @@ namespace Wasmtime
 
             GC.KeepAlive(_store);
 
-            return new Global(_store, ext.of.global);
+            return _store.GetCachedExtern(ext.of.global);
         }
 
         private bool TryGetExtern(StoreContext context, string name, out Extern ext)

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -333,5 +333,18 @@ namespace Wasmtime
 
             return (Memory)mem;
         }
+
+        internal Global GetCachedExtern(ExternGlobal @extern)
+        {
+            var key = (ExternKind.Global, @extern.store, @extern.index);
+
+            if (!_externCache.TryGetValue(key, out var global))
+            {
+                global = new Global(this, @extern);
+                global = _externCache.GetOrAdd(key, global);
+            }
+
+            return (Global)global;
+        }
     }
 }


### PR DESCRIPTION
We already have `Function` and `Memory` objects in the `Store` cache, this adds `Global` objects too.