### PR TITLE
Use `csharp` instead of `c#` for code blocks for the package's README.md

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -33,7 +33,7 @@ $ dotnet add package wasmtime
 
 Replace the contents of `Program.cs` with the following code:
 
-```c#
+```csharp
 using System;
 using Wasmtime;
 


### PR DESCRIPTION
NuGet doesn't seem to recognize `c#` as language for code blocks and doesn't apply syntax highlighting for it, whereas `csharp` seems to work - see https://www.nuget.org/packages/MySqlConnector with https://github.com/mysql-net/MySqlConnector/blob/master/src/MySqlConnector/docs/README.md for an example.

Thanks!