### PR TITLE
Update wasmtime to v34

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">32.0.1</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">33.0.1</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">
       $(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">25.0.3</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">26.0.1</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">
       $(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">23.0.0</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">24.0.3</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>
     <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">$(WasmtimeVersion)$(WasmtimeDotnetVersion)</WasmtimePackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">30.0.2</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">31.0.0</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">
       $(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">27.0.0</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">28.0.1</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">
       $(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,11 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">24.0.3</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">25.0.3</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
-    <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>
-    <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">$(WasmtimeVersion)$(WasmtimeDotnetVersion)</WasmtimePackageVersion>
+    <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">
+      $(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>
+    <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">
+      $(WasmtimeVersion)$(WasmtimeDotnetVersion)</WasmtimePackageVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">31.0.0</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">32.0.1</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">
       $(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">29.0.1</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">30.0.2</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">
       $(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">28.0.1</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">29.0.1</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">
       $(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">26.0.1</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">27.0.0</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">
       $(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <DevBuild Condition="'$(DevBuild)'==''">true</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">22.0.0</WasmtimeVersion>
+    <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">23.0.0</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>
     <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">$(WasmtimeVersion)$(WasmtimeDotnetVersion)</WasmtimePackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,9 @@
 <Project>
   <PropertyGroup>
-    <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">33.0.1</WasmtimeVersion>
+    <DevBuild Condition="'$(DevBuild)'==''">true</DevBuild>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">34.0.1</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
-    <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">
-      $(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>
-    <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">
-      $(WasmtimeVersion)$(WasmtimeDotnetVersion)</WasmtimePackageVersion>
+    <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>
+    <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">$(WasmtimeVersion)$(WasmtimeDotnetVersion)</WasmtimePackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -303,24 +303,13 @@ namespace Wasmtime
         }
 
         /// <summary>
-        /// Sets the maximum size of the guard region for static WebAssembly linear memories.
+        /// Sets the size of the guard region used at the end of a linear memory’s address space reservation
         /// </summary>
-        /// <param name="size">The maximum guard region size for static WebAssembly linear memories, in bytes.</param>
+        /// <param name="size">The size, in bytes, of the guard region used at the end of a linear memory’s address space reservation</param>
         /// <returns>Returns the current config.</returns>
-        public Config WithStaticMemoryGuardSize(ulong size)
+        public Config WithMemoryGuardSize(ulong size)
         {
-            Native.wasmtime_config_static_memory_guard_size_set(handle, size);
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the maximum size of the guard region for dynamic WebAssembly linear memories.
-        /// </summary>
-        /// <param name="size">The maximum guard region size for dynamic WebAssembly linear memories, in bytes.</param>
-        /// <returns>Returns the current config.</returns>
-        public Config WithDynamicMemoryGuardSize(ulong size)
-        {
-            Native.wasmtime_config_dynamic_memory_guard_size_set(handle, size);
+            Native.wasmtime_config_memory_guard_size_set(handle, size);
             return this;
         }
 
@@ -457,10 +446,7 @@ namespace Wasmtime
             public static extern void wasmtime_config_static_memory_maximum_size_set(Handle config, ulong size);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_static_memory_guard_size_set(Handle config, ulong size);
-
-            [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_dynamic_memory_guard_size_set(Handle config, ulong size);
+            public static extern void wasmtime_config_memory_guard_size_set(Handle config, ulong size);
 
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasmtime_config_cache_config_load(Handle config, [MarshalAs(Extensions.LPUTF8Str)] string? path);

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -298,7 +298,7 @@ namespace Wasmtime
         /// <returns>Returns the current config.</returns>
         public Config WithStaticMemoryMaximumSize(ulong size)
         {
-            Native.wasmtime_config_static_memory_maximum_size_set(handle, size);
+            Native.wasmtime_config_memory_reservation_set(handle, size);
             return this;
         }
 
@@ -443,7 +443,7 @@ namespace Wasmtime
             public static extern void wasmtime_config_profiler_set(Handle config, byte strategy);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_config_static_memory_maximum_size_set(Handle config, ulong size);
+            public static extern void wasmtime_config_memory_reservation_set(Handle config, ulong size);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_memory_guard_size_set(Handle config, ulong size);

--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -1,41 +1,69 @@
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace Wasmtime
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal struct ExternFunc
+    internal record struct ExternFunc
     {
+        static ExternFunc() => Debug.Assert(Marshal.SizeOf(typeof(ExternFunc)) == 16);
+
+        public ulong store;
+        public IntPtr __private;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    internal record struct ExternTable
+    {
+        static ExternTable() => Debug.Assert(Marshal.SizeOf(typeof(ExternTable)) == 24);
+
+        // Use explicit offsets because the struct in the C api has extra padding
+        // due to field alignments. The total struct size is 24 bytes.
+        
+        [FieldOffset(0)]
+        public ulong store;
+        [FieldOffset(8)]
+        public uint __private1;
+        [FieldOffset(16)]
+        public uint __private2;
+    }
+
+    
+    [StructLayout(LayoutKind.Explicit)]
+    internal record struct ExternMemory
+    {
+        static ExternMemory() => Debug.Assert(Marshal.SizeOf(typeof(ExternMemory)) == 24);
+
+        // Use explicit offsets because the struct in the C api has extra padding
+        // due to field alignments. The total struct size is 24 bytes.
+        
+        [FieldOffset(0)]
+        public ulong store;
+        [FieldOffset(8)]
+        public uint __private1;
+        [FieldOffset(16)]
+        public uint __private2;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal record struct ExternInstance
+    {
+        static ExternInstance() => Debug.Assert(Marshal.SizeOf(typeof(ExternInstance)) == 16);
+
         public ulong store;
         public nuint __private;
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct ExternTable
+    internal record struct ExternGlobal
     {
-        public ulong store;
-        public nuint __private;
-    }
+        static ExternGlobal() => Debug.Assert(Marshal.SizeOf(typeof(ExternMemory)) == 24);
 
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct ExternMemory
-    {
         public ulong store;
-        public nuint __private;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct ExternInstance
-    {
-        public ulong store;
-        public nuint __private;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct ExternGlobal
-    {
-        public ulong store;
-        public nuint __private;
+        public uint __private1;
+        public uint __private2;
+        public uint __private3;
     }
 
     internal enum ExternKind : byte
@@ -50,6 +78,8 @@ namespace Wasmtime
     [StructLayout(LayoutKind.Explicit)]
     internal struct ExternUnion
     {
+        static ExternUnion() => Debug.Assert(Marshal.SizeOf(typeof(ExternUnion)) == 24);
+
         [FieldOffset(0)]
         public ExternFunc func;
 
@@ -69,6 +99,8 @@ namespace Wasmtime
     [StructLayout(LayoutKind.Sequential)]
     internal struct Extern : IDisposable
     {
+        static Extern() => Debug.Assert(Marshal.SizeOf(typeof(Extern)) == 32);
+        
         public ExternKind kind;
         public ExternUnion of;
 

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -17,7 +17,8 @@ namespace Wasmtime
         /// <param name="minimum">The minimum number of WebAssembly pages.</param>
         /// <param name="maximum">The maximum number of WebAssembly pages, or <c>null</c> to not specify a maximum.</param>
         /// <param name="is64Bit"><c>true</c> when memory type represents a 64-bit memory, <c>false</c> when it represents a 32-bit memory.</param>
-        public Memory(Store store, long minimum = 0, long? maximum = null, bool is64Bit = false)
+        /// <param name="isShared"><c>true</c> when memory is shared, <c>false</c> when it is not shared.</param>
+        public Memory(Store store, long minimum = 0, long? maximum = null, bool is64Bit = false, bool isShared = false)
         {
             if (store is null)
             {
@@ -43,8 +44,9 @@ namespace Wasmtime
             Minimum = minimum;
             Maximum = maximum;
             Is64Bit = is64Bit;
+            IsShared = isShared;
 
-            var typeHandle = Native.wasmtime_memorytype_new((ulong)minimum, maximum is not null, (ulong)(maximum ?? 0), is64Bit);
+            var typeHandle = Native.wasmtime_memorytype_new((ulong)minimum, maximum is not null, (ulong)(maximum ?? 0), is64Bit, isShared);
             try
             {
 
@@ -61,7 +63,7 @@ namespace Wasmtime
                 Native.wasm_memorytype_delete(typeHandle);
             }
         }
-
+        
         /// <summary>
         /// The size, in bytes, of a WebAssembly memory page.
         /// </summary>
@@ -84,6 +86,12 @@ namespace Wasmtime
         /// </summary>
         /// <value><c>true</c> if this type of memory represents a 64-bit memory, <c>false</c> otherwise.</value>
         public bool Is64Bit { get; }
+
+        /// <summary>
+        /// Gets a value that indicates whether this memory is shared.
+        /// </summary>
+        /// <value><c>true</c> if this memory is shared, <c>false</c> otherwise.</value>
+        public bool IsShared { get; }
 
         /// <summary>
         /// Gets the current size of the memory, in WebAssembly page units.
@@ -595,7 +603,7 @@ namespace Wasmtime
             public static extern IntPtr wasmtime_memory_type(IntPtr context, in ExternMemory memory);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_memorytype_new(ulong min, [MarshalAs(UnmanagedType.I1)] bool max_present, ulong max, [MarshalAs(UnmanagedType.I1)] bool is_64);
+            public static extern IntPtr wasmtime_memorytype_new(ulong min, [MarshalAs(UnmanagedType.I1)] bool max_present, ulong max, [MarshalAs(UnmanagedType.I1)] bool is_64, [MarshalAs(UnmanagedType.I1)] bool shared);
 
             [DllImport(Engine.LibraryName)]
             public static extern ulong wasmtime_memorytype_minimum(IntPtr type);

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -17,8 +17,7 @@ namespace Wasmtime
         /// <param name="minimum">The minimum number of WebAssembly pages.</param>
         /// <param name="maximum">The maximum number of WebAssembly pages, or <c>null</c> to not specify a maximum.</param>
         /// <param name="is64Bit"><c>true</c> when memory type represents a 64-bit memory, <c>false</c> when it represents a 32-bit memory.</param>
-        /// <param name="isShared"><c>true</c> when memory is shared, <c>false</c> when it is not shared.</param>
-        public Memory(Store store, long minimum = 0, long? maximum = null, bool is64Bit = false, bool isShared = false)
+        public Memory(Store store, long minimum = 0, long? maximum = null, bool is64Bit = false)
         {
             if (store is null)
             {
@@ -44,9 +43,9 @@ namespace Wasmtime
             Minimum = minimum;
             Maximum = maximum;
             Is64Bit = is64Bit;
-            IsShared = isShared;
-
-            var typeHandle = Native.wasmtime_memorytype_new((ulong)minimum, maximum is not null, (ulong)(maximum ?? 0), is64Bit, isShared);
+            IsShared = false;
+            
+            var typeHandle = Native.wasmtime_memorytype_new((ulong)minimum, maximum is not null, (ulong)(maximum ?? 0), is64Bit, IsShared);
             try
             {
 

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -147,17 +147,17 @@ namespace Wasmtime
         {
             var v = Value.FromObject(store, value, Kind);
 
-            try 
+            try
             {
                 var error = Native.wasmtime_table_set(store.Context.handle, this.table, index, v);
-                GC.KeepAlive(store);                
+                GC.KeepAlive(store);
 
                 if (error != IntPtr.Zero)
                 {
                     throw WasmtimeException.FromOwnedError(error);
                 }
             }
-            finally 
+            finally
             {
                 v.Release(store);
             }
@@ -167,7 +167,7 @@ namespace Wasmtime
         /// Gets the current size of the table.
         /// </summary>
         /// <value>Returns the current size of the table.</value>
-        public uint GetSize()
+        public ulong GetSize()
         {
             var result = Native.wasmtime_table_size(store.Context.handle, this.table);
             GC.KeepAlive(store);
@@ -180,14 +180,14 @@ namespace Wasmtime
         /// <param name="delta">The number of elements to grow the table.</param>
         /// <param name="initialValue">The initial value for the new elements.</param>
         /// <returns>Returns the previous number of elements in the table.</returns>
-        public uint Grow(uint delta, object? initialValue)
+        public ulong Grow(uint delta, object? initialValue)
         {
             var v = Value.FromObject(store, initialValue, Kind);
 
             try
             {
                 var error = Native.wasmtime_table_grow(store.Context.handle, this.table, delta, v, out var prev);
-                GC.KeepAlive(store);                
+                GC.KeepAlive(store);
 
                 if (error != IntPtr.Zero)
                 {
@@ -261,16 +261,16 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             [return: MarshalAs(UnmanagedType.I1)]
-            public static extern bool wasmtime_table_get(IntPtr context, in ExternTable table, uint index, out Value val);
+            public static extern bool wasmtime_table_get(IntPtr context, in ExternTable table, ulong index, out Value val);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_table_set(IntPtr context, in ExternTable table, uint index, in Value val);
+            public static extern IntPtr wasmtime_table_set(IntPtr context, in ExternTable table, ulong index, in Value val);
 
             [DllImport(Engine.LibraryName)]
-            public static extern uint wasmtime_table_size(IntPtr context, in ExternTable table);
+            public static extern ulong wasmtime_table_size(IntPtr context, in ExternTable table);
 
             [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_table_grow(IntPtr context, in ExternTable table, uint delta, in Value value, out uint prev);
+            public static extern IntPtr wasmtime_table_grow(IntPtr context, in ExternTable table, ulong delta, in Value value, out ulong prev);
 
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasmtime_table_type(IntPtr context, in ExternTable table);

--- a/src/TrapException.cs
+++ b/src/TrapException.cs
@@ -37,8 +37,53 @@ namespace Wasmtime
         Unreachable = 9,
         /// <summary>The trap was the result of interrupting execution.</summary>
         Interrupt = 10,
+        /// <summary>
+        /// The trap was the result of executing a function that was `canon lift`'d, then `canonlower`'d, then called. 
+        /// </summary>
+        /// <remarks>
+        /// When the component model feature is enabled this trap represents a function that was `canon lift`'d,
+        /// then `canonlower`'d, then called. This combination of creation of a function in the component model
+        /// generates a function that always traps and, when called, produces this flavor of trap.
+        /// </remarks>
+        AlwaysTrapAdapter = 11,
         /// <summary>The trap was the result of running out of the configured fuel amount.</summary>
-        OutOfFuel = 11,
+        OutOfFuel = 12,
+        /// <summary>
+        /// The trap was the result of atomic wait operations on non-shared memory.
+        /// </summary>
+        AtomicWaitNonSharedMemory = 13,
+        /// <summary>
+        /// The trap was the result of a call to a null reference.
+        /// </summary>
+        NullReference = 14,
+        /// <summary>
+        /// The trap was the result of an attempt to access beyond the bounds of an array.
+        /// </summary>
+        ArrayOutOfBounds = 15,
+        /// <summary>
+        /// The trap was the result of an allocation that was too large to succeed.
+        /// </summary>
+        AllocationTooLarge = 16,
+        /// <summary>
+        /// The trap was the result of an attempt to cast a reference to a type that it is not an instance of.
+        /// </summary>
+        CastFailure = 17,
+        /// <summary>
+        /// The trap was the result of a component calling another component that would have violated the reentrance rules.
+        /// </summary>
+        CannotEnterComponent = 18,
+        /// <summary>
+        /// The trap was the result of an async-lifted export failing to return a valid async result.
+        /// </summary>
+        /// <remarks>
+        /// An async-lifted export failed to produce a result by calling `task.return` before returning `STATUS_DONE`
+        /// and/or after all host tasks completed.
+        /// </remarks>
+        NoAsyncResult = 19,
+        /// <summary>
+        /// The trap was the result of a Pulley opcode executed at runtime when the opcode was disabled at compile time.
+        /// </summary>
+        DisabledOpCode = 20
     }
 
     /// <summary>

--- a/tests/WasiTests.cs
+++ b/tests/WasiTests.cs
@@ -287,7 +287,7 @@ namespace Wasmtime.Tests
             using var file = new TempFile();
 
             var config = new WasiConfiguration()
-                .WithPreopenedDirectory(Path.GetDirectoryName(file.Path), "/foo");
+                .WithPreopenedDirectory(Path.GetDirectoryName(file.Path), "/foo", WasiDirectoryPermissions.Read | WasiDirectoryPermissions.Write, WasiFilePermissions.Read | WasiFilePermissions.Write);
 
             using var engine = new Engine();
             using var module = Module.FromTextFile(engine, Path.Combine("Modules", path));


### PR DESCRIPTION
Update the wasmtime dependency to the latest release: [v34.0.1](https://github.com/bytecodealliance/wasmtime/releases/tag/v34.0.1). As wasmtime-dotnet was several major versions behind a commit has been created for each major. See the individual commits for the changes related to that version.

The C api of wasmtime had some breaking changes so changes have been made to make interop with wasmtime-dotnet work again. The focus of this PR is compatibility: support for major features that are now available in wasmtime, such as shared memory or components, are out of scope.

