### PR TITLE
Revert the changes to the cache of externs in `Store`

### DIFF
--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -7,35 +7,35 @@ namespace Wasmtime
     internal struct ExternFunc
     {
         public ulong store;
-        private nuint __private;
+        public nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternTable
     {
         public ulong store;
-        private nuint __private;
+        public nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternMemory
     {
         public ulong store;
-        private nuint __private;
+        public nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternInstance
     {
         public ulong store;
-        private nuint __private;
+        public nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternGlobal
     {
         public ulong store;
-        private nuint __private;
+        public nuint __private;
     }
 
     internal enum ExternKind : byte

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -344,7 +344,12 @@ namespace Wasmtime
 
         internal Function GetCachedExtern(ExternFunc @extern)
         {
-            // TODO: Check if using the __private field is Ok.
+            // We use a `ValueTuple` as key, consisting of the extern type and the both
+            // struct fields, which works since all `Extern...` structs have the same
+            // fields.
+            // Even though the second field is named "__private", it should be Ok to
+            // access it since we won't interpret the value in any way, but just use it
+            // to compare it to other values.
             var key = (ExternKind.Func, @extern.store, @extern.__private);
 
             if (!_externCache.TryGetValue(key, out var func))

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -340,7 +340,7 @@ namespace Wasmtime
 
         private static readonly Native.Finalizer Finalizer = (p) => GCHandle.FromIntPtr(p).Free();
 
-        private readonly ConcurrentDictionary<(ExternKind kind, ulong store, nuint index), object> _externCache = new();
+        private readonly ConcurrentDictionary<(ExternKind kind, ulong store, nuint __private), object> _externCache = new();
 
         internal Function GetCachedExtern(ExternFunc @extern)
         {

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -340,41 +340,46 @@ namespace Wasmtime
 
         private static readonly Native.Finalizer Finalizer = (p) => GCHandle.FromIntPtr(p).Free();
 
-        private readonly ConcurrentDictionary<ExternFunc, Function> _externFuncCache = new();
-        private readonly ConcurrentDictionary<ExternMemory, Memory> _externMemoryCache = new();
-        private readonly ConcurrentDictionary<ExternGlobal, Global> _externGlobalCache = new();
+        private readonly ConcurrentDictionary<(ExternKind kind, ulong store, nuint index), object> _externCache = new();
 
         internal Function GetCachedExtern(ExternFunc @extern)
         {
-            if (!_externFuncCache.TryGetValue(@extern, out var func))
+            // TODO: Check if using the __private field is Ok.
+            var key = (ExternKind.Func, @extern.store, @extern.__private);
+
+            if (!_externCache.TryGetValue(key, out var func))
             {
                 func = new Function(this, @extern);
-                func = _externFuncCache.GetOrAdd(@extern, func);
+                func = _externCache.GetOrAdd(key, func);
             }
 
-            return func;
+            return (Function)func;
         }
 
         internal Memory GetCachedExtern(ExternMemory @extern)
         {
-            if (!_externMemoryCache.TryGetValue(@extern, out var mem))
+            var key = (ExternKind.Memory, @extern.store, @extern.__private);
+
+            if (!_externCache.TryGetValue(key, out var mem))
             {
                 mem = new Memory(this, @extern);
-                mem = _externMemoryCache.GetOrAdd(@extern, mem);
+                mem = _externCache.GetOrAdd(key, mem);
             }
 
-            return mem;
+            return (Memory)mem;
         }
 
         internal Global GetCachedExtern(ExternGlobal @extern)
         {
-            if (!_externGlobalCache.TryGetValue(@extern, out var global))
+            var key = (ExternKind.Global, @extern.store, @extern.__private);
+
+            if (!_externCache.TryGetValue(key, out var global))
             {
                 global = new Global(this, @extern);
-                global = _externGlobalCache.GetOrAdd(@extern, global);
+                global = _externCache.GetOrAdd(key, global);
             }
 
-            return global;
+            return (Global)global;
         }
     }
 }


### PR DESCRIPTION
Revert the changes to the cache of externs in `Store` from #318, as those would have negative performance impact.

When looking up a value in the dictionary, it would use the `Equals(object)` method on the struct which causes the struct to be boxed. Additionally, the default `ValueType.GetHashCode()` apparently doesn't incorporate the value of `[U]IntPtr`/`n[u]int` fields, so we would also need to implement `GetHashCode()` in the `Extern...` structs.

Instead, we use a `ValueTuple` as key consisting of the extern type and the the both struct fields, like it was done previously (`ValueTuple<...>` implements `IEquatable<T>` to avoid boxing, and uses all elements for calculating the hash code).

It should be Ok to access the `__private` field of the `Extern...` structs, because we don't interpret its value in any way, and just use it to compare the value to other struct instances.