### PR TITLE
.NET Standard 2.0 support

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -426,7 +426,7 @@ namespace Wasmtime
             public static extern void wasmtime_config_dynamic_memory_guard_size_set(Handle config, ulong size);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_config_cache_config_load(Handle config, [MarshalAs(UnmanagedType.LPUTF8Str)] string? path);
+            public static extern IntPtr wasmtime_config_cache_config_load(Handle config, [MarshalAs(Extensions.LPUTF8Str)] string? path);
         }
 
         private readonly Handle handle;

--- a/src/Export.cs
+++ b/src/Export.cs
@@ -84,7 +84,7 @@ namespace Wasmtime
                 }
                 else
                 {
-                    Name = Marshal.PtrToStringUTF8((IntPtr)name->data, checked((int)name->size));
+                    Name = Extensions.PtrToStringUTF8((IntPtr)name->data, checked((int)name->size));
                 }
             }
         }

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Wasmtime
+{
+    internal static class Extensions
+    {
+        public const UnmanagedType LPUTF8Str =
+#if NETSTANDARD2_0
+            (UnmanagedType)48;
+#else
+            UnmanagedType.LPUTF8Str;
+#endif
+
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe string GetString(this Encoding encoding, Span<byte> bytes)
+        {
+            fixed (byte* bytesPtr = bytes)
+            {
+                return encoding.GetString(bytesPtr, bytes.Length);
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+        {
+            fixed (byte* bytesPtr = bytes)
+            {
+                return encoding.GetString(bytesPtr, bytes.Length);
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe int GetBytes(this Encoding encoding, Span<char> chars, Span<byte> bytes)
+        {
+            fixed (char* charsPtr = chars)
+            fixed (byte* bytesPtr = bytes)
+            {
+                return encoding.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
+        {
+            fixed (char* charsPtr = chars)
+            fixed (byte* bytesPtr = bytes)
+            {
+                return encoding.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe int GetBytes(this Encoding encoding, string chars, Span<byte> bytes)
+        {
+            fixed (char* charsPtr = chars)
+            fixed (byte* bytesPtr = bytes)
+            {
+                return encoding.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
+            }
+        }
+#endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsTupleType(this Type type)
+        {
+#if NETSTANDARD2_0
+            return type.FullName.StartsWith("System.ValueTuple`");
+#else
+            return typeof(ITuple).IsAssignableFrom(type);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Int32BitsToSingle(int value)
+        {
+#if NETSTANDARD2_0
+            unsafe
+            {
+                return *(float*)&value;
+            }
+#else
+            return BitConverter.Int32BitsToSingle(value);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int SingleToInt32Bits(float value)
+        {
+#if NETSTANDARD2_0
+            unsafe
+            {
+                return *(int*)&value;
+            }
+#else
+            return BitConverter.SingleToInt32Bits(value);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string PtrToStringUTF8(IntPtr ptr, int byteLen)
+        {
+#if NETSTANDARD2_0
+            unsafe
+            {
+                return Encoding.UTF8.GetString((byte*)ptr, byteLen);
+            }
+#else
+            return Marshal.PtrToStringUTF8(ptr, byteLen);
+#endif
+        }
+    }
+}

--- a/src/Function.Wrap.cs
+++ b/src/Function.Wrap.cs
@@ -1098,7 +1098,7 @@ namespace Wasmtime
             // Fetch a converter for each parameter type to box it
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(0, Results.Count);
@@ -1148,7 +1148,7 @@ namespace Wasmtime
             var convT = ValueRaw.Converter<T>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(1, Results.Count);
@@ -1200,7 +1200,7 @@ namespace Wasmtime
             var convT2 = ValueRaw.Converter<T2>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(2, Results.Count);
@@ -1254,7 +1254,7 @@ namespace Wasmtime
             var convT3 = ValueRaw.Converter<T3>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(3, Results.Count);
@@ -1310,7 +1310,7 @@ namespace Wasmtime
             var convT4 = ValueRaw.Converter<T4>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(4, Results.Count);
@@ -1368,7 +1368,7 @@ namespace Wasmtime
             var convT5 = ValueRaw.Converter<T5>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(5, Results.Count);
@@ -1428,7 +1428,7 @@ namespace Wasmtime
             var convT6 = ValueRaw.Converter<T6>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(6, Results.Count);
@@ -1490,7 +1490,7 @@ namespace Wasmtime
             var convT7 = ValueRaw.Converter<T7>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(7, Results.Count);
@@ -1554,7 +1554,7 @@ namespace Wasmtime
             var convT8 = ValueRaw.Converter<T8>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(8, Results.Count);
@@ -1620,7 +1620,7 @@ namespace Wasmtime
             var convT9 = ValueRaw.Converter<T9>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(9, Results.Count);
@@ -1688,7 +1688,7 @@ namespace Wasmtime
             var convT10 = ValueRaw.Converter<T10>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(10, Results.Count);
@@ -1758,7 +1758,7 @@ namespace Wasmtime
             var convT11 = ValueRaw.Converter<T11>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(11, Results.Count);
@@ -1830,7 +1830,7 @@ namespace Wasmtime
             var convT12 = ValueRaw.Converter<T12>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(12, Results.Count);
@@ -1904,7 +1904,7 @@ namespace Wasmtime
             var convT13 = ValueRaw.Converter<T13>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(13, Results.Count);
@@ -1980,7 +1980,7 @@ namespace Wasmtime
             var convT14 = ValueRaw.Converter<T14>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(14, Results.Count);
@@ -2058,7 +2058,7 @@ namespace Wasmtime
             var convT15 = ValueRaw.Converter<T15>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(15, Results.Count);
@@ -2138,7 +2138,7 @@ namespace Wasmtime
             var convT16 = ValueRaw.Converter<T16>();
 
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
             // Determine how much space to allocate for params/results
             var allocCount = Math.Max(16, Results.Count);

--- a/src/Function.Wrap.tt
+++ b/src/Function.Wrap.tt
@@ -73,7 +73,7 @@ var parameterTypes = new Type[] { <#= callbackParameterTypeExpressions #>};
     { 
 #>
             // Create a factory for the return type
-            var factory = IReturnTypeFactory<TResult>.Create();
+            var factory = ReturnTypeFactory<TResult>.Create();
 
 <# 
     } 

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -132,10 +132,10 @@ namespace Wasmtime
             }
 
             // Validate the return type(s)
-            if (returnType != null)
+            if(returnType != null)
             {
                 // Multiple return types are represented by a tuple.
-                if (typeof(ITuple).IsAssignableFrom(returnType))
+                if (returnType.IsTupleType())
                 {
                     // Get the types from the tuple
                     var returnTypes = returnType.GetGenericArguments();

--- a/src/Import.cs
+++ b/src/Import.cs
@@ -91,7 +91,7 @@ namespace Wasmtime
                 }
                 else
                 {
-                    ModuleName = Marshal.PtrToStringUTF8((IntPtr)moduleName->data, checked((int)moduleName->size));
+                    ModuleName = Extensions.PtrToStringUTF8((IntPtr)moduleName->data, checked((int)moduleName->size));
                 }
 
                 var name = Native.wasm_importtype_name(importType);
@@ -101,7 +101,7 @@ namespace Wasmtime
                 }
                 else
                 {
-                    Name = Marshal.PtrToStringUTF8((IntPtr)name->data, checked((int)name->size));
+                    Name = Extensions.PtrToStringUTF8((IntPtr)name->data, checked((int)name->size));
                 }
             }
         }

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -481,7 +481,7 @@ namespace Wasmtime
         /// <returns>Returns the single read from memory.</returns>
         public float ReadSingle(long address)
         {
-            return BitConverter.Int32BitsToSingle(ReadInt32(address));
+            return Extensions.Int32BitsToSingle(ReadInt32(address));
         }
 
         /// <summary>
@@ -491,7 +491,7 @@ namespace Wasmtime
         /// <param name="value">The single to write.</param>
         public void WriteSingle(long address, float value)
         {
-            WriteInt32(address, BitConverter.SingleToInt32Bits(value));
+            WriteInt32(address, Extensions.SingleToInt32Bits(value));
         }
 
         /// <summary>

--- a/src/Module.cs
+++ b/src/Module.cs
@@ -438,7 +438,7 @@ namespace Wasmtime
             public static extern unsafe IntPtr wasmtime_module_deserialize(Engine.Handle engine, byte* bytes, UIntPtr size, out IntPtr handle);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_module_deserialize_file(Engine.Handle engine, [MarshalAs(UnmanagedType.LPUTF8Str)] string path, out IntPtr handle);
+            public static extern IntPtr wasmtime_module_deserialize_file(Engine.Handle engine, [MarshalAs(Extensions.LPUTF8Str)] string path, out IntPtr handle);
         }
 
         private readonly Handle handle;

--- a/src/TemporaryAllocation.cs
+++ b/src/TemporaryAllocation.cs
@@ -37,7 +37,7 @@ namespace Wasmtime
 
             var rented = ArrayPool<byte>.Shared.Rent(length);
             Encoding.UTF8.GetBytes(str, rented);
-            return new TemporaryAllocation(rented[..length], rented);
+            return new TemporaryAllocation(rented.AsSpan()[..length], rented);
         }
 
         /// <summary>

--- a/src/V128.cs
+++ b/src/V128.cs
@@ -92,7 +92,14 @@ namespace Wasmtime
         {
             unsafe
             {
+#if NETSTANDARD2_0
+                fixed (byte* bytesPtr = bytes)
+                {
+                    return new Span<byte>(bytesPtr, 16);
+                }
+#else
                 return MemoryMarshal.CreateSpan(ref bytes[0], 16);
+#endif
             }
         }
 

--- a/src/ValueRaw.cs
+++ b/src/ValueRaw.cs
@@ -142,7 +142,7 @@ namespace Wasmtime
         public void Box(StoreContext storeContext, Store store, ref ValueRaw valueRaw, float value)
         {
             // See comments in Int32ValueRawConverter for why we set the i64 field.
-            valueRaw.i64 = unchecked((uint)BitConverter.SingleToInt32Bits(value));
+            valueRaw.i64 = unchecked((uint)Extensions.SingleToInt32Bits(value));
         }
     }
 

--- a/src/WasiConfiguration.cs
+++ b/src/WasiConfiguration.cs
@@ -355,7 +355,7 @@ namespace Wasmtime
 
             if (!string.IsNullOrEmpty(_standardInputPath))
             {
-                if (!Native.wasi_config_set_stdin_file(config, _standardInputPath))
+                if (!Native.wasi_config_set_stdin_file(config, _standardInputPath!))
                 {
                     throw new InvalidOperationException($"Failed to set stdin to file '{_standardInputPath}'.");
                 }
@@ -372,7 +372,7 @@ namespace Wasmtime
 
             if (!string.IsNullOrEmpty(_standardOutputPath))
             {
-                if (!Native.wasi_config_set_stdout_file(config, _standardOutputPath))
+                if (!Native.wasi_config_set_stdout_file(config, _standardOutputPath!))
                 {
                     throw new InvalidOperationException($"Failed to set stdout to file '{_standardOutputPath}'.");
                 }
@@ -389,7 +389,7 @@ namespace Wasmtime
 
             if (!string.IsNullOrEmpty(_standardErrorPath))
             {
-                if (!Native.wasi_config_set_stderr_file(config, _standardErrorPath))
+                if (!Native.wasi_config_set_stderr_file(config, _standardErrorPath!))
                 {
                     throw new InvalidOperationException($"Failed to set stderr to file '{_standardErrorPath}'.");
                 }
@@ -467,7 +467,7 @@ namespace Wasmtime
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasi_config_set_stdin_file(
                 Handle config,
-                [MarshalAs(UnmanagedType.LPUTF8Str)] string path
+                [MarshalAs(Extensions.LPUTF8Str)] string path
             );
 
             [DllImport(Engine.LibraryName)]
@@ -477,7 +477,7 @@ namespace Wasmtime
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasi_config_set_stdout_file(
                 Handle config,
-                [MarshalAs(UnmanagedType.LPUTF8Str)] string path
+                [MarshalAs(Extensions.LPUTF8Str)] string path
             );
 
             [DllImport(Engine.LibraryName)]
@@ -487,7 +487,7 @@ namespace Wasmtime
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasi_config_set_stderr_file(
                 Handle config,
-                [MarshalAs(UnmanagedType.LPUTF8Str)] string path
+                [MarshalAs(Extensions.LPUTF8Str)] string path
             );
 
             [DllImport(Engine.LibraryName)]
@@ -497,8 +497,8 @@ namespace Wasmtime
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasi_config_preopen_dir(
                 Handle config,
-                [MarshalAs(UnmanagedType.LPUTF8Str)] string path,
-                [MarshalAs(UnmanagedType.LPUTF8Str)] string guestPath
+                [MarshalAs(Extensions.LPUTF8Str)] string path,
+                [MarshalAs(Extensions.LPUTF8Str)] string guestPath
             );
         }
 

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net7.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
@@ -39,10 +39,12 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="IndexRange" Version="1.0.2" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Updated to support .NET Standard 2.0 via multi-targeting. This brings the following changes (most of which are conditionally-compiled):

* Added references to `System.Memory` and `IndexRange` (only for `netstandard2.0`).
* `UnmanagedType.LPUTF8Str` is referenced as `(UnmanagedType)48`.
* `Marshal.PtrToStringUTF8` and various other methods are reimplemented using various workarounds, found in the `Extensions` class.
* Detection of tuple types checks for types starting with <code>System.ValueTuple\`</code> instead of implementing `ITuple` (which is perhaps even better, since `System.Tuple` also implements `ITuple` but cannot be used this way).
* Static methods in `IReturnTypeFactory` moved to new non-interface `ReturnTypeFactory`.
* Unconditional workarounds for `GetSubArray` (should be faster anyway).