### PR TITLE
Update CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   <strong>A <a href="https://bytecodealliance.org/">Bytecode Alliance</a> project</strong>
 
   <p>
-    <a href="https://github.com/bytecodealliance/wasmtime-dotnet/actions?query=workflow%3ACI">
-      <img src="https://github.com/bytecodealliance/wasmtime-dotnet/workflows/CI/badge.svg" alt="CI status"/>
+    <a href="https://github.com/bytecodealliance/wasmtime-dotnet/actions/workflows/main.yml">
+      <img src="https://github.com/bytecodealliance/wasmtime-dotnet/actions/workflows/main.yml/badge.svg" alt="CI status"/>
     </a>
     <a href="https://www.nuget.org/packages/Wasmtime">
       <img src="https://img.shields.io/nuget/v/wasmtime" alt="Latest Version"/>


### PR DESCRIPTION
The CI Badge was invalid on the main readme page. this is fixing the issue

<img width="325" alt="image" src="https://github.com/bytecodealliance/wasmtime-dotnet/assets/601810/d72a84ce-dbfa-4130-bb6e-cff0816afcc1">
