### PR TITLE
Fixed `wasmtime_engine_is_pulley` marshalling

### DIFF
--- a/src/Engine.cs
+++ b/src/Engine.cs
@@ -92,6 +92,7 @@ namespace Wasmtime
             public static extern void wasmtime_engine_increment_epoch(Handle engine);
             
             [DllImport(LibraryName)]
+            [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasmtime_engine_is_pulley(Handle engine);
         }
 


### PR DESCRIPTION
Fixing review feedback by @kpreisser here: https://github.com/bytecodealliance/wasmtime-dotnet/pull/338#pullrequestreview-3027070360