### PR TITLE
Update to recent Wasmtime C API changes regarding values

### DIFF
--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -7,35 +7,35 @@ namespace Wasmtime
     internal struct ExternFunc
     {
         public ulong store;
-        public nuint __private;
+        private nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternTable
     {
         public ulong store;
-        public nuint __private;
+        private nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternMemory
     {
         public ulong store;
-        public nuint __private;
+        private nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternInstance
     {
         public ulong store;
-        public nuint __private;
+        private nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternGlobal
     {
         public ulong store;
-        public nuint __private;
+        private nuint __private;
     }
 
     internal enum ExternKind : byte

--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -7,35 +7,35 @@ namespace Wasmtime
     internal struct ExternFunc
     {
         public ulong store;
-        public UIntPtr index;
+        public nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternTable
     {
         public ulong store;
-        public UIntPtr index;
+        public nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternMemory
     {
         public ulong store;
-        public UIntPtr index;
+        public nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternInstance
     {
         public ulong store;
-        public UIntPtr index;
+        public nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternGlobal
     {
         public ulong store;
-        public UIntPtr index;
+        public nuint __private;
     }
 
     internal enum ExternKind : byte
@@ -44,6 +44,7 @@ namespace Wasmtime
         Global,
         Table,
         Memory,
+        SharedMemory,
     }
 
     [StructLayout(LayoutKind.Explicit)]
@@ -60,6 +61,9 @@ namespace Wasmtime
 
         [FieldOffset(0)]
         public ExternMemory memory;
+
+        [FieldOffset(0)]
+        public IntPtr sharedmemory;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -88,7 +88,7 @@ namespace Wasmtime
         /// <summary>
         /// Determines if the underlying function reference is null.
         /// </summary>
-        public bool IsNull => func.index == UIntPtr.Zero && func.store == 0;
+        public bool IsNull => func.IsNull();
 
         /// <summary>
         /// Represents a null function reference.
@@ -333,7 +333,7 @@ namespace Wasmtime
                 {
                     for (int i = 0; i < Results.Count; ++i)
                     {
-                        resultsSpan[i].Dispose();
+                        resultsSpan[i].Release(store);
                     }
                 }
             }
@@ -341,7 +341,7 @@ namespace Wasmtime
             {
                 for (int i = 0; i < arguments.Length; ++i)
                 {
-                    args[i].Dispose();
+                    args[i].Release(store);
                 }
             }
 
@@ -444,8 +444,7 @@ namespace Wasmtime
         internal Function()
         {
             this.store = null;
-            this.func.store = 0;
-            this.func.index = (UIntPtr)0;
+            this.func = default;
             this.Parameters = this.Results = Array.Empty<ValueKind>();
         }
 

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -344,7 +344,8 @@ namespace Wasmtime
 
         internal Function GetCachedExtern(ExternFunc @extern)
         {
-            var key = (ExternKind.Func, @extern.store, @extern.index);
+            // TODO: Check if using the __private field is Ok.
+            var key = (ExternKind.Func, @extern.store, @extern.__private);
 
             if (!_externCache.TryGetValue(key, out var func))
             {
@@ -357,7 +358,7 @@ namespace Wasmtime
 
         internal Memory GetCachedExtern(ExternMemory @extern)
         {
-            var key = (ExternKind.Memory, @extern.store, @extern.index);
+            var key = (ExternKind.Memory, @extern.store, @extern.__private);
 
             if (!_externCache.TryGetValue(key, out var mem))
             {
@@ -370,7 +371,7 @@ namespace Wasmtime
 
         internal Global GetCachedExtern(ExternGlobal @extern)
         {
-            var key = (ExternKind.Global, @extern.store, @extern.index);
+            var key = (ExternKind.Global, @extern.store, @extern.__private);
 
             if (!_externCache.TryGetValue(key, out var global))
             {

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -340,46 +340,41 @@ namespace Wasmtime
 
         private static readonly Native.Finalizer Finalizer = (p) => GCHandle.FromIntPtr(p).Free();
 
-        private readonly ConcurrentDictionary<(ExternKind kind, ulong store, nuint index), object> _externCache = new();
+        private readonly ConcurrentDictionary<ExternFunc, Function> _externFuncCache = new();
+        private readonly ConcurrentDictionary<ExternMemory, Memory> _externMemoryCache = new();
+        private readonly ConcurrentDictionary<ExternGlobal, Global> _externGlobalCache = new();
 
         internal Function GetCachedExtern(ExternFunc @extern)
         {
-            // TODO: Check if using the __private field is Ok.
-            var key = (ExternKind.Func, @extern.store, @extern.__private);
-
-            if (!_externCache.TryGetValue(key, out var func))
+            if (!_externFuncCache.TryGetValue(@extern, out var func))
             {
                 func = new Function(this, @extern);
-                func = _externCache.GetOrAdd(key, func);
+                func = _externFuncCache.GetOrAdd(@extern, func);
             }
 
-            return (Function)func;
+            return func;
         }
 
         internal Memory GetCachedExtern(ExternMemory @extern)
         {
-            var key = (ExternKind.Memory, @extern.store, @extern.__private);
-
-            if (!_externCache.TryGetValue(key, out var mem))
+            if (!_externMemoryCache.TryGetValue(@extern, out var mem))
             {
                 mem = new Memory(this, @extern);
-                mem = _externCache.GetOrAdd(key, mem);
+                mem = _externMemoryCache.GetOrAdd(@extern, mem);
             }
 
-            return (Memory)mem;
+            return mem;
         }
 
         internal Global GetCachedExtern(ExternGlobal @extern)
         {
-            var key = (ExternKind.Global, @extern.store, @extern.__private);
-
-            if (!_externCache.TryGetValue(key, out var global))
+            if (!_externGlobalCache.TryGetValue(@extern, out var global))
             {
                 global = new Global(this, @extern);
-                global = _externCache.GetOrAdd(key, global);
+                global = _externGlobalCache.GetOrAdd(@extern, global);
             }
 
-            return (Global)global;
+            return global;
         }
     }
 }

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -65,7 +65,7 @@ namespace Wasmtime
     {
         public static bool IsNull(this in AnyRef anyref)
         {
-            // This code originates from macro "wasmtime_anyref_is_null" in `val.h`.
+            // This code originates from inline function "wasmtime_anyref_is_null" in `val.h`.
             return anyref.store == 0;
         }
     }
@@ -74,7 +74,7 @@ namespace Wasmtime
     {
         public static bool IsNull(this in ExternRef externref)
         {
-            // This code originates from macro "wasmtime_externref_is_null" in `val.h`.
+            // This code originates from inline function "wasmtime_externref_is_null" in `val.h`.
             return externref.store == 0;
         }
     }
@@ -83,7 +83,7 @@ namespace Wasmtime
     {
         public static bool IsNull(this in ExternFunc externfunc)
         {
-            // This code originates from macro "wasmtime_funcref_is_null" in `val.h`.
+            // This code originates from inline function "wasmtime_funcref_is_null" in `val.h`.
             return externfunc.store == 0;
         }
     }
@@ -514,9 +514,9 @@ namespace Wasmtime
     {
         public ulong store;
 
-        public uint __private1;
+        private uint __private1;
 
-        public uint __private2;
+        private uint __private2;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -524,8 +524,8 @@ namespace Wasmtime
     {
         public ulong store;
 
-        public uint __private1;
+        private uint __private1;
 
-        public uint __private2;
+        private uint __private2;
     }
 }

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -196,6 +196,22 @@ namespace Wasmtime
         }
     }
 
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When owning the value and you are finished with using it, you must release/unroot
+    /// it by calling the <see cref="Release(Store)"/> method. After that, the
+    /// <see cref="Value"/> must no longer be used.
+    /// </para>
+    /// <para>
+    /// Previously, this type implemented the <see cref="IDisposable"/> interface, but since
+    /// Wasmtime v20.0.0, unrooting the value requires passing a store context, which is why
+    /// the <see cref="Release(Store)"/> method needs to explicitly be called, passing a
+    /// <see cref="Store"/>.
+    /// </para>
+    /// </remarks>
     [StructLayout(LayoutKind.Sequential)]
     internal struct Value
     {
@@ -276,7 +292,6 @@ namespace Wasmtime
                             ref value.of.externref
                         ))
                         {
-                            // TODO: Check in which places this exception could be thrown.
                             throw new WasmtimeException("The host wasn't able to create more GC values at this time.");
                         }
                     }
@@ -365,7 +380,6 @@ namespace Wasmtime
                                     ref value.of.externref
                                 ))
                                 {
-                                    // TODO: Check in which places this exception could be thrown.
                                     throw new WasmtimeException("The host wasn't able to create more GC values at this time.");
                                 }
                             }

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -37,6 +37,10 @@ namespace Wasmtime
         /// The value is an external reference.
         /// </summary>
         ExternRef,
+        /// <summary>
+        /// The value is an `anyref`.
+        /// </summary>
+        AnyRef,
     }
 
     internal static class ValueKindExtensions
@@ -54,6 +58,33 @@ namespace Wasmtime
                 ValueKind.ExternRef => type.IsClass,
                 _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
             };
+        }
+    }
+
+    internal static class AnyRefExtensions
+    {
+        public static bool IsNull(this in AnyRef anyref)
+        {
+            // This code originates from macro "wasmtime_anyref_is_null" in `val.h`.
+            return anyref.store == 0;
+        }
+    }
+
+    internal static class ExternRefExtensions
+    {
+        public static bool IsNull(this in ExternRef externref)
+        {
+            // This code originates from macro "wasmtime_externref_is_null" in `val.h`.
+            return externref.store == 0;
+        }
+    }
+
+    internal static class ExternFuncExtensions
+    {
+        public static bool IsNull(this in ExternFunc externfunc)
+        {
+            // This code originates from macro "wasmtime_funcref_is_null" in `val.h`.
+            return externfunc.store == 0;
         }
     }
 
@@ -166,12 +197,12 @@ namespace Wasmtime
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct Value : IDisposable
+    internal struct Value
     {
-        /// <inheritdoc/>
-        public void Dispose()
+        public void Release(Store store)
         {
-            Native.wasmtime_val_delete(this);
+            Native.wasmtime_val_unroot(store.Context.handle, this);
+            GC.KeepAlive(store);
         }
 
         public static bool TryGetKind(Type type, out ValueKind kind)
@@ -230,15 +261,30 @@ namespace Wasmtime
 
             if (value.kind == ValueKind.ExternRef)
             {
-                value.of.externref = IntPtr.Zero;
+                value.of.externref = default;
 
                 if (box.ExternRefObject is not null)
                 {
-                    value.of.externref = Native.wasmtime_externref_new(
-                        store.Context.handle,
-                        GCHandle.ToIntPtr(GCHandle.Alloc(box.ExternRefObject)),
-                        Finalizer
-                    );
+                    var gcHandle = GCHandle.Alloc(box.ExternRefObject);
+
+                    try
+                    {
+                        if (!Native.wasmtime_externref_new(
+                            store.Context.handle,
+                            GCHandle.ToIntPtr(gcHandle),
+                            Finalizer,
+                            ref value.of.externref
+                        ))
+                        {
+                            // TODO: Check in which places this exception could be thrown.
+                            throw new WasmtimeException("The host wasn't able to create more GC values at this time.");
+                        }
+                    }
+                    catch
+                    {
+                        gcHandle.Free();
+                        throw;
+                    }
 
                     GC.KeepAlive(store);
                 }
@@ -304,15 +350,30 @@ namespace Wasmtime
                         break;
 
                     case ValueKind.ExternRef:
-                        value.of.externref = IntPtr.Zero;
+                        value.of.externref = default;
 
-                        if (!(o is null))
+                        if (o is not null)
                         {
-                            value.of.externref = Native.wasmtime_externref_new(
-                                store.Context.handle,
-                                GCHandle.ToIntPtr(GCHandle.Alloc(o)),
-                                Value.Finalizer
-                            );
+                            var gcHandle = GCHandle.Alloc(o);
+
+                            try
+                            {
+                                if (!Native.wasmtime_externref_new(
+                                    store.Context.handle,
+                                    GCHandle.ToIntPtr(gcHandle),
+                                    Value.Finalizer,
+                                    ref value.of.externref
+                                ))
+                                {
+                                    // TODO: Check in which places this exception could be thrown.
+                                    throw new WasmtimeException("The host wasn't able to create more GC values at this time.");
+                                }
+                            }
+                            catch
+                            {
+                                gcHandle.Free();
+                                throw;
+                            }
 
                             GC.KeepAlive(store);
                         }
@@ -378,7 +439,7 @@ namespace Wasmtime
 
         private object? ResolveExternRef(Store store)
         {
-            if (of.externref == IntPtr.Zero)
+            if (of.externref.IsNull())
             {
                 return null;
             }
@@ -395,22 +456,23 @@ namespace Wasmtime
             public delegate void Finalizer(IntPtr data);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_val_delete(in Value val);
+            public static extern void wasmtime_val_unroot(IntPtr context, in Value val);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_externref_new(IntPtr context, IntPtr data, Finalizer? finalizer);
+            [return: MarshalAs(UnmanagedType.I1)]
+            public static extern bool wasmtime_externref_new(IntPtr context, IntPtr data, Finalizer? finalizer, ref ExternRef @out);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_externref_data(IntPtr context, IntPtr externref);
+            public static extern IntPtr wasmtime_externref_data(IntPtr context, in ExternRef externref);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_externref_delete(IntPtr context, IntPtr externref);
+            public static extern void wasmtime_externref_unroot(IntPtr context, in ExternRef externref);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_externref_from_raw(IntPtr context, IntPtr raw);
+            public static extern void wasmtime_externref_from_raw(IntPtr context, uint raw, out ExternRef @out);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_externref_to_raw(IntPtr context, IntPtr externref);
+            public static extern uint wasmtime_externref_to_raw(IntPtr context, in ExternRef externref);
         }
 
         public static readonly Native.Finalizer Finalizer = (p) => GCHandle.FromIntPtr(p).Free();
@@ -435,12 +497,35 @@ namespace Wasmtime
         public double f64;
 
         [FieldOffset(0)]
+        public AnyRef anyref;
+
+        [FieldOffset(0)]
+        public ExternRef externref;
+
+        [FieldOffset(0)]
         public ExternFunc funcref;
 
         [FieldOffset(0)]
-        public IntPtr externref;
-
-        [FieldOffset(0)]
         public V128 v128;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct AnyRef
+    {
+        public ulong store;
+
+        public uint __private1;
+
+        public uint __private2;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ExternRef
+    {
+        public ulong store;
+
+        public uint __private1;
+
+        public uint __private2;
     }
 }

--- a/src/ValueRaw.cs
+++ b/src/ValueRaw.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Wasmtime
@@ -24,10 +23,13 @@ namespace Wasmtime
         public V128 v128;
 
         [FieldOffset(0)]
-        public IntPtr funcref;
+        public uint anyref;
 
         [FieldOffset(0)]
-        public IntPtr externref;
+        public uint externref;
+
+        [FieldOffset(0)]
+        public IntPtr funcref;
 
         public static IValueRawConverter<T> Converter<T>()
         {
@@ -256,10 +258,10 @@ namespace Wasmtime
         {
             object? o = null;
 
-            if (valueRaw.externref != IntPtr.Zero)
+            if (valueRaw.externref != 0)
             {
-                // The externref is an owned value, so we must delete it afterwards.
-                var externref = Value.Native.wasmtime_externref_from_raw(storeContext.handle, valueRaw.externref);
+                // The externref is an owned value, so we must unroot it afterwards.
+                Value.Native.wasmtime_externref_from_raw(storeContext.handle, valueRaw.externref, out var externref);
 
                 try
                 {
@@ -271,7 +273,7 @@ namespace Wasmtime
                 }
                 finally
                 {
-                    Value.Native.wasmtime_externref_delete(storeContext.handle, externref);
+                    Value.Native.wasmtime_externref_unroot(storeContext.handle, externref);
                 }
             }
 
@@ -280,14 +282,31 @@ namespace Wasmtime
 
         public void Box(StoreContext storeContext, Store store, ref ValueRaw valueRaw, T value)
         {
-            IntPtr externrefPtr = IntPtr.Zero;
+            uint externrefRaw = 0;
 
             if (value is not null)
             {
-                var externref = Value.Native.wasmtime_externref_new(
-                    storeContext.handle,
-                    GCHandle.ToIntPtr(GCHandle.Alloc(value)),
-                    Value.Finalizer);
+                var externref = default(ExternRef);
+
+                var gcHandle = GCHandle.Alloc(value);
+
+                try
+                {
+                    if (!Value.Native.wasmtime_externref_new(
+                        storeContext.handle,
+                        GCHandle.ToIntPtr(gcHandle),
+                        Value.Finalizer,
+                        ref externref))
+                    {
+                        // TODO: Check in which places this exception could be thrown.
+                        throw new WasmtimeException("The host wasn't able to create more GC values at this time.");
+                    }
+                }
+                catch
+                {
+                    gcHandle.Free();
+                    throw;
+                }
 
                 try
                 {
@@ -295,17 +314,17 @@ namespace Wasmtime
                     // Note: The externref data isn't tracked by wasmtime's GC until
                     // it enters WebAssembly, so Store.GC() mustn't be called between
                     // converting the value and passing it to WebAssembly.
-                    externrefPtr = Value.Native.wasmtime_externref_to_raw(storeContext.handle, externref);
+                    externrefRaw = Value.Native.wasmtime_externref_to_raw(storeContext.handle, externref);
                 }
                 finally
                 {
-                    // We still must delete the old externref afterwards because
+                    // We still must unroot the old externref afterwards because
                     // wasmtime_externref_to_raw doesn't transfer ownership.
-                    Value.Native.wasmtime_externref_delete(storeContext.handle, externref);
+                    Value.Native.wasmtime_externref_unroot(storeContext.handle, externref);
                 }
             }
 
-            valueRaw.externref = externrefPtr;
+            valueRaw.externref = externrefRaw;
         }
     }
 

--- a/src/ValueRaw.cs
+++ b/src/ValueRaw.cs
@@ -292,13 +292,16 @@ namespace Wasmtime
 
                 try
                 {
+                    // The externref allocated here won't be rooted when this method returns
+                    // (see comments below), so unlike with the regular `Value`, we don't
+                    // need to do a special clean-up in the caller when trying to allocate
+                    // multiple (externref) values and one of it fails.
                     if (!Value.Native.wasmtime_externref_new(
                         storeContext.handle,
                         GCHandle.ToIntPtr(gcHandle),
                         Value.Finalizer,
                         ref externref))
                     {
-                        // TODO: Check in which places this exception could be thrown.
                         throw new WasmtimeException("The host wasn't able to create more GC values at this time.");
                     }
                 }

--- a/tests/ValueBoxTests.cs
+++ b/tests/ValueBoxTests.cs
@@ -199,13 +199,11 @@ namespace Wasmtime.Tests
             var converted = box.ToValue(Store, ValueKind.FuncRef).ToValueBox(Store);
             converted.Kind.Should().Be(ValueKind.FuncRef);
             var unboxed = ValueBox.Converter<Function>().Unbox(Store, converted);
-            unboxed.func.__private.Should().Be(func.func.__private);
-            unboxed.func.store.Should().Be(func.func.store);
+            unboxed.func.Should().Be(func.func);
 
             var value = box.ToValue(Store, ValueKind.FuncRef);
             var obj = (Function)value.ToObject(Store)!;
-            obj.func.__private.Should().Be(func.func.__private);
-            obj.func.store.Should().Be(func.func.store);
+            obj.func.Should().Be(func.func);
         }
 
         private struct Unsupported

--- a/tests/ValueBoxTests.cs
+++ b/tests/ValueBoxTests.cs
@@ -199,12 +199,12 @@ namespace Wasmtime.Tests
             var converted = box.ToValue(Store, ValueKind.FuncRef).ToValueBox(Store);
             converted.Kind.Should().Be(ValueKind.FuncRef);
             var unboxed = ValueBox.Converter<Function>().Unbox(Store, converted);
-            unboxed.func.index.Should().Be(func.func.index);
+            unboxed.func.__private.Should().Be(func.func.__private);
             unboxed.func.store.Should().Be(func.func.store);
 
             var value = box.ToValue(Store, ValueKind.FuncRef);
             var obj = (Function)value.ToObject(Store)!;
-            obj.func.index.Should().Be(func.func.index);
+            obj.func.__private.Should().Be(func.func.__private);
             obj.func.store.Should().Be(func.func.store);
         }
 


### PR DESCRIPTION
Update to recent Wasmtime C API changes regarding values.

This includes updates for:
- bytecodealliance/wasmtime#8011
- bytecodealliance/wasmtime#8451
- bytecodealliance/wasmtime#8461

TODOs:
- [X] Allocating an `externref` can now fail (by `wasmtime_externref_new` returning `false`). With this PR, we will throw a `WasmtimeException` in that case. We need to check where that exception can be thrown, and whether we need to do any additional clean-up (e.g. when converting arguments for a function call).
- [x] Check whether we can avoid directly accessing the `__private` field of externs (which has been remaned in the C API, previously it was `index`).

**Note:** The `anyref` type is not yet supported; it was introduced by the [GC Proposal](https://github.com/WebAssembly/gc/blob/main/proposals/gc/Overview.md). Support for this type can be added separately, after deciding how the API should look like.

Fixes part of #315 (the WASI part is fixed by #316).