### PR TITLE
Instance Get All Exports

### DIFF
--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -656,17 +656,11 @@ namespace Wasmtime
             GC.KeepAlive(_store);
         }
 
-        /// <summary>
-        /// Try to get the nth extern, optionally filtered to a specific type
-        /// </summary>
-        /// <param name="i"></param>
-        /// <param name="type"></param>
-        /// <returns></returns>
-        private (string name, Extern @extern)? TryGetExtern(int i, ExternKind? type = null)
+        private (string name, Extern @extern)? TryGetExtern(int index, ExternKind? type = null)
         {
             unsafe
             {
-                if (!Native.wasmtime_instance_export_nth(_store.Context.handle, instance, (UIntPtr)i, out var namePtr, out var nameLen, out var @extern))
+                if (!Native.wasmtime_instance_export_nth(_store.Context.handle, instance, (UIntPtr)index, out var namePtr, out var nameLen, out var @extern))
                 {
                     return null;
                 }

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -589,7 +589,9 @@ namespace Wasmtime
             for (var i = 0; i < int.MaxValue; i++)
             {
                 if (TryGetExtern(i, ExternKind.Func) is not var (name, @extern))
+                {
                     break;
+                }
 
                 yield return (name, _store.GetCachedExtern(@extern.of.func));
             }
@@ -606,7 +608,9 @@ namespace Wasmtime
             for (var i = 0; i < int.MaxValue; i++)
             {
                 if (TryGetExtern(i, ExternKind.Table) is not var (name, @extern))
+                {
                     break;
+                }
 
                 yield return (name, new Table(_store, @extern.of.table));
             }
@@ -623,7 +627,9 @@ namespace Wasmtime
             for (var i = 0; i < int.MaxValue; i++)
             {
                 if (TryGetExtern(i, ExternKind.Memory) is not var (name, @extern))
+                {
                     break;
+                }
 
                 yield return (name, _store.GetCachedExtern(@extern.of.memory));
             }
@@ -640,7 +646,9 @@ namespace Wasmtime
             for (var i = 0; i < int.MaxValue; i++)
             {
                 if (TryGetExtern(i, ExternKind.Global) is not var (name, @extern))
+                {
                     break;
+                }
 
                 yield return (name, _store.GetCachedExtern(@extern.of.global));
             }
@@ -659,10 +667,14 @@ namespace Wasmtime
             unsafe
             {
                 if (!Native.wasmtime_instance_export_nth(_store.Context.handle, instance, (UIntPtr)i, out var namePtr, out var nameLen, out var @extern))
+                {
                     return null;
+                }
 
                 if (type != null && type.Value != @extern.kind)
-                    return null;
+                {
+                    return  null;
+                }
 
                 var name = Encoding.UTF8.GetString(namePtr, checked((int)nameLen));
                 return (name, @extern);

--- a/tests/InstanceTests.cs
+++ b/tests/InstanceTests.cs
@@ -5,7 +5,8 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class InstanceFixture : ModuleFixture
+    public class InstanceFixture
+        : ModuleFixture
     {
         protected override string ModuleFileName => "Hello.wat";
     }
@@ -25,6 +26,8 @@ namespace Wasmtime.Tests
 
             Linker.DefineFunction("env", "add", (int x, int y) => x + y);
             Linker.DefineFunction("env", "swap", (int x, int y) => (y, x));
+            Linker.DefineFunction("", "hi", (int x, int y) => (y, x));
+
             Linker.DefineFunction("", "hello", () => { });
         }
 

--- a/tests/InstanceTests.cs
+++ b/tests/InstanceTests.cs
@@ -8,7 +8,7 @@ namespace Wasmtime.Tests
     public class InstanceFixture
         : ModuleFixture
     {
-        protected override string ModuleFileName => "Hello.wat";
+        protected override string ModuleFileName => "hello.wat";
     }
 
     public class InstanceTests

--- a/tests/InstanceTests.cs
+++ b/tests/InstanceTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Wasmtime.Tests
+{
+    public class InstanceFixture : ModuleFixture
+    {
+        protected override string ModuleFileName => "Hello.wat";
+    }
+
+    public class InstanceTests
+        : IClassFixture<InstanceFixture>, IDisposable
+    {
+        private Store Store { get; set; }
+
+        private Linker Linker { get; set; }
+
+        public InstanceTests(InstanceFixture fixture)
+        {
+            Fixture = fixture;
+            Linker = new Linker(Fixture.Engine);
+            Store = new Store(Fixture.Engine);
+
+            Linker.DefineFunction("env", "add", (int x, int y) => x + y);
+            Linker.DefineFunction("env", "swap", (int x, int y) => (y, x));
+            Linker.DefineFunction("", "hello", () => { });
+        }
+
+        private InstanceFixture Fixture { get; }
+
+        [Fact]
+        public void ItGetsExportedFunctions()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+
+            var results = instance.GetFunctions();
+
+            results.Single().Name.Should().Be("run");
+        }
+
+        public void Dispose()
+        {
+            Store.Dispose();
+            Linker.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Added methods to fetch all exports from an Instance, using `wasmtime_instance_export_nth` to enumerate exports.

Also removed `wasmtime_instancetype_delete`, since it doesn't appear to be part of the c-api any more.