### PR TITLE
Update to the new fuel APIs

### DIFF
--- a/examples/consumefuel/Program.cs
+++ b/examples/consumefuel/Program.cs
@@ -12,7 +12,12 @@ linker.Define(
     "expensive",
     Function.FromCallback(store, (Caller caller) =>
     {
-        var remaining = caller.ConsumeFuel(1000UL);
+        checked
+        {
+            caller.Fuel -= 1000UL;
+        }
+
+        var remaining = caller.Fuel;
         Console.WriteLine($"Called an expensive function which consumed 1000 fuel. {remaining} units of fuel remaining.");
     }
 ));
@@ -26,7 +31,7 @@ if (expensive is null)
     return;
 }
 
-store.AddFuel(5000UL);
+store.Fuel += 5000UL;
 Console.WriteLine("Added 5000 units of fuel");
 
 for (var i = 0; i < 4; i++)

--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -137,33 +137,23 @@ namespace Wasmtime
         public Store Store => store;
 
         /// <summary>
-        /// Adds fuel to this store for WebAssembly code to consume while executing.
+        /// Gets or sets the fuel available for WebAssembly code to consume while executing.
         /// </summary>
-        /// <param name="fuel">The fuel to add to the store.</param>
-        public void AddFuel(ulong fuel) => context.AddFuel(fuel);
-
-        /// <summary>
-        /// Synthetically consumes fuel from this store.
-        ///
-        /// For this method to work fuel consumption must be enabled via <see cref="Config.WithFuelConsumption(bool)"/>.
-        ///
+        /// <remarks>
+        /// <para>
+        /// For this property to work, fuel consumption must be enabled via <see cref="Config.WithFuelConsumption(bool)"/>.
+        /// </para>
+        /// <para>
         /// WebAssembly execution will automatically consume fuel but if so desired the embedder can also consume fuel manually
         /// to account for relative costs of host functions, for example.
-        ///
-        /// This method will attempt to consume <paramref name="fuel"/> units of fuel from within this store. If the remaining
-        /// amount of fuel allows this then the amount of remaining fuel is returned. Otherwise, a <see cref="WasmtimeException"/>
-        /// is thrown and no fuel is consumed.
-        /// </summary>
-        /// <param name="fuel">The fuel to consume from the store.</param>
-        /// <returns>Returns the remaining amount of fuel.</returns>
-        /// <exception cref="WasmtimeException">Thrown if more fuel is consumed than the store currently has.</exception>
-        public ulong ConsumeFuel(ulong fuel) => context.ConsumeFuel(fuel);
-
-        /// <summary>
-        /// Gets the fuel consumed by the executing WebAssembly code.
-        /// </summary>
-        /// <returns>Returns the fuel consumed by the executing WebAssembly code or 0 if fuel consumption was not enabled.</returns>
-        public ulong GetConsumedFuel() => context.GetConsumedFuel();
+        /// </para>
+        /// </remarks>
+        /// <value>The fuel available for WebAssembly code to consume while executing.</value>
+        public ulong Fuel
+        {
+            get => context.GetFuel();
+            set => context.SetFuel(value);
+        }
 
         /// <summary>
         /// Gets the user-defined data from the Store. 

--- a/tests/CallerTests.cs
+++ b/tests/CallerTests.cs
@@ -30,7 +30,7 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
         Linker = new Linker(Fixture.Engine);
         Store = new Store(Fixture.Engine);
 
-        Store.AddFuel(1000000);
+        Store.Fuel = 1000000;
     }
 
     [Fact]
@@ -309,11 +309,12 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
 
 
     [Fact]
-    public void ItCanConsumeFuel()
+    public void ItCanRemoveFuel()
     {
         Linker.DefineFunction("env", "callback", (Caller c) =>
         {
-            c.ConsumeFuel(10).Should().Be(1000000 - (10 + 2));
+            c.Fuel -= 10;
+            c.Fuel.Should().Be(1000000 - (10 + 2));
         });
 
         var instance = Linker.Instantiate(Store, Fixture.Module);
@@ -323,7 +324,7 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
 
         // 10 is consumed by the explicit fuel consumption
         // 2 is consumed by the rest of the WASM which executes behind the scenes in this test
-        Store.GetConsumedFuel().Should().Be(10 + 2);
+        Store.Fuel.Should().Be(1000000 - (10 + 2));
     }
 
     [Fact]
@@ -331,8 +332,8 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
     {
         Linker.DefineFunction("env", "callback", (Caller c) =>
         {
-            c.AddFuel(2);
-            c.ConsumeFuel(0).Should().Be(1000000);
+            c.Fuel += 2;
+            c.Fuel.Should().Be(1000000);
         });
 
         var instance = Linker.Instantiate(Store, Fixture.Module);
@@ -341,15 +342,15 @@ public class CallerTests : IClassFixture<CallerFixture>, IDisposable
         callback.Invoke();
 
         // 2 is consumed by the WASM which executes behind the scenes in this test
-        Store.GetConsumedFuel().Should().Be(2);
+        Store.Fuel.Should().Be(1000000);
     }
 
     [Fact]
-    public void ItCanGetConsumedFuel()
+    public void ItCanGetFuel()
     {
         Linker.DefineFunction("env", "callback", (Caller c) =>
         {
-            c.GetConsumedFuel().Should().Be(2);
+            c.Fuel.Should().Be(1000000 - 2);
         });
 
         var instance = Linker.Instantiate(Store, Fixture.Module);


### PR DESCRIPTION
Update to the new fuel APIs introduced in bytecodealliance/wasmtime#7298.

I switched to a property so that it's possible e.g. to add or consume fuel with code like this:
```cs
store.Fuel += 100;

// Consume fuel, throwing an OverflowException if too little fuel is available.
checked {
    store.Fuel -= 150;
}
```

What do you think?
Thanks!