### PR TITLE
Bump version to 21.0.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">true</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">19.0.1</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">21.0.1</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>
     <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">$(WasmtimeVersion)$(WasmtimeDotnetVersion)</WasmtimePackageVersion>

--- a/README.md
+++ b/README.md
@@ -143,13 +143,6 @@ in `Directory.Build.props`:
 <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">$VERSION</WasmtimeVersion>
 ```
 
-Additionally, edit `Wasmtime.csproj` to change the `PackageReleaseNotes` to the
-new version:
-
-```xml
-<PackageReleaseNotes>Update Wasmtime to $VERSION.</PackageReleaseNotes>
-```
-
 ### Publishing the Wasmtime .NET NuGet package
 
 GitHub actions is used to automatically publish a package to NuGet when a tag

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -20,7 +20,7 @@
     <RepositoryUrl>https://github.com/bytecodealliance/wasmtime-dotnet</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <PackageReleaseNotes>Update Wasmtime to 19.0.1.</PackageReleaseNotes>
+    <PackageReleaseNotes>Update Wasmtime to $(WasmtimeVersion).</PackageReleaseNotes>
     <Summary>A .NET API for Wasmtime, a standalone WebAssembly runtime</Summary>
     <PackageTags>webassembly, .net, wasm, wasmtime</PackageTags>
     <Title>Wasmtime</Title>


### PR DESCRIPTION
This also makes it only one place where the version needs updated. I tested this locally and it prints the right version in the `nuspec`:

```
    <releaseNotes>Update Wasmtime to 21.0.1.</releaseNotes>
```