### PR TITLE
Change to use `windows-2019` to fix CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,10 @@ jobs:
             os: macos-latest
             config: release
           - build: windows-debug
-            os: windows-latest
+            os: windows-2019
             config: debug
           - build: windows-release
-            os: windows-latest
+            os: windows-2019
             config: release
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR is an attempt to work around flakiness in the Windows CI relating to downloading Wasmtime release assets.

See https://github.com/actions/runner-images/issues/7007.