### PR TITLE
Update definition of `wasmtime_func_call_unchecked`.

### DIFF
--- a/src/Function.cs
+++ b/src/Function.cs
@@ -416,7 +416,7 @@ namespace Wasmtime
             IntPtr trap;
             fixed (ValueRaw* argsAndResultsPtr = argumentsAndResults)
             {
-                error = Native.wasmtime_func_call_unchecked(storeContext.handle, func, argsAndResultsPtr, out trap);
+                error = Native.wasmtime_func_call_unchecked(storeContext.handle, func, argsAndResultsPtr, (nuint)argumentsAndResults.Length, out trap);
 
                 // See comments above for the two reasons why the `Store` must be kept alive here.
                 GC.KeepAlive(store);
@@ -718,7 +718,7 @@ namespace Wasmtime
             public static unsafe extern IntPtr wasmtime_func_call(IntPtr context, in ExternFunc func, Value* args, nuint nargs, Value* results, nuint nresults, out IntPtr trap);
 
             [DllImport(Engine.LibraryName)]
-            public static unsafe extern IntPtr wasmtime_func_call_unchecked(IntPtr context, in ExternFunc func, ValueRaw* args_and_results, out IntPtr trap);
+            public static unsafe extern IntPtr wasmtime_func_call_unchecked(IntPtr context, in ExternFunc func, ValueRaw* args_and_results, nuint args_and_results_len, out IntPtr trap);
 
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasmtime_func_type(IntPtr context, in ExternFunc func);


### PR DESCRIPTION
Update definition of `wasmtime_func_call_unchecked`. See bytecodealliance/wasmtime#6262

Fixes #244

Note: The unit tests run successfully on my machine (Windows 10 x64) e.g. with `dotnet test` or when running them in Visual Studio without debugging; but when I run them in Visual Studio with debugging, the test `Wasmtime.Tests.ErrorTests.ItPassesCallbackErrorCauseAsInnerException` always fails with a `SEHException`, which seems to be caused by a Rust panic:

```
Building Test Projects
========== Starting test run ==========
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.3+1b45f5407b (64-bit .NET 7.0.5)
[xUnit.net 00:00:02.83]   Starting:    Wasmtime.Tests
[xUnit.net 00:00:03.40]     Wasmtime.Tests.ErrorTests.ItPassesCallbackErrorCauseAsInnerException [FAIL]
[xUnit.net 00:00:03.40]       Expected a <Wasmtime.WasmtimeException> to be thrown, but found <System.Runtime.InteropServices.SEHException>: "
[xUnit.net 00:00:03.40]       "System.Runtime.InteropServices.SEHException with message "External component has thrown an exception."
[xUnit.net 00:00:03.40]            at Wasmtime.Function.Native.wasmtime_func_call_unchecked(IntPtr context, ExternFunc& func, ValueRaw* args_and_results, UIntPtr args_and_results_len, IntPtr& trap)
[xUnit.net 00:00:03.40]            at Wasmtime.Function.Invoke(Span`1 argumentsAndResults, StoreContext storeContext) in C:\Users\developer4\Desktop\WebAssembly-Tests\wasmtime-dotnet\src\Function.cs:line 419
[xUnit.net 00:00:03.40]            at Wasmtime.Function.InvokeWithoutReturn(Span`1 arguments, StoreContext storeContext) in C:\Users\developer4\Desktop\WebAssembly-Tests\wasmtime-dotnet\src\Function.cs:line 232
[xUnit.net 00:00:03.40]            at Wasmtime.Function.<>c__DisplayClass171_0.<WrapAction>b__0() in C:\Users\developer4\Desktop\WebAssembly-Tests\wasmtime-dotnet\src\Function.Wrap.cs:line 56
[xUnit.net 00:00:03.40]            at FluentAssertions.Specialized.ActionAssertions.InvokeSubject()
[xUnit.net 00:00:03.40]            at FluentAssertions.Specialized.DelegateAssertions`2.InvokeSubjectWithInterception()
[xUnit.net 00:00:03.40]       .
[xUnit.net 00:00:03.40]       Stack Trace:
[xUnit.net 00:00:03.40]            at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message)
[xUnit.net 00:00:03.40]            at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
[xUnit.net 00:00:03.40]            at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
[xUnit.net 00:00:03.40]            at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
[xUnit.net 00:00:03.40]            at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
[xUnit.net 00:00:03.40]            at FluentAssertions.Execution.AssertionScope.FailWith(String message, Object[] args)
[xUnit.net 00:00:03.40]            at FluentAssertions.Specialized.DelegateAssertionsBase`2.ThrowInternal[TException](Exception exception, String because, Object[] becauseArgs)
[xUnit.net 00:00:03.40]            at FluentAssertions.Specialized.DelegateAssertions`2.Throw[TException](String because, Object[] becauseArgs)
[xUnit.net 00:00:03.40]         C:\Users\developer4\Desktop\WebAssembly-Tests\wasmtime-dotnet\tests\ErrorTests.cs(59,0): at Wasmtime.Tests.ErrorTests.ItPassesCallbackErrorCauseAsInnerException()
[xUnit.net 00:00:03.40]            at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
[xUnit.net 00:00:03.40]            at System.Reflection.MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
The active test run was aborted. Reason: Test host process crashed : thread '<unnamed>' panicked at '0x1 > 0xd6ef1fb140', crates\runtime\src\traphandlers\backtrace.rs:301:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at '0x1 > 0xd6ef1fb1f0', crates\runtime\src\traphandlers\backtrace.rs:301:13
stack backtrace:
   0:     0x7ff8a2844392 - set_vmctx_memory
   1:     0x7ff8a28626fb - set_vmctx_memory
   2:     0x7ff8a283f23a - set_vmctx_memory
   3:     0x7ff8a28440db - set_vmctx_memory
   4:     0x7ff8a28469c9 - set_vmctx_memory
   5:     0x7ff8a284664b - set_vmctx_memory
   6:     0x7ff8a28470f8 - set_vmctx_memory
   7:     0x7ff8a2846fee - set_vmctx_memory
   8:     0x7ff8a2844d79 - set_vmctx_memory
   9:     0x7ff8a2846ca0 - set_vmctx_memory
  10:     0x7ff8a290cd45 - _jit_debug_register_code
  11:     0x7ff8a2799aa5 - set_vmctx_memory
  12:     0x7ff8a2798788 - set_vmctx_memory
  13:     0x7ff8a279849b - set_vmctx_memory
  14:     0x7ff8a278c857 - wasm_module_delete
  15:     0x7ff8a278c9d7 - wasm_module_delete
  16:     0x7ff8a278c7ef - wasm_module_delete
  17:     0x7ff8a278c8b0 - wasm_module_delete
  18:     0x7ff8a23b112c - wasm_module_delete
  19:     0x7ff8a2266794 - wasm_foreign_as_ref_const
  20:     0x7ff8a28c3113 - _jit_debug_register_code
  21:     0x7ff8a225e8f2 - wasmtime_error_delete
  22:     0x7ff8a217cc29 - wasm_foreign_delete
  23:     0x7ff8a217cadb - wasm_foreign_delete
  24:     0x7ff8a228d2f8 - wasmtime_func_call_unchecked
  25:     0x7ff84eb0ad54 - <unknown>
  26:     0x7ff84eb0ab82 - <unknown>
  27:     0x7ff84eb0a9a9 - <unknown>
  28:     0x7ff84eb0a82d - <unknown>
  29:     0x7ff84eb0a6f1 - <unknown>
  30:     0x7ff84eb096ac - <unknown>
  31:     0x7ff84eb06e66 - <unknown>
  32:     0x7ff84eb30e44 - <unknown>
  33:     0x7ff8ac5bf523 - coreclr_shutdown_2
  34:     0x7ff8ac4f2fa4 - <unknown>
  35:     0x7ff84d2f42b9 - <unknown>
  36:     0x7ff84d2f34bf - <unknown>
  37:     0x7ff8a7518393 - <unknown>
  38:     0x7ff84eb0271c - <unknown>
  39:     0x7ff84eb022b6 - <unknown>
  40:     0x7ff84eb01c93 - <unknown>
  41:     0x7ff84eb01bc0 - <unknown>
  42:     0x7ff84eb01b36 - <unknown>
  43:     0x7ff84eb018c8 - <unknown>
  44:     0x7ff84eb01716 - <unknown>
  45:     0x7ff84eb0162c - <unknown>
  46:     0x7ff84eb01582 - <unknown>
  47:     0x7ff84eb01466 - <unknown>
  48:     0x7ff84eb01113 - <unknown>
  49:     0x7ff84eb00ef6 - <unknown>
  50:     0x7ff84eb00dac - <unknown>
  51:     0x7ff84eb00c7c - <unknown>
  52:     0x7ff84eb0070b - <unknown>
  53:     0x7ff84eb003c3 - <unknown>
  54:     0x7ff84eb00200 - <unknown>
  55:     0x7ff84eb000d3 - <unknown>
  56:     0x7ff84cb428ce - <unknown>
  57:     0x7ff84d340501 - <unknown>
  58:     0x7ff84d33fff3 - <unknown>
  59:     0x7ff84d33ff20 - <unknown>
  60:     0x7ff84d33fe91 - <unknown>
  61:     0x7ff84d33f915 - <unknown>
  62:     0x7ff84d33f7e6 - <unknown>
  63:     0x7ff84d33f2ac - <unknown>
  64:     0x7ff84d33f21c - <unknown>
  65:     0x7ff84d33f171 - <unknown>
  66:     0x7ff84d33eb1f - <unknown>
  67:     0x7ff84d33e7d2 - <unknown>
  68:     0x7ff84d33e576 - <unknown>
  69:     0x7ff84d33e4f0 - <unknown>
  70:     0x7ff84d33e495 - <unknown>
  71:     0x7ff84d33e3fa - <unknown>
  72:     0x7ff84d33e042 - <unknown>
  73:     0x7ff84d33df03 - <unknown>
  74:     0x7ff84d33de30 - <unknown>
  75:     0x7ff84d33dd61 - <unknown>
  76:     0x7ff84d33d2c5 - <unknown>
  77:     0x7ff84d33c8b3 - <unknown>
  78:     0x7ff84d33c7e0 - <unknown>
  79:     0x7ff84d33c5db - <unknown>
  80:     0x7ff84d33ae88 - <unknown>
  81:     0x7ff84d33a524 - <unknown>
  82:     0x7ff84d33a213 - <unknown>
  83:     0x7ff84d33a140 - <unknown>
  84:     0x7ff84d33a0a1 - <unknown>
  85:     0x7ff84d339852 - <unknown>
  86:     0x7ff84d339717 - <unknown>
  87:     0x7ff84d33937d - <unknown>
  88:     0x7ff84d3390d3 - <unknown>
  89:     0x7ff84d339000 - <unknown>
  90:     0x7ff84d338f5b - <unknown>
  91:     0x7ff84d338890 - <unknown>
  92:     0x7ff84d338663 - <unknown>
  93:     0x7ff84d338590 - <unknown>
  94:     0x7ff84d3384f0 - <unknown>
  95:     0x7ff84d3380a9 - <unknown>
  96:     0x7ff84d336b73 - <unknown>
  97:     0x7ff84d3363f3 - <unknown>
  98:     0x7ff84d336320 - <unknown>
  99:     0x7ff84d33627c - <unknown>
 100:     0x7ff84d330488 - <unknown>
 101:     0x7ff84d330143 - <unknown>
 102:     0x7ff84d330070 - <unknown>
 103:     0x7ff84d32ffd1 - <unknown>
 104:     0x7ff84d32fa96 - <unknown>
 105:     0x7ff84d32f3bb - <unknown>
 106:     0x7ff84d32ed03 - <unknown>
 107:     0x7ff84d32ec30 - <unknown>
 108:     0x7ff84d32eaab - <unknown>
 109:     0x7ff84d32c7e9 - <unknown>
 110:     0x7ff84d32c323 - <unknown>
 111:     0x7ff84d32c110 - <unknown>
 112:     0x7ff84d32c071 - <unknown>
 113:     0x7ff84d32b6b0 - <unknown>
 114:     0x7ff84d32b513 - <unknown>
 115:     0x7ff8a768abbf - <unknown>
 116:     0x7ff8a749cc98 - <unknown>
 117:     0x7ff8a74b4864 - <unknown>
 118:     0x7ff8a74b46bd - <unknown>
 119:     0x7ff8a74bd948 - <unknown>
 120:     0x7ff84d32b453 - <unknown>
 121:     0x7ff84d32b3e7 - <unknown>
 122:     0x7ff8a749cc98 - <unknown>
 123:     0x7ff84d32b358 - <unknown>
 124:     0x7ff84d329d52 - <unknown>
 125:     0x7ff84d326f73 - <unknown>
 126:     0x7ff8a749cc98 - <unknown>
 127:     0x7ff8a74b4864 - <unknown>
 128:     0x7ff8ac5bf523 - coreclr_shutdown_2
 129:     0x7ff8ac46eed0 - <unknown>
 130:     0x7ff8ac5afe43 - coreclr_execute_assembly
 131:     0x7ff8ac54a2e1 - MetaDataGetDispenser
 132:     0x7ff8ac54a1f7 - MetaDataGetDispenser
 133:     0x7ff8ac54a0e9 - MetaDataGetDispenser
 134:     0x7ff9728c7604 - BaseThreadInitThunk
 135:     0x7ff9745e26a1 - RtlUserThreadStart
thread panicked while panicking. aborting.

========== Test run aborted: 0 Tests (0 Passed, 0 Failed, 0 Skipped) run in < 1 ms ==========

```

I'm not sure what could be causing this, and why it happens only when running the tests with debugging.