### PR TITLE
Added support for Linker.DefineFunction with generic tuples

### DIFF
--- a/src/Linker.DefineFunction.cs
+++ b/src/Linker.DefineFunction.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -40,7 +39,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(Array.Empty<Type>(), default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(Array.Empty<Type>(), default(Type), allowCaller: false, allowTuple: true);
 
             unsafe
             {
@@ -139,7 +138,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T), }, default(Type), allowCaller: false, allowTuple: true);
             var convT = ValueRaw.Converter<T>();
 
             unsafe
@@ -239,7 +238,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
 
@@ -341,7 +340,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -445,7 +444,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -551,7 +550,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -659,7 +658,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -769,7 +768,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -881,7 +880,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -995,7 +994,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -1111,7 +1110,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -1229,7 +1228,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -1349,7 +1348,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), }, default(Type), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), }, default(Type), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -1471,7 +1470,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(Array.Empty<Type>(), typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(Array.Empty<Type>(), typeof(TResult), allowCaller: false, allowTuple: true);
             var convTResult = ValueRaw.Converter<TResult>();
 
             unsafe
@@ -1572,7 +1571,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT = ValueRaw.Converter<T>();
             var convTResult = ValueRaw.Converter<TResult>();
 
@@ -1674,7 +1673,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convTResult = ValueRaw.Converter<TResult>();
@@ -1778,7 +1777,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -1884,7 +1883,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -1992,7 +1991,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -2102,7 +2101,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -2214,7 +2213,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -2328,7 +2327,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -2444,7 +2443,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -2562,7 +2561,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -2682,7 +2681,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -2804,7 +2803,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), }, typeof(TResult), allowCaller: false, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), }, typeof(TResult), allowCaller: false, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -7455,7 +7454,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), }, default(Type), allowCaller: true, allowTuple: true);
 
             unsafe
             {
@@ -7554,7 +7553,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T), }, default(Type), allowCaller: true, allowTuple: true);
             var convT = ValueRaw.Converter<T>();
 
             unsafe
@@ -7655,7 +7654,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
 
@@ -7758,7 +7757,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -7863,7 +7862,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -7970,7 +7969,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -8079,7 +8078,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -8190,7 +8189,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -8303,7 +8302,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -8418,7 +8417,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -8535,7 +8534,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -8654,7 +8653,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -8775,7 +8774,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), }, default(Type), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), }, default(Type), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -8898,7 +8897,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convTResult = ValueRaw.Converter<TResult>();
 
             unsafe
@@ -8999,7 +8998,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT = ValueRaw.Converter<T>();
             var convTResult = ValueRaw.Converter<TResult>();
 
@@ -9102,7 +9101,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convTResult = ValueRaw.Converter<TResult>();
@@ -9207,7 +9206,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -9314,7 +9313,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -9423,7 +9422,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -9534,7 +9533,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -9647,7 +9646,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -9762,7 +9761,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -9879,7 +9878,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -9998,7 +9997,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -10119,7 +10118,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();
@@ -10242,7 +10241,7 @@ namespace Wasmtime
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), }, typeof(TResult), allowCaller: true, allowTuple: false);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(new Type[] { typeof(Caller), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), }, typeof(TResult), allowCaller: true, allowTuple: true);
             var convT1 = ValueRaw.Converter<T1>();
             var convT2 = ValueRaw.Converter<T2>();
             var convT3 = ValueRaw.Converter<T3>();

--- a/src/Linker.DefineFunction.tt
+++ b/src/Linker.DefineFunction.tt
@@ -19,7 +19,6 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -62,7 +61,7 @@ foreach (var (hasCaller, resultCount, parameterCount, methodGenerics, delegateTy
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            var (parameterKinds, resultKinds) = Function.GetFunctionType(<# if (callbackParameterTypeExpressions.Length == 0) { #>Array.Empty<Type>()<# } else { #>new Type[] { <#= callbackParameterTypeExpressions #>}<# } #>, <#= callbackReturnTypeExpression #>, allowCaller: <#= hasCaller ? "true" : "false" #>, allowTuple: <#= (resultCount > 1) ? "true" : "false" #>);
+            var (parameterKinds, resultKinds) = Function.GetFunctionType(<# if (callbackParameterTypeExpressions.Length == 0) { #>Array.Empty<Type>()<# } else { #>new Type[] { <#= callbackParameterTypeExpressions #>}<# } #>, <#= callbackReturnTypeExpression #>, allowCaller: <#= hasCaller ? "true" : "false" #>, allowTuple: true);
 <#= parameterConverters
 #><#= resultConverters
 #>

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -494,10 +494,9 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
-        public void ItThrowsForInvalidDefinitionWithTupleReturn()
+        public void ItAcceptsDefinitionWithTupleReturn()
         {
-            var action = () => { Linker.DefineFunction<(int, int)>("", "invalid", () => (1, 2)); };
-            action.Should().Throw<InvalidOperationException>().WithMessage("Returning a ValueTuple is not allowed for this callback*");
+            Linker.DefineFunction<(int, int)>("", "invalid", () => (1, 2));
         }
 
         [Fact]


### PR DESCRIPTION
Added support for defining functions which have a tuple as a generic parameter.

Previously defining like this would work:

```csharp
Linker.DefineFunction<int, int, int>("module", "name", (int a) => (a, a));
```

But doing this would _not_ work:

```csharp
void DefineWrapper<TIn, TOut>(Func<TIn, TOut> func)
{
    Linker.DefineFunction<TIn, TOut>("module", "name", func);
}

DefineWrapper<int, (int, int)>((int a) => (a, a));
```

Even though they're ultimately doing the same thing, just with one more level of generic typing.

This PR detects that case and adds limited support for tuples (only up to 4 elements).

I have **not** added support for `ValueRaw` unboxing of tuples. As far as I can tell it's not required anywhere.