### PR TITLE
Added `TableKind` for tables

### DIFF
--- a/examples/table/Program.cs
+++ b/examples/table/Program.cs
@@ -6,7 +6,7 @@ using var module = Module.FromTextFile(engine, "table.wat");
 using var linker = new Linker(engine);
 using var store = new Store(engine);
 
-var table = new Table(store, ValueKind.FuncRef, null, 4);
+var table = new Table(store, TableKind.FuncRef, null, 4);
 
 table.SetElement(0, Function.FromCallback(store, (int a, int b) => a + b));
 table.SetElement(1, Function.FromCallback(store, (int a, int b) => a - b));

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -33,6 +33,7 @@ namespace Wasmtime
         /// <param name="initialValue">The initial value for elements in the table.</param>
         /// <param name="initial">The number of initial elements in the table.</param>
         /// <param name="maximum">The maximum number of elements in the table.</param>
+        [Obsolete("Replace ValueKind parameter with TableKind")]
         public Table(Store store, ValueKind kind, object? initialValue, uint initial, uint maximum = uint.MaxValue)
             : this(store, (TableKind)kind, initialValue, initial, maximum)
         {

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -5,6 +5,22 @@ using Microsoft.Win32.SafeHandles;
 namespace Wasmtime
 {
     /// <summary>
+    /// Represents the possible kinds of WebAssembly values stored in a table
+    /// </summary>
+    public enum TableKind
+    {
+        /// <summary>
+        /// The value is a function reference.
+        /// </summary>
+        FuncRef = ValueKind.FuncRef,
+
+        /// <summary>
+        /// The value is an external reference.
+        /// </summary>
+        ExternRef = ValueKind.ExternRef,
+    }
+
+    /// <summary>
     /// Represents a WebAssembly table.
     /// </summary>
     public class Table : IExternal
@@ -18,13 +34,26 @@ namespace Wasmtime
         /// <param name="initial">The number of initial elements in the table.</param>
         /// <param name="maximum">The maximum number of elements in the table.</param>
         public Table(Store store, ValueKind kind, object? initialValue, uint initial, uint maximum = uint.MaxValue)
+            : this(store, (TableKind)kind, initialValue, initial, maximum)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new WebAssembly table.
+        /// </summary>
+        /// <param name="store">The store to create the table in.</param>
+        /// <param name="kind">The value kind for the elements in the table.</param>
+        /// <param name="initialValue">The initial value for elements in the table.</param>
+        /// <param name="initial">The number of initial elements in the table.</param>
+        /// <param name="maximum">The maximum number of elements in the table.</param>
+        public Table(Store store, TableKind kind, object? initialValue, uint initial, uint maximum = uint.MaxValue)
         {
             if (store is null)
             {
                 throw new ArgumentNullException(nameof(store));
             }
 
-            if (kind != ValueKind.ExternRef && kind != ValueKind.FuncRef)
+            if (kind != TableKind.ExternRef && kind != TableKind.FuncRef)
             {
                 throw new WasmtimeException($"Table elements must be externref or funcref.");
             }
@@ -63,7 +92,7 @@ namespace Wasmtime
         /// Gets the value kind of the table.
         /// </summary>
         /// <value></value>
-        public ValueKind Kind { get; private set; }
+        public TableKind Kind { get; private set; }
 
         /// <summary>
         /// The minimum table element size.
@@ -154,7 +183,7 @@ namespace Wasmtime
             using var type = new TypeHandle(Native.wasmtime_table_type(store.Context.handle, this.table));
             GC.KeepAlive(store);
 
-            this.Kind = ValueType.ToKind(Native.wasm_tabletype_element(type.DangerousGetHandle()));
+            this.Kind = (TableKind)ValueType.ToKind(Native.wasm_tabletype_element(type.DangerousGetHandle()));
 
             unsafe
             {

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -59,6 +59,11 @@ namespace Wasmtime
 
     internal static class ValueType
     {
+        public static IntPtr FromKind(TableKind kind)
+        {
+            return FromKind((ValueKind)kind);
+        }
+
         public static IntPtr FromKind(ValueKind kind)
         {
             switch (kind)
@@ -249,6 +254,11 @@ namespace Wasmtime
             {
                 return new ValueBox(ResolveExternRef());
             }
+        }
+
+        public static Value FromObject(object? o, TableKind kind)
+        {
+            return FromObject(o, (ValueKind)kind);
         }
 
         public static Value FromObject(object? o, ValueKind kind)

--- a/tests/StoreTests.cs
+++ b/tests/StoreTests.cs
@@ -39,7 +39,7 @@ namespace Wasmtime.Tests
         {
             Store.SetLimits(tableElements: 5);
 
-            var table = new Table(Store, ValueKind.ExternRef, null, 0);
+            var table = new Table(Store, TableKind.ExternRef, null, 0);
             table.GetSize().Should().Be(0);
 
             table.Grow(5, null);

--- a/tests/TableExportsTests.cs
+++ b/tests/TableExportsTests.cs
@@ -50,19 +50,19 @@ namespace Wasmtime.Tests
 
             var table1 = instance.GetTable("table1");
             table1.Should().NotBeNull();
-            table1.Kind.Should().Be(ValueKind.FuncRef);
+            table1.Kind.Should().Be(TableKind.FuncRef);
             table1.Minimum.Should().Be(1);
             table1.Maximum.Should().Be(10);
 
             var table2 = instance.GetTable("table2");
             table2.Should().NotBeNull();
-            table2.Kind.Should().Be(ValueKind.FuncRef);
+            table2.Kind.Should().Be(TableKind.FuncRef);
             table2.Minimum.Should().Be(10);
             table2.Maximum.Should().Be(uint.MaxValue);
 
             var table3 = instance.GetTable("table3");
             table3.Should().NotBeNull();
-            table3.Kind.Should().Be(ValueKind.FuncRef);
+            table3.Kind.Should().Be(TableKind.FuncRef);
             table3.Minimum.Should().Be(100);
             table3.Maximum.Should().Be(1000);
         }

--- a/tests/TableImportBindingTests.cs
+++ b/tests/TableImportBindingTests.cs
@@ -38,8 +38,8 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItFailsToInstantiateWithTableTypeMismatch()
         {
-            var funcs = new Table(Store, ValueKind.ExternRef, null, 10);
-            var externs = new Table(Store, ValueKind.ExternRef, null, 10);
+            var funcs = new Table(Store, TableKind.ExternRef, null, 10);
+            var externs = new Table(Store, TableKind.ExternRef, null, 10);
 
             Linker.Define("", "funcs", funcs);
             Linker.Define("", "externs", externs);
@@ -55,8 +55,8 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItFailsToInstantiateWithTableLimitsMismatch()
         {
-            var funcs = new Table(Store, ValueKind.FuncRef, null, 10);
-            var externs = new Table(Store, ValueKind.ExternRef, null, 1);
+            var funcs = new Table(Store, TableKind.FuncRef, null, 10);
+            var externs = new Table(Store, TableKind.ExternRef, null, 1);
 
             Linker.Define("", "funcs", funcs);
             Linker.Define("", "externs", externs);
@@ -72,8 +72,8 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItBindsTheTableCorrectly()
         {
-            var funcs = new Table(Store, ValueKind.FuncRef, null, 10);
-            var externs = new Table(Store, ValueKind.ExternRef, null, 10);
+            var funcs = new Table(Store, TableKind.FuncRef, null, 10);
+            var externs = new Table(Store, TableKind.ExternRef, null, 10);
 
             Linker.Define("", "funcs", funcs);
             Linker.Define("", "externs", externs);
@@ -120,8 +120,8 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItGrowsATable()
         {
-            var funcs = new Table(Store, ValueKind.FuncRef, null, 10, 20);
-            var externs = new Table(Store, ValueKind.ExternRef, null, 10, 20);
+            var funcs = new Table(Store, TableKind.FuncRef, null, 10, 20);
+            var externs = new Table(Store, TableKind.ExternRef, null, 10, 20);
 
             Linker.Define("", "funcs", funcs);
             Linker.Define("", "externs", externs);


### PR DESCRIPTION
Replaced `ValueKind` with `TableKind` in `Table`. This properly represents the range of type a `Table` may contain. I've minimised the amount of breakage by still accepting `ValueKind` in the constructor (marked with an `Obsolete` attribute, to steer peope towards the new constructor).

This is a small improvement (it provides a hint at valid table types) but it is still a bit fragile. It's very easy to use an incorrect `Kind` or to pass an incorrect type into `SetElement`. We may want to improve on that in the future (e.g. type safe table wrappers, like we have for globals).