### PR TITLE
Use a more reliable way to apply a timeout (epoch interruption)

### DIFF
--- a/tests/EpochInterruptionTests.cs
+++ b/tests/EpochInterruptionTests.cs
@@ -41,11 +41,10 @@ public class EpochInterruptionTests : IClassFixture<EpochInterruptionFixture>, I
 
         var action = () =>
         {
-            using (var timer = new Timer(state => Fixture.Engine.IncrementEpoch()))
-            {
-                timer.Change(TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(Timeout.Infinite));
-                run.Invoke();
-            }
+            using var cts = new CancellationTokenSource(100);
+            using var tokenRegistration = cts.Token.Register(Fixture.Engine.IncrementEpoch);
+
+            run.Invoke();            
         };
 
         action.Should()


### PR DESCRIPTION
Use a more reliable way to apply a timeout for a wasm function call with epoch interruption in the `EpochInterruptionTests`.

(This is not strictly required for this specific test as the wasm function is an infinite loop, but intended to be a better example illustrating this approach.)

When using a `System.Threading.Timer` with a `dueTime`, it could happen that the specified callback is called even after the timer was disposed, which could mean that if the wasm function isn't actually an infinite loop, the engine might already have been disposed when the timer callback is executed, which would lead to a crash due to an unhandled `ObjectDisposedException` thrown by `Engine.IncrementEpoch()`.

In contrast, `CancellationTokenRegistration.Dispose()` waits until the callback is finished (if it's currently executing), so that it's guaranteed that after disposing the registration, `Engine.IncrementEpoch()` isn't called any more.