### PR TITLE
Added New `Config` Options

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -1,6 +1,6 @@
+using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;
-using Microsoft.Win32.SafeHandles;
 
 namespace Wasmtime
 {
@@ -104,6 +104,39 @@ namespace Wasmtime
         public Config WithFuelConsumption(bool enable)
         {
             Native.wasmtime_config_consume_fuel_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether or not to the WebAssembly tail call proposal is enabled. 
+        /// </summary>
+        /// <param name="enable">True to enable tails calls or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithTailCalls(bool enable)
+        {
+            Native.wasmtime_config_wasm_tail_call_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether the WebAssembly typed function reference types proposal is enabled. 
+        /// </summary>
+        /// <param name="enable">True to enable function references or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithFunctionReferences(bool enable)
+        {
+            Native.wasmtime_config_wasm_function_references_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether the WebAssembly GC proposal is enabled. 
+        /// </summary>
+        /// <param name="enable">True to enable GC or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithGc(bool enable)
+        {
+            Native.wasmtime_config_wasm_gc_set(handle, enable);
             return this;
         }
 
@@ -214,6 +247,41 @@ namespace Wasmtime
         }
 
         /// <summary>
+        /// Sets whether the WebAssembly wide-arithmetic proposal is enabled. 
+        /// </summary>
+        /// <param name="enable">True to enable WebAssembly wide arithmetic support or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithWideArithmetic(bool enable)
+        {
+            Native.wasmtime_config_wasm_wide_arithmetic_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether the WebAssembly stack switching proposal is enabled. 
+        /// </summary>
+        /// <param name="enable">True to enable WebAssembly stack switching support or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        private Config WithStackSwitching(bool enable)
+        {
+            // todo: unlikely to be compatible with wasmtime-dotnet on Windows due to threads
+
+            Native.wasmtime_config_wasm_stack_switching_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether wasmtime should compile a module using multiple threads.
+        /// </summary>
+        /// <param name="enable">True to enable parallel compilation or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithParallelCompilation(bool enable)
+        {
+            Native.wasmtime_config_parallel_compilation_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
         /// Sets the compiler strategy to use.
         /// </summary>
         /// <param name="strategy">The compiler strategy to use.</param>
@@ -237,6 +305,17 @@ namespace Wasmtime
         public Config WithCraneliftDebugVerifier(bool enable)
         {
             Native.wasmtime_config_cranelift_debug_verifier_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures whether memory_reservation is the maximal size of linear memory. <see cref="WithStaticMemoryMaximumSize"/>
+        /// </summary>
+        /// <param name="enable">True to allow memory base pointer to move or false to disable</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithMemoryMayMove(bool enable)
+        {
+            Native.wasmtime_config_memory_may_move_set(handle, enable);
             return this;
         }
 
@@ -292,13 +371,40 @@ namespace Wasmtime
         }
 
         /// <summary>
-        /// Sets the maximum size of static WebAssembly linear memories.
+        /// Configures the size, in bytes, of initial memory reservation size for linear memories. If <see cref="WithMemoryMayMove"/> if not set, this is the maximum size of memory.
         /// </summary>
-        /// <param name="size">The maximum size of static WebAssembly linear memories, in bytes.</param>
+        /// <param name="size">The initial size of static WebAssembly linear memories, in bytes.</param>
         /// <returns>Returns the current config.</returns>
         public Config WithStaticMemoryMaximumSize(ulong size)
         {
             Native.wasmtime_config_memory_reservation_set(handle, size);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the size, in bytes, of the extra virtual memory space reserved for memories to grow into after being relocated.
+        /// </summary>
+        /// <param name="size">The extra reserved bytes of virtual memory reserved for future growth.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithMemoryReservationForGrowth(ulong size)
+        {
+            Native.wasmtime_config_memory_reservation_for_growth_set(handle, size);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures whether copy-on-write memory-mapped data is used to initialize a linear memory.
+        /// Initializing linear memory via a copy-on-write mapping can drastically improve instantiation costs of a
+        /// WebAssembly module because copying memory is deferred.Additionally if a page of memory is only ever read
+        /// from WebAssembly and never written too then the same underlying page of data will be reused between
+        /// all instantiations of a module meaning that if a module is instantiated many times this can lower the
+        /// overall memory required needed to run that module.
+        /// </summary>
+        /// <param name="enabled">True to enable copy on write for memory initialisation or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithMemoryInitCopyOnWrite(bool enabled)
+        {
+            Native.wasmtime_config_memory_init_cow_set(handle, enabled);
             return this;
         }
 
@@ -343,6 +449,45 @@ namespace Wasmtime
         public Config WithMacosMachPorts(bool enable)
         {
             Native.wasmtime_config_macos_use_mach_ports(handle, enable);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures whether to generate native unwind information (e.g. .eh_frame on Linux).
+        /// 
+        /// For more information see the Rust documentation at <a href="https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.native_unwind_info">https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.native_unwind_info</a>
+        /// </summary>
+        /// <param name="enable">True to enable unwind info or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithUnwindInfo(bool enable)
+        {
+            Native.wasmtime_config_native_unwind_info_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the Wasmtime allocation strategy to use the pooling allocator. For more
+        /// information see the Rust documentation at
+        /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.allocation_strategy">https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.allocation_strategy</a>
+        /// </summary>
+        /// <param name="strategy">The pooling strategy config</param>
+        /// <returns></returns>
+        public Config WithPoolingAllocationStrategy(PoolingAllocationConfig strategy)
+        {
+            PoolingAllocationConfig.Native.wasmtime_pooling_allocation_strategy_set(NativeHandle, strategy.NativeHandle);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures whether the WebAssembly component-model proposal will be enabled for compilation. For more
+        /// information see the Rust documentation at
+        /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_component_model">https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_component_model</a>
+        /// </summary>
+        /// <param name="enabled">True to enable component model or false to disable.</param>
+        /// <returns></returns>
+        public Config WithComponentModel(bool enabled)
+        {
+            Native.wasmtime_config_wasm_component_model_set(NativeHandle, enabled);
             return this;
         }
 
@@ -398,6 +543,15 @@ namespace Wasmtime
             public static extern void wasmtime_config_consume_fuel_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_tail_call_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_function_references_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_gc_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+
+            [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_max_wasm_stack_set(Handle config, nuint size);
 
             [DllImport(Engine.LibraryName)]
@@ -426,6 +580,15 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_wasm_memory64_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+            
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_wide_arithmetic_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+            
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_stack_switching_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+            
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_parallel_compilation_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_strategy_set(Handle config, byte strategy);
@@ -435,6 +598,18 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_cranelift_nan_canonicalization_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+            
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_memory_may_move_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_native_unwind_info_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_memory_init_cow_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+            
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_memory_reservation_for_growth_set(Handle config, ulong bytes);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_cranelift_opt_level_set(Handle config, byte level);
@@ -453,6 +628,11 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_macos_use_mach_ports(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_component_model_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool value);
+
+            // todo: void wasmtime_config_host_memory_creator_set(wasm_config_t *, wasmtime_memory_creator_t *)
         }
 
         private readonly Handle handle;

--- a/src/PoolingAllocationConfig.cs
+++ b/src/PoolingAllocationConfig.cs
@@ -1,0 +1,393 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+namespace Wasmtime;
+
+/// <summary>
+/// A type containing configuration options for the pooling allocator. For more information
+/// see the Rust documentation at <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html</a>
+/// </summary>
+public class PoolingAllocationConfig
+    : IDisposable
+{
+    private readonly Handle handle;
+
+    /// <summary>
+    /// Creates a new configuration.
+    /// </summary>
+    public PoolingAllocationConfig()
+    {
+        handle = new Handle(Native.wasmtime_pooling_allocation_config_new());
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        handle.Dispose();
+    }
+
+    internal Handle NativeHandle
+    {
+        get
+        {
+            if (handle.IsInvalid || handle.IsClosed)
+            {
+                throw new ObjectDisposedException(typeof(Config).FullName);
+            }
+
+            return handle;
+        }
+    }
+
+    /// <summary>
+    /// Configures the maximum number of “unused warm slots” to retain in the pooling allocator. For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_unused_warm_slots">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_unused_warm_slots</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxUnusedWarmSlots(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_max_unused_warm_slots_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The target number of decommits to do per batch. For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.decommit_batch_size">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.decommit_batch_size</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithDecommitBatchSize(nuint count)
+    {
+        Native.wasmtime_pooling_allocation_config_decommit_batch_size_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// How much memory, in bytes, to keep resident for async stacks allocated with the pooling allocator. For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.async_stack_keep_resident">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.async_stack_keep_resident</a>
+    /// </summary>
+    /// <param name="bytes"></param>
+    /// <returns></returns>
+    private PoolingAllocationConfig WithAsyncStackKeepResidentBytes(nuint bytes)
+    {
+        // todo: Wasmtime-dotnet does not support async! Expose this if support is added.
+
+        Native.wasmtime_pooling_allocation_config_async_stack_keep_resident_set(NativeHandle, bytes);
+        return this;
+    }
+
+    /// <summary>
+    /// How much memory, in bytes, to keep resident for each linear memory after deallocation. For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.linear_memory_keep_resident">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.linear_memory_keep_resident</a>
+    /// </summary>
+    /// <param name="bytes"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithLinearMemoryKeepResidentBytes(nuint bytes)
+    {
+        Native.wasmtime_pooling_allocation_config_linear_memory_keep_resident_set(NativeHandle, bytes);
+        return this;
+    }
+
+    /// <summary>
+    /// How much memory, in bytes, to keep resident for each table after deallocation. For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.table_keep_resident">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.table_keep_resident</a>
+    /// </summary>
+    /// <param name="bytes"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithTableKeepResidentBytes(nuint bytes)
+    {
+        Native.wasmtime_pooling_allocation_config_table_keep_resident_set(NativeHandle, bytes);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of concurrent component instances supported (default is 1000). For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_component_instances">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_component_instances</a> 
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithTotalComponentInstances(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_total_component_instances_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum size, in bytes, allocated for a component instance’s VMComponentContext metadata. For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_component_instance_size">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_component_instance_size</a> 
+    /// </summary>
+    /// <param name="bytes"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxComponentInstanceSize(nuint bytes)
+    {
+        Native.wasmtime_pooling_allocation_config_max_component_instance_size_set(NativeHandle, bytes);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum size, in bytes, allocated for a core instance’s VMContext metadata. For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_core_instance_size">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_core_instance_size</a> 
+    /// </summary>
+    /// <param name="bytes"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxCoreInstanceSize(nuint bytes)
+    {
+        Native.wasmtime_pooling_allocation_config_max_core_instance_size_set(NativeHandle, bytes);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of core instances a single component may contain (default is unlimited). For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_core_instances_per_component">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_core_instances_per_component</a> 
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxCoreInstancesPerComponent(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_max_core_instances_per_component_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of Wasm linear memories that a single component may transitively contain (default is unlimited). For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memories_per_component">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memories_per_component</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxMemoriesPerComponent(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_max_memories_per_component_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of tables that a single component may transitively contain (default is unlimited).  For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_tables_per_component">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_tables_per_component</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxTablesPerComponent(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_max_tables_per_component_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of concurrent Wasm linear memories supported (default is 1000). For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_memories">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_memories</a> 
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxMemories(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_total_memories_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of execution stacks allowed for asynchronous execution, when enabled (default is 1000).
+    /// For more information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_stacks">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_stacks</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    private PoolingAllocationConfig WithMaxStacks(uint count)
+    {
+        // todo: Wasmtime-dotnet does not support async! Expose this if support is added.
+
+        Native.wasmtime_pooling_allocation_config_total_stacks_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of concurrent tables supported (default is 1000). For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_tables">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_tables</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxTables(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_total_tables_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of concurrent core instances supported (default is 1000). For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_core_instances">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_core_instances</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxCoreInstances(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_total_core_instances_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of defined tables for a core module (default is 1). For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_tables_per_module">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_tables_per_module</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxTablesPerModule(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_max_tables_per_module_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum table elements for any table defined in a module (default is 20000). For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.table_elements">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.table_elements</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxTableElements(nuint count)
+    {
+        Native.wasmtime_pooling_allocation_config_table_elements_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of defined linear memories for a module (default is 1). For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memories_per_module">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memories_per_module</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxMemoriesPerModule(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_max_memories_per_module_set(NativeHandle, count);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum byte size that any WebAssembly linear memory may grow to. For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memory_size">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.max_memory_size</a>
+    /// </summary>
+    /// <param name="bytes"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxMemorySize(nuint bytes)
+    {
+        Native.wasmtime_pooling_allocation_config_max_memory_size_set(NativeHandle, bytes);
+        return this;
+    }
+
+    /// <summary>
+    /// The maximum number of concurrent GC heaps supported (default is 1000). For more
+    /// information see the Rust documentation at
+    /// <a href="https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_gc_heaps">https://docs.wasmtime.dev/api/wasmtime/struct.PoolingAllocationConfig.html#method.total_gc_heaps</a>
+    /// </summary>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public PoolingAllocationConfig WithMaxGcHeaps(uint count)
+    {
+        Native.wasmtime_pooling_allocation_config_total_gc_heaps_set(NativeHandle, count);
+        return this;
+    }
+
+    internal class Handle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public Handle(IntPtr handle)
+            : base(true)
+        {
+            SetHandle(handle);
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Native.wasmtime_pooling_allocation_config_delete(handle);
+            return true;
+        }
+    }
+
+    internal static class Native
+    {
+        [DllImport(Engine.LibraryName)]
+        public static extern IntPtr wasmtime_pooling_allocation_config_new();
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_delete(IntPtr intPtr);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_max_unused_warm_slots_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_decommit_batch_size_set(Handle handle, nuint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_async_stack_keep_resident_set(Handle handle, nuint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_linear_memory_keep_resident_set(Handle handle, nuint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_table_keep_resident_set(Handle handle, nuint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_total_component_instances_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_max_component_instance_size_set(Handle handle, nuint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_max_core_instances_per_component_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_max_memories_per_component_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_max_tables_per_component_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_total_memories_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_total_tables_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_total_stacks_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_total_core_instances_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_max_core_instance_size_set(Handle handle, nuint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_max_tables_per_module_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_table_elements_set(Handle handle, nuint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_max_memories_per_module_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_max_memory_size_set(Handle handle, nuint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_config_total_gc_heaps_set(Handle handle, uint value);
+
+        [DllImport(Engine.LibraryName)]
+        public static extern void wasmtime_pooling_allocation_strategy_set(Config.Handle configHandle, Handle handle);
+    }
+}

--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -95,6 +95,16 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItSetsWideArithmetic()
+        {
+            var config = new Config();
+
+            config.WithWideArithmetic(true);
+
+            using var engine = new Engine(config);
+        }
+
+        [Fact]
         public void ItSetsThreads()
         {
             var config = new Config();
@@ -177,6 +187,22 @@ namespace Wasmtime.Tests
             Assert.Throws<ObjectDisposedException>(() => config.WithBulkMemory(true));
             Assert.Throws<ObjectDisposedException>(() => config.WithCacheConfig(null));
             Assert.Throws<ObjectDisposedException>(() => config.WithEpochInterruption(true));
+        }
+
+        [Fact]
+        public void ItSetsPoolingStrategy()
+        {
+            using var strategy = new PoolingAllocationConfig()
+                .WithDecommitBatchSize(4)
+                .WithLinearMemoryKeepResidentBytes(8)
+                .WithMaxGcHeaps(15)
+                .WithMaxMemorySize(16)
+                .WithMaxUnusedWarmSlots(23)
+                .WithTableKeepResidentBytes(42);
+
+            using var config = new Config();
+            config.WithPoolingAllocationStrategy(strategy);
+            using var engine = new Engine(config);
         }
     }
 }


### PR DESCRIPTION
Added almost all new `Config` options, including new `PoolingAllocationConfig` type.

Skipped support for `wasmtime_config_host_memory_creator_set`, since that's a fairly large and very advanced feature.