### PR TITLE
Optimisations On 10M Calls

### DIFF
--- a/src/Function.FromCallback.cs
+++ b/src/Function.FromCallback.cs
@@ -39,10 +39,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             );
 
@@ -104,10 +101,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
 
@@ -170,10 +164,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]));
@@ -238,10 +229,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -308,10 +296,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -380,10 +365,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -454,10 +436,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -530,10 +509,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -608,10 +584,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -688,10 +661,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -770,10 +740,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -854,10 +821,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -940,10 +904,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -1016,10 +977,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             );
 
@@ -1083,10 +1041,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
 
@@ -1151,10 +1106,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]));
@@ -1221,10 +1173,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -1293,10 +1242,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -1367,10 +1313,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -1443,10 +1386,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -1521,10 +1461,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -1601,10 +1538,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -1683,10 +1617,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -1767,10 +1698,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -1853,10 +1781,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -1941,10 +1866,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -2019,10 +1941,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             );
 
@@ -2088,10 +2007,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
 
@@ -2158,10 +2074,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]));
@@ -2230,10 +2143,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -2304,10 +2214,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -2380,10 +2287,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -2458,10 +2362,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -2538,10 +2439,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -2620,10 +2518,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -2704,10 +2599,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -2790,10 +2682,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -2878,10 +2767,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -2968,10 +2854,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -3048,10 +2931,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             );
 
@@ -3119,10 +2999,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
 
@@ -3191,10 +3068,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]));
@@ -3265,10 +3139,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -3341,10 +3212,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -3419,10 +3287,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -3499,10 +3364,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -3581,10 +3443,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -3665,10 +3524,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -3751,10 +3607,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -3839,10 +3692,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -3929,10 +3779,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -4021,10 +3868,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -4103,10 +3947,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             );
 
@@ -4176,10 +4017,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT.Unbox(storeContext, store, args_and_results[0]));
 
@@ -4250,10 +4088,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]));
@@ -4326,10 +4161,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -4404,10 +4236,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -4484,10 +4313,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -4566,10 +4392,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -4650,10 +4473,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -4736,10 +4556,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -4824,10 +4641,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -4914,10 +4728,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -5006,10 +4817,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),
@@ -5100,10 +4908,7 @@ namespace Wasmtime
                 {
                     try
                     {
-                        var caller = new Caller(callerPtr);
-                        var storeContext = caller.context;
-                        var store = caller.store;
-
+                        var storeContext = store.Context;
                         var result = callback(
                             convT1.Unbox(storeContext, store, args_and_results[0]),
                             convT2.Unbox(storeContext, store, args_and_results[1]),

--- a/src/Function.FromCallback.tt
+++ b/src/Function.FromCallback.tt
@@ -61,7 +61,7 @@ foreach (var (hasCaller, resultCount, parameterCount, methodGenerics, delegateTy
             {
                 Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-<# GenerateCallbackContent(hasCaller, resultCount, parameterCount); #>
+<# GenerateCallbackContent(hasCaller, resultCount, parameterCount, true); #>
                 };
 
                 var funcType = CreateFunctionType(parameterKinds, resultKinds);

--- a/src/FunctionCallbackOverloadTemplates.t4
+++ b/src/FunctionCallbackOverloadTemplates.t4
@@ -4,14 +4,23 @@
 
 // Suppress the "not used" warning when this file is referenced but the function is not called.
 #pragma warning disable CS8321 // Local function is declared but never used
-void GenerateCallbackContent(bool hasCaller, int resultCount, int parameterCount) {
+void GenerateCallbackContent(bool hasCaller, int resultCount, int parameterCount, bool storeAvailable) {
 #pragma warning restore CS8321 // Local function is declared but never used
 #>
                     try
                     {
-                        var caller = new Caller(callerPtr);
+                        <# if (storeAvailable && !hasCaller)
+                        {
+                            #>var storeContext = store.Context;<#
+                        }
+                        else
+                        {
+                            #>var caller = new Caller(callerPtr);
                         var storeContext = caller.context;
                         var store = caller.store;
+<#
+                        }
+                        #>
 
                         <#= resultCount > 0 ? "var result = " : "" #>callback(
                             <#

--- a/src/Linker.DefineFunction.tt
+++ b/src/Linker.DefineFunction.tt
@@ -69,7 +69,7 @@ foreach (var (hasCaller, resultCount, parameterCount, methodGenerics, delegateTy
             {
                 Function.Native.WasmtimeFuncUncheckedCallback func = (env, callerPtr, args_and_results, num_args_and_results) =>
                 {
-<# GenerateCallbackContent(hasCaller, resultCount, parameterCount); #>
+<# GenerateCallbackContent(hasCaller, resultCount, parameterCount, false); #>
                 };
 
                 const int StackallocThreshold = 256;

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -292,7 +292,7 @@ namespace Wasmtime
         {
             get
             {
-                if (handle.IsInvalid)
+                if (handle.IsClosed)
                 {
                     throw new ObjectDisposedException(typeof(Store).FullName);
                 }


### PR DESCRIPTION
Optimisations based on profiling a simple program that loops and makes 10M calls back into C#. Runtime of this test program was 350ms initially. Test program is here: https://gist.github.com/martindevans/0e0f334bc095808b81c13dedde6c80c1

`FromCallback` has been modified to use the store initially used to create the callback, instead of retrieving it from the caller context. In cases where the `Caller` is not required this skips creating the `Caller` (in turn skipping a call to `wasmtime_caller_context`) and skips accessing the store from the caller (in turn skipping `GCHandle.FromIntPtr` to retrieve the `Store` object). Overall this reduced the total execution time down from 350ms to 272ms.

`Store` has been modified to fetch the `contextHandle` when first created. The docs (https://docs.wasmtime.dev/c-api/structwasmtime__context.html) state that the context handle lifetime is the same as the store lifetime, so it should be safe to keep it as long as the store is checked before accessing the context. This is achieved by checking `handle.IsInvalid` in the `Context` property. Doing all of this skips a call to `wasmtime_store_context` every time `Context` is accessed. Overall this reduced total execution from time down from 272ms to 208ms.