### PR TITLE
Fix Some C-API calls

### DIFF
--- a/src/WasiConfiguration.cs
+++ b/src/WasiConfiguration.cs
@@ -454,6 +454,7 @@ namespace Wasmtime
             public static extern void wasi_config_delete(IntPtr config);
 
             [DllImport(Engine.LibraryName)]
+            [return: MarshalAs(UnmanagedType.I1)]
             public unsafe static extern bool wasi_config_set_argv(Handle config, nuint argc, byte** argv);
 
             [DllImport(Engine.LibraryName)]

--- a/src/WasiConfiguration.cs
+++ b/src/WasiConfiguration.cs
@@ -299,7 +299,9 @@ namespace Wasmtime
             {
                 fixed (byte** arrayOfStringsPtrNamedArgs = args)
                 {
-                    Native.wasi_config_set_argv(config, _args.Count, arrayOfStringsPtrNamedArgs);
+                    // This shouldn't ever fail - it would only return false if `ToUTF8PtrArray` creates invalid UTF8 bytes!
+                    if (!Native.wasi_config_set_argv(config, (nuint)_args.Count, arrayOfStringsPtrNamedArgs))
+                        throw new WasmtimeException("Failed to encode string to UTF8");
                 }
             }
             finally
@@ -329,7 +331,9 @@ namespace Wasmtime
 
             try
             {
-                Native.wasi_config_set_env(config, _vars.Count, names, values);
+                // This shouldn't ever fail - it would only return false if `ToUTF8PtrArray` creates invalid UTF8 bytes!
+                if (!Native.wasi_config_set_env(config, (nuint)_vars.Count, names, values))
+                    throw new WasmtimeException("Failed to encode string to UTF8");
             }
             finally
             {
@@ -450,12 +454,12 @@ namespace Wasmtime
             public static extern void wasi_config_delete(IntPtr config);
 
             [DllImport(Engine.LibraryName)]
-            public unsafe static extern void wasi_config_set_argv(Handle config, int argc, byte** argv);
+            public unsafe static extern bool wasi_config_set_argv(Handle config, nuint argc, byte** argv);
 
             [DllImport(Engine.LibraryName)]
-            public static extern unsafe void wasi_config_set_env(
+            public static extern unsafe bool wasi_config_set_env(
                 Handle config,
-                int envc,
+                nuint envc,
                 byte*[] names,
                 byte*[] values
             );

--- a/src/WasiConfiguration.cs
+++ b/src/WasiConfiguration.cs
@@ -458,6 +458,7 @@ namespace Wasmtime
             public unsafe static extern bool wasi_config_set_argv(Handle config, nuint argc, byte** argv);
 
             [DllImport(Engine.LibraryName)]
+            [return: MarshalAs(UnmanagedType.I1)]
             public static extern unsafe bool wasi_config_set_env(
                 Handle config,
                 nuint envc,


### PR DESCRIPTION
Fixed breakage due to changes introduced in https://github.com/bytecodealliance/wasmtime/commit/e55fa3cc928547a88738597cb6236d8571c42501

Obviously I can't run all the tests, due to the other changes mentioned here https://github.com/bytecodealliance/wasmtime-dotnet/issues/315#issuecomment-2182893613. Here's what I could run:

<img width="972" alt="devenv_2024-06-21_17-05-33" src="https://github.com/bytecodealliance/wasmtime-dotnet/assets/177519/5f928bf5-f8a2-4604-b097-331226791470">

The WasiTests cover the changed code.