### PR TITLE
Add Wasmtime Windows ARM64 (AArch64) binary

### DIFF
--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -144,6 +144,15 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       <FileExtension>zip</FileExtension>
       <LibraryFilename>wasmtime.dll</LibraryFilename>
     </Wasmtime>
+
+    <Wasmtime Include="windows-aarch64">
+      <Copy Condition="$([MSBuild]::IsOsPlatform('Windows')) And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='Arm64'">true</Copy>
+      <OS>windows</OS>
+      <Arch>aarch64</Arch>
+      <RID>win-arm64</RID>
+      <FileExtension>zip</FileExtension>
+      <LibraryFilename>wasmtime.dll</LibraryFilename>
+    </Wasmtime>
   </ItemGroup>
 
   <!-- This target downloads wasmtime and runs before any inner TFM-specific builds -->


### PR DESCRIPTION
Wasmtime recently completed Windows ARM64 support with bytecodealliance/wasmtime#9266 and added release artifacts with bytecodealliance/wasmtime#9283. This PR adds the Windows ARM64 Wasmtime binary to `wasmtime-dotnet`.

I think it should be available starting with Wasmtime 26.0.0.

Fixes #298