### PR TITLE
`handle.IsClosed` Checks

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -353,7 +353,7 @@ namespace Wasmtime
         {
             get
             {
-                if (handle.IsInvalid)
+                if (handle.IsInvalid || handle.IsClosed)
                 {
                     throw new ObjectDisposedException(typeof(Config).FullName);
                 }

--- a/src/Engine.cs
+++ b/src/Engine.cs
@@ -48,7 +48,7 @@ namespace Wasmtime
         {
             get
             {
-                if (handle.IsInvalid)
+                if (handle.IsInvalid || handle.IsClosed)
                 {
                     throw new ObjectDisposedException(typeof(Engine).FullName);
                 }

--- a/src/Module.cs
+++ b/src/Module.cs
@@ -387,7 +387,7 @@ namespace Wasmtime
         {
             get
             {
-                if (handle.IsInvalid)
+                if (handle.IsInvalid || handle.IsClosed)
                 {
                     throw new ObjectDisposedException(typeof(Module).FullName);
                 }

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -279,7 +279,7 @@ namespace Wasmtime
         {
             get
             {
-                if (handle.IsInvalid)
+                if (handle.IsInvalid || handle.IsClosed)
                 {
                     throw new ObjectDisposedException(typeof(Store).FullName);
                 }

--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -166,5 +166,17 @@ namespace Wasmtime.Tests
 
             act.Should().Throw<WasmtimeException>();
         }
+
+        [Fact]
+        public void ItCannotBeAccessedOnceDisposed()
+        {
+            var config = new Config();
+            config.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => config.NativeHandle);
+            Assert.Throws<ObjectDisposedException>(() => config.WithBulkMemory(true));
+            Assert.Throws<ObjectDisposedException>(() => config.WithCacheConfig(null));
+            Assert.Throws<ObjectDisposedException>(() => config.WithEpochInterruption(true));
+        }
     }
 }

--- a/tests/EngineTests.cs
+++ b/tests/EngineTests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Xunit;
+
+namespace Wasmtime.Tests;
+
+public class EngineTests
+{
+    [Fact]
+    public void ItCannotBeAccessedOnceDisposed()
+    {
+        var engine = new Engine();
+
+        engine.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => engine.NativeHandle);
+        Assert.Throws<ObjectDisposedException>(() => engine.IncrementEpoch());
+    }
+}

--- a/tests/ModuleLoadTests.cs
+++ b/tests/ModuleLoadTests.cs
@@ -51,5 +51,20 @@ namespace Wasmtime.Tests
             // `ObjectDisposedException`
             stream.Read(new byte[0], 0, 0);
         }
+
+        [Fact]
+        public void ItCannotBeAccessedOnceDisposed()
+        {
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("hello.wasm");
+            stream.Should().NotBeNull();
+
+            using var engine = new Engine();
+            var module = Module.FromStream(engine, "hello.wasm", stream);
+
+            module.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => module.NativeHandle);
+            Assert.Throws<ObjectDisposedException>(() => module.Serialize());
+        }
     }
 }

--- a/tests/StoreTests.cs
+++ b/tests/StoreTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using System.IO;
 using Xunit;
 
@@ -90,6 +91,20 @@ namespace Wasmtime.Tests
 
             var act = () => { new Instance(Store, module); };
             act.Should().Throw<WasmtimeException>();
+        }
+
+        [Fact]
+        public void ItCannotBeAccessedOnceDisposed()
+        {
+            var ctx = Store.Context;
+            Assert.Equal(Store, ctx.Store);
+
+            Store.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => { var x = Store.Context; });
+            Assert.Throws<ObjectDisposedException>(() => Store.NativeHandle);
+            Assert.Throws<ObjectDisposedException>(() => Store.Fuel);
+            Assert.Throws<ObjectDisposedException>(() => Store.GC());
         }
     }
 }


### PR DESCRIPTION
Some previous relevant discussion: https://github.com/bytecodealliance/wasmtime-dotnet/pull/288#issuecomment-1861032709

The handles in wasmtime-dotnet never seem to be made invalid, so the IsInvalid checks seem to be useless. I've added `IsClosed` checks onto all the places that `IsInvalid` is used.

Previously all these paths were untested, added new tests which cover these paths.