### PR TITLE
Fix failing tests after the changes in bytecodealliance/wasmtime#7285

### DIFF
--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -109,6 +109,7 @@ namespace Wasmtime.Tests
         {
             var config = new Config();
             config.WithSIMD(false);
+            config.WithRelaxedSIMD(false, false);
 
             Action act = () =>
             {
@@ -123,10 +124,15 @@ namespace Wasmtime.Tests
         public void ItSetsRelaxedSIMD()
         {
             var config = new Config();
-            config.WithRelaxedSIMD(true, true);
+            config.WithRelaxedSIMD(false, false);
 
-            using var engine = new Engine(config);
-            using var module = Module.FromTextFile(engine, Path.Combine("Modules", "RelaxedSIMD.wat"));
+            Action act = () =>
+            {
+                using var engine = new Engine(config);
+                using var module = Module.FromTextFile(engine, Path.Combine("Modules", "RelaxedSIMD.wat"));
+            };
+
+            act.Should().Throw<WasmtimeException>();
         }
 
         [Fact]
@@ -134,6 +140,7 @@ namespace Wasmtime.Tests
         {
             var config = new Config();
             config.WithBulkMemory(false);
+            config.WithWasmThreads(false);
             config.WithReferenceTypes(false);
 
             Action act = () =>

--- a/tests/MultiMemoryTests.cs
+++ b/tests/MultiMemoryTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using FluentAssertions;
 using Xunit;
 
@@ -8,9 +7,9 @@ namespace Wasmtime.Tests
     public class MultiMemoryTests
     {
         [Fact]
-        public void ItFailsWithoutMultiMemoryEnabled()
+        public void ItFailsWithMultiMemoryDisabled()
         {
-            using var engine = new Engine();
+            using var engine = new Engine(new Config().WithMultiMemory(false));
             Action action = () =>
             {
                 using var module = Module.FromText(engine, "test", @"(module (memory 0 1) (memory 0 1))");
@@ -23,9 +22,9 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
-        public void ItSucceedsWithMultiMemoryEnabled()
+        public void ItSucceedsWithoutMultiMemoryDisabled()
         {
-            using var engine = new Engine(new Config().WithMultiMemory(true));
+            using var engine = new Engine();
             using var module = Module.FromText(engine, "test", @"(module (memory 0 1) (memory 0 1))");
         }
     }


### PR DESCRIPTION
Fix failing tests after the changes in bytecodealliance/wasmtime#7285.

Since that change, `threads`, `multi-memory`, and `relaxed-simd` are enabled by default. E.g. disabling `bulk-memory` also requires disabling `threads`, and disabling `simd` also requires disabling `relaxed-simd`.