### PR TITLE
Update to Wasmtime 20.0.2 to pass CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,8 @@ jobs:
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
       run: dotnet clean Wasmtime.sln && dotnet nuget locals all --clear
-    - name: Enable development builds for the main branch
-      if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
+    - name: Enable development builds for the main branch on schedule
+      if: github.ref == 'refs/heads/main' && github.event_name == 'schedule'
       shell: bash
       run: |
         echo "DevBuild=true" >> $GITHUB_ENV

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <DevBuild Condition="'$(DevBuild)'==''">true</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">19.0.1</WasmtimeVersion>
+    <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">20.0.2</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>
     <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">$(WasmtimeVersion)$(WasmtimeDotnetVersion)</WasmtimePackageVersion>


### PR DESCRIPTION
This was previously always pulling the dev c api for wasmtime, causing failures on simple PR's like #313. 

This temporally disables the dev version of the wasmtime c-api in order to get start making incremental updates  as a part of fixing #315 