### PR TITLE
Added Relaxed SIMD

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -157,7 +157,7 @@ namespace Wasmtime
         }
 
         /// <summary>
-        /// Sets whether or not enable WebAssembly Relaxed SIMD support. New SIMD instructions that may be non-deterministic across different hosts unless deterministic mode is enabled.
+        /// Sets whether or not to enable WebAssembly Relaxed SIMD support. New SIMD instructions that may be non-deterministic across different hosts unless deterministic mode is enabled.
         /// </summary>
         /// <param name="enable">True to enable WebAssembly Relaxed SIMD support or false to disable.</param>
         /// <param name="deterministic">True to enable deterministic mode for WebAssembly Relaxed SIMD or false to allow non-deterministic execution.</param>

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -157,6 +157,19 @@ namespace Wasmtime
         }
 
         /// <summary>
+        /// Sets whether or not enable WebAssembly Relaxed SIMD support. New SIMD instructions that may be non-deterministic across different hosts unless deterministic mode is enabled.
+        /// </summary>
+        /// <param name="enable">True to enable WebAssembly Relaxed SIMD support or false to disable.</param>
+        /// <param name="deterministic">True to enable deterministic mode for WebAssembly Relaxed SIMD or false to allow non-deterministic execution.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithRelaxedSIMD(bool enable, bool deterministic)
+        {
+            Native.wasmtime_config_wasm_relaxed_simd_set(handle, enable);
+            Native.wasmtime_config_wasm_relaxed_simd_deterministic_set(handle, deterministic);
+            return this;
+        }
+
+        /// <summary>
         /// Sets whether or not enable WebAssembly bulk memory support.
         /// </summary>
         /// <param name="enable">True to enable WebAssembly bulk memory support or false to disable.</param>
@@ -392,6 +405,12 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_wasm_simd_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_relaxed_simd_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_relaxed_simd_deterministic_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_wasm_bulk_memory_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);

--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -120,6 +120,16 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItSetsRelaxedSIMD()
+        {
+            var config = new Config();
+            config.WithRelaxedSIMD(true, true);
+
+            using var engine = new Engine(config);
+            using var module = Module.FromTextFile(engine, Path.Combine("Modules", "RelaxedSIMD.wat"));
+        }
+
+        [Fact]
         public void ItSetsBulkMemory()
         {
             var config = new Config();

--- a/tests/Modules/RelaxedSIMD.wat
+++ b/tests/Modules/RelaxedSIMD.wat
@@ -1,0 +1,9 @@
+﻿(module
+  (func $madd_v128 (param v128) (result v128)
+	local.get 0
+	local.get 0
+	local.get 0
+	f32x4.relaxed_madd
+  )
+  (export "$madd_v128" (func $madd_v128))
+)


### PR DESCRIPTION
Added a new config method `WithRelaxedSIMD(bool enable, bool deterministic)` which enables relaxed SIMD (introduced in https://github.com/bytecodealliance/wasmtime/pull/5892, exposed to c-api in https://github.com/bytecodealliance/wasmtime/pull/6292)