### PR TITLE
Replace Exec task with Unzip task

### DIFF
--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -167,8 +167,6 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       Condition="('$(Packing)'=='true' Or '%(Wasmtime.Copy)'=='true') And %(Wasmtime.FileExtension) == 'zip' And !Exists('$(BaseIntermediateOutputPath)$(ReleaseFileNameBase)-%(Wasmtime.Arch)-%(Wasmtime.OS)-c-api')"
       SourceFiles="$(BaseIntermediateOutputPath)\$(ReleaseFileNameBase)-%(Wasmtime.Arch)-%(Wasmtime.OS)-c-api.%(Wasmtime.FileExtension)"
       DestinationFolder="$(BaseIntermediateOutputPath)"
-      StandardOutputImportance="Low"
-      StandardErrorImportance="Low"
     />
 
     <!-- The content here is specifically for packing -->

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -163,10 +163,10 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       StandardOutputImportance="Low"
       StandardErrorImportance="Low"
     />
-    <Exec
+    <Unzip
       Condition="('$(Packing)'=='true' Or '%(Wasmtime.Copy)'=='true') And %(Wasmtime.FileExtension) == 'zip' And !Exists('$(BaseIntermediateOutputPath)$(ReleaseFileNameBase)-%(Wasmtime.Arch)-%(Wasmtime.OS)-c-api')"
-      Command="unzip $(ReleaseFileNameBase)-%(Wasmtime.Arch)-%(Wasmtime.OS)-c-api.%(Wasmtime.FileExtension)"
-      WorkingDirectory="$(BaseIntermediateOutputPath)"
+      SourceFiles="$(BaseIntermediateOutputPath)\$(ReleaseFileNameBase)-%(Wasmtime.Arch)-%(Wasmtime.OS)-c-api.%(Wasmtime.FileExtension)"
+      DestinationFolder="$(BaseIntermediateOutputPath)"
       StandardOutputImportance="Low"
       StandardErrorImportance="Low"
     />


### PR DESCRIPTION
Removes dependency on having unzip in path

**How did I test it?**

The only test I have run is on Windows 11 building under Powershell 7.3.5

```powershell
PS> dotnet build .\Wasmtime.sln
```

If your CI does not handle the other platforms then let me know if you feel additional testing is needed on my side.

Fixes #266 