### PR TITLE
Less Allocation In `Instance.TryGetExtern`

### DIFF
--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -581,10 +581,11 @@ namespace Wasmtime
 
         private bool TryGetExtern(StoreContext context, string name, out Extern ext)
         {
+            using var nameBytes = name.ToUTF8(stackalloc byte[Math.Min(64, name.Length * 2)]);
+
             unsafe
             {
-                var nameBytes = Encoding.UTF8.GetBytes(name);
-                fixed (byte* ptr = nameBytes)
+                fixed (byte* ptr = nameBytes.Span)
                 {
                     return Native.wasmtime_instance_export_get(context.handle, this.instance, ptr, (UIntPtr)nameBytes.Length, out ext);
                 }


### PR DESCRIPTION
Removed a use of `GetBytes` in `Instance.TryGetExtern` and using a stack buffer instead.