### PR TITLE
Support for native AOT & static linking

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <DevBuild Condition="'$(DevBuild)'==''">true</DevBuild>
-    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">35.0.0</WasmtimeVersion>
+    <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">38.0.3</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>
     <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">$(WasmtimeVersion)$(WasmtimeDotnetVersion)</WasmtimePackageVersion>

--- a/examples/Directory.Build.targets
+++ b/examples/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\src\build\wasmtime.targets" />
+</Project>

--- a/examples/hello/hello.csproj
+++ b/examples/hello/hello.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\Wasmtime.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -7,7 +7,7 @@ namespace Wasmtime
     [StructLayout(LayoutKind.Sequential)]
     internal record struct ExternFunc
     {
-        static ExternFunc() => Debug.Assert(Marshal.SizeOf(typeof(ExternFunc)) == 16);
+        static ExternFunc() => Debug.Assert(Marshal.SizeOf<ExternFunc>() == 16);
 
         public ulong store;
         public IntPtr __private;
@@ -16,7 +16,7 @@ namespace Wasmtime
     [StructLayout(LayoutKind.Explicit)]
     internal record struct ExternTable
     {
-        static ExternTable() => Debug.Assert(Marshal.SizeOf(typeof(ExternTable)) == 24);
+        static ExternTable() => Debug.Assert(Marshal.SizeOf<ExternTable>() == 24);
 
         // Use explicit offsets because the struct in the C api has extra padding
         // due to field alignments. The total struct size is 24 bytes.
@@ -33,7 +33,7 @@ namespace Wasmtime
     [StructLayout(LayoutKind.Explicit)]
     internal record struct ExternMemory
     {
-        static ExternMemory() => Debug.Assert(Marshal.SizeOf(typeof(ExternMemory)) == 24);
+        static ExternMemory() => Debug.Assert(Marshal.SizeOf<ExternMemory>() == 24);
 
         // Use explicit offsets because the struct in the C api has extra padding
         // due to field alignments. The total struct size is 24 bytes.
@@ -49,7 +49,7 @@ namespace Wasmtime
     [StructLayout(LayoutKind.Sequential)]
     internal record struct ExternInstance
     {
-        static ExternInstance() => Debug.Assert(Marshal.SizeOf(typeof(ExternInstance)) == 16);
+        static ExternInstance() => Debug.Assert(Marshal.SizeOf<ExternInstance>() == 16);
 
         public ulong store;
         public nuint __private;
@@ -58,7 +58,7 @@ namespace Wasmtime
     [StructLayout(LayoutKind.Sequential)]
     internal record struct ExternGlobal
     {
-        static ExternGlobal() => Debug.Assert(Marshal.SizeOf(typeof(ExternMemory)) == 24);
+        static ExternGlobal() => Debug.Assert(Marshal.SizeOf<ExternGlobal>() == 24);
 
         public ulong store;
         public uint __private1;
@@ -78,7 +78,7 @@ namespace Wasmtime
     [StructLayout(LayoutKind.Explicit)]
     internal struct ExternUnion
     {
-        static ExternUnion() => Debug.Assert(Marshal.SizeOf(typeof(ExternUnion)) == 24);
+        static ExternUnion() => Debug.Assert(Marshal.SizeOf<ExternUnion>() == 24);
 
         [FieldOffset(0)]
         public ExternFunc func;
@@ -99,7 +99,7 @@ namespace Wasmtime
     [StructLayout(LayoutKind.Sequential)]
     internal struct Extern : IDisposable
     {
-        static Extern() => Debug.Assert(Marshal.SizeOf(typeof(Extern)) == 32);
+        static Extern() => Debug.Assert(Marshal.SizeOf<Extern>() == 32);
         
         public ExternKind kind;
         public ExternUnion of;

--- a/src/Function.FromCallback.cs
+++ b/src/Function.FromCallback.cs
@@ -9,6 +9,9 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -19,6 +22,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback(Store store, Action callback)
         {
             if (store is null)
@@ -80,6 +86,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T>(Store store, Action<T?> callback)
         {
             if (store is null)
@@ -142,6 +151,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2>(Store store, Action<T1?, T2?> callback)
         {
             if (store is null)
@@ -206,6 +218,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3>(Store store, Action<T1?, T2?, T3?> callback)
         {
             if (store is null)
@@ -272,6 +287,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4>(Store store, Action<T1?, T2?, T3?, T4?> callback)
         {
             if (store is null)
@@ -340,6 +358,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5>(Store store, Action<T1?, T2?, T3?, T4?, T5?> callback)
         {
             if (store is null)
@@ -410,6 +431,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?> callback)
         {
             if (store is null)
@@ -482,6 +506,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
         {
             if (store is null)
@@ -556,6 +583,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
         {
             if (store is null)
@@ -632,6 +662,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
         {
             if (store is null)
@@ -710,6 +743,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
         {
             if (store is null)
@@ -790,6 +826,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
         {
             if (store is null)
@@ -872,6 +911,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
         {
             if (store is null)
@@ -956,6 +998,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<TResult>(Store store, Func<TResult> callback)
         {
             if (store is null)
@@ -1019,6 +1065,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T, TResult>(Store store, Func<T?, TResult> callback)
         {
             if (store is null)
@@ -1083,6 +1133,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, TResult>(Store store, Func<T1?, T2?, TResult> callback)
         {
             if (store is null)
@@ -1149,6 +1203,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, TResult>(Store store, Func<T1?, T2?, T3?, TResult> callback)
         {
             if (store is null)
@@ -1217,6 +1275,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, TResult>(Store store, Func<T1?, T2?, T3?, T4?, TResult> callback)
         {
             if (store is null)
@@ -1287,6 +1349,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, TResult> callback)
         {
             if (store is null)
@@ -1359,6 +1425,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
         {
             if (store is null)
@@ -1433,6 +1503,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
         {
             if (store is null)
@@ -1509,6 +1583,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
         {
             if (store is null)
@@ -1587,6 +1665,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
         {
             if (store is null)
@@ -1667,6 +1749,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
         {
             if (store is null)
@@ -1749,6 +1835,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
         {
             if (store is null)
@@ -1833,6 +1923,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
         {
             if (store is null)
@@ -1919,6 +2013,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<TResult1, TResult2>(Store store, Func<ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -1984,6 +2082,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T, TResult1, TResult2>(Store store, Func<T?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2050,6 +2152,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, TResult1, TResult2>(Store store, Func<T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2118,6 +2224,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2188,6 +2298,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2260,6 +2374,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2334,6 +2452,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2410,6 +2532,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2488,6 +2614,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2568,6 +2698,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2650,6 +2784,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2734,6 +2872,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2820,6 +2962,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2908,6 +3054,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<TResult1, TResult2, TResult3>(Store store, Func<ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -2975,6 +3125,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T, TResult1, TResult2, TResult3>(Store store, Func<T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3043,6 +3197,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3113,6 +3271,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3185,6 +3347,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3259,6 +3425,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3335,6 +3505,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3413,6 +3587,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3493,6 +3671,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3575,6 +3757,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3659,6 +3845,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3745,6 +3935,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3833,6 +4027,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3923,6 +4121,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<TResult1, TResult2, TResult3, TResult4>(Store store, Func<ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -3992,6 +4194,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4062,6 +4268,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4134,6 +4344,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4208,6 +4422,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4284,6 +4502,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4362,6 +4584,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4442,6 +4668,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4524,6 +4754,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4608,6 +4842,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4694,6 +4932,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4782,6 +5024,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4872,6 +5118,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4964,6 +5214,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback(Store store, CallerAction callback)
         {
             if (store is null)
@@ -5028,6 +5281,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T>(Store store, CallerAction<T?> callback)
         {
             if (store is null)
@@ -5094,6 +5350,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2>(Store store, CallerAction<T1?, T2?> callback)
         {
             if (store is null)
@@ -5162,6 +5421,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3>(Store store, CallerAction<T1?, T2?, T3?> callback)
         {
             if (store is null)
@@ -5232,6 +5494,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4>(Store store, CallerAction<T1?, T2?, T3?, T4?> callback)
         {
             if (store is null)
@@ -5304,6 +5569,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?> callback)
         {
             if (store is null)
@@ -5378,6 +5646,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?> callback)
         {
             if (store is null)
@@ -5454,6 +5725,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
         {
             if (store is null)
@@ -5532,6 +5806,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
         {
             if (store is null)
@@ -5612,6 +5889,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
         {
             if (store is null)
@@ -5694,6 +5974,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
         {
             if (store is null)
@@ -5778,6 +6061,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
         {
             if (store is null)
@@ -5864,6 +6150,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
         {
             if (store is null)
@@ -5952,6 +6241,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<TResult>(Store store, CallerFunc<TResult> callback)
         {
             if (store is null)
@@ -6018,6 +6311,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T, TResult>(Store store, CallerFunc<T?, TResult> callback)
         {
             if (store is null)
@@ -6086,6 +6383,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, TResult>(Store store, CallerFunc<T1?, T2?, TResult> callback)
         {
             if (store is null)
@@ -6156,6 +6457,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, TResult>(Store store, CallerFunc<T1?, T2?, T3?, TResult> callback)
         {
             if (store is null)
@@ -6228,6 +6533,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, TResult> callback)
         {
             if (store is null)
@@ -6302,6 +6611,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, TResult> callback)
         {
             if (store is null)
@@ -6378,6 +6691,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
         {
             if (store is null)
@@ -6456,6 +6773,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
         {
             if (store is null)
@@ -6536,6 +6857,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
         {
             if (store is null)
@@ -6618,6 +6943,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
         {
             if (store is null)
@@ -6702,6 +7031,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
         {
             if (store is null)
@@ -6788,6 +7121,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
         {
             if (store is null)
@@ -6876,6 +7213,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
         {
             if (store is null)
@@ -6966,6 +7307,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<TResult1, TResult2>(Store store, CallerFunc<ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7034,6 +7379,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T, TResult1, TResult2>(Store store, CallerFunc<T?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7104,6 +7453,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7176,6 +7529,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7250,6 +7607,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7326,6 +7687,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7404,6 +7769,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7484,6 +7853,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7566,6 +7939,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7650,6 +8027,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7736,6 +8117,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7824,6 +8209,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7914,6 +8303,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -8006,6 +8399,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<TResult1, TResult2, TResult3>(Store store, CallerFunc<ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8076,6 +8473,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T, TResult1, TResult2, TResult3>(Store store, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8148,6 +8549,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8222,6 +8627,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8298,6 +8707,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8376,6 +8789,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8456,6 +8873,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8538,6 +8959,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8622,6 +9047,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8708,6 +9137,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8796,6 +9229,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8886,6 +9323,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8978,6 +9419,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -9072,6 +9517,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9144,6 +9593,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9218,6 +9671,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9294,6 +9751,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9372,6 +9833,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9452,6 +9917,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9534,6 +10003,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9618,6 +10091,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9704,6 +10181,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9792,6 +10273,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9882,6 +10367,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9974,6 +10463,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -10068,6 +10561,10 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+#endif
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)

--- a/src/Function.FromCallback.tt
+++ b/src/Function.FromCallback.tt
@@ -20,6 +20,9 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -41,6 +44,12 @@ foreach (var (hasCaller, resultCount, parameterCount, methodGenerics, delegateTy
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating functions from callbacks may require runtime code generation for parameter and result types.")]
+<# if (resultCount > 0) { #>
+        [RequiresUnreferencedCode("Creating functions with results may require reflection.")]
+<# } #>
+#endif
         public static Function FromCallback<#= methodGenerics #>(Store store, <#= delegateType #> callback)
         {
             if (store is null)

--- a/src/Function.Wrap.cs
+++ b/src/Function.Wrap.cs
@@ -7,6 +7,9 @@
 #nullable enable
 
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -18,6 +21,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action? WrapAction()
         {
             if (store is null || IsNull)
@@ -64,6 +70,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T>? WrapAction<T>()
         {
             if (store is null || IsNull)
@@ -112,6 +121,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2>? WrapAction<T1, T2>()
         {
             if (store is null || IsNull)
@@ -162,6 +174,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3>? WrapAction<T1, T2, T3>()
         {
             if (store is null || IsNull)
@@ -214,6 +229,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4>? WrapAction<T1, T2, T3, T4>()
         {
             if (store is null || IsNull)
@@ -268,6 +286,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5>? WrapAction<T1, T2, T3, T4, T5>()
         {
             if (store is null || IsNull)
@@ -324,6 +345,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6>? WrapAction<T1, T2, T3, T4, T5, T6>()
         {
             if (store is null || IsNull)
@@ -382,6 +406,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6, T7>? WrapAction<T1, T2, T3, T4, T5, T6, T7>()
         {
             if (store is null || IsNull)
@@ -442,6 +469,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6, T7, T8>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8>()
         {
             if (store is null || IsNull)
@@ -504,6 +534,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9>()
         {
             if (store is null || IsNull)
@@ -568,6 +601,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>()
         {
             if (store is null || IsNull)
@@ -634,6 +670,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>()
         {
             if (store is null || IsNull)
@@ -702,6 +741,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>()
         {
             if (store is null || IsNull)
@@ -772,6 +814,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>()
         {
             if (store is null || IsNull)
@@ -844,6 +889,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>()
         {
             if (store is null || IsNull)
@@ -918,6 +966,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>()
         {
             if (store is null || IsNull)
@@ -994,6 +1045,9 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>()
         {
             if (store is null || IsNull)
@@ -1072,6 +1126,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<TResult?>? WrapFunc<TResult>()
         {
             if (store is null || IsNull)
@@ -1121,6 +1179,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T, TResult?>? WrapFunc<T, TResult>()
         {
             if (store is null || IsNull)
@@ -1172,6 +1234,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, TResult?>? WrapFunc<T1, T2, TResult>()
         {
             if (store is null || IsNull)
@@ -1225,6 +1291,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, TResult?>? WrapFunc<T1, T2, T3, TResult>()
         {
             if (store is null || IsNull)
@@ -1280,6 +1350,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, TResult?>? WrapFunc<T1, T2, T3, T4, TResult>()
         {
             if (store is null || IsNull)
@@ -1337,6 +1411,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, TResult?>? WrapFunc<T1, T2, T3, T4, T5, TResult>()
         {
             if (store is null || IsNull)
@@ -1396,6 +1474,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, TResult>()
         {
             if (store is null || IsNull)
@@ -1457,6 +1539,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, T7, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, TResult>()
         {
             if (store is null || IsNull)
@@ -1520,6 +1606,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, TResult>()
         {
             if (store is null || IsNull)
@@ -1585,6 +1675,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>()
         {
             if (store is null || IsNull)
@@ -1652,6 +1746,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>()
         {
             if (store is null || IsNull)
@@ -1721,6 +1819,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>()
         {
             if (store is null || IsNull)
@@ -1792,6 +1894,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>()
         {
             if (store is null || IsNull)
@@ -1865,6 +1971,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>()
         {
             if (store is null || IsNull)
@@ -1940,6 +2050,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>()
         {
             if (store is null || IsNull)
@@ -2017,6 +2131,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>()
         {
             if (store is null || IsNull)
@@ -2096,6 +2214,10 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>()
         {
             if (store is null || IsNull)

--- a/src/Function.Wrap.tt
+++ b/src/Function.Wrap.tt
@@ -18,6 +18,9 @@
 #nullable enable
 
 using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -39,6 +42,16 @@ foreach (var (_, returnTypeCount, parameterCount, methodGenerics, delegateType, 
         /// Attempt to wrap this function as <#= returnTypeCount > 0 ? "a <c>Func</c>" : "an <c>Action</c>" #>. Wrapped <c><#= returnTypeCount > 0 ? "Func" : "Action" #></c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c><#= returnTypeCount > 0 ? "Func" : "Action" #></c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+<# if (returnTypeCount > 0) { #>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+#endif
+<# } else { #>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
+<# } #>
         public <#= delegateType #>? Wrap<#= returnTypeCount > 0 ? "Func" : "Action" #><#= methodGenerics #>()
         {
             if (store is null || IsNull)

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -101,7 +104,16 @@ namespace Wasmtime
         /// <param name="returnType">Return type (use a tuple for multiple return types)</param>
         /// <param name="parameters">The parameters of the function</param>
         /// <returns>Returns true if the type signature of the function is valid or false if not.</returns>
-        public bool CheckTypeSignature(Type? returnType = null, params Type[] parameters)
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
+            Justification = "The GetResultInnerType method returns a type that maintains the same interface requirements as the input type.")]
+#endif
+        public bool CheckTypeSignature(
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] 
+#endif
+            Type? returnType = null, 
+            params Type[] parameters)
         {
             // Check if the return type is a recognised result type (i.e. implements IActionResult or IFunctionResult)
             if (returnType != null && returnType.IsResultType())

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -69,6 +72,9 @@ namespace Wasmtime
         /// </summary>
         /// <param name="name">The name of the exported function.</param>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action? GetAction(string name)
         {
             return GetFunction(name)
@@ -81,6 +87,9 @@ namespace Wasmtime
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TA">Parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<TA>? GetAction<TA>(string name)
         {
             return GetFunction(name)
@@ -94,6 +103,9 @@ namespace Wasmtime
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TB">Second parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<TA, TB>? GetAction<TA, TB>(string name)
         {
             return GetFunction(name)
@@ -108,6 +120,9 @@ namespace Wasmtime
         /// <typeparam name="TB">Second parameter type</typeparam>
         /// <typeparam name="TC">Third parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<TA, TB, TC>? GetAction<TA, TB, TC>(string name)
         {
             return GetFunction(name)
@@ -123,6 +138,9 @@ namespace Wasmtime
         /// <typeparam name="TC">Third parameter type</typeparam>
         /// <typeparam name="TD">Fourth parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<TA, TB, TC, TD>? GetAction<TA, TB, TC, TD>(string name)
         {
             return GetFunction(name)
@@ -139,6 +157,9 @@ namespace Wasmtime
         /// <typeparam name="TD">Fourth parameter type</typeparam>
         /// <typeparam name="TE">Fifth parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Wrapping functions may require runtime code generation for parameter types.")]
+#endif
         public Action<TA, TB, TC, TD, TE>? GetAction<TA, TB, TC, TD, TE>(string name)
         {
             return GetFunction(name)
@@ -151,6 +172,10 @@ namespace Wasmtime
         /// <param name="name">The name of the exported function.</param>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TR?>? GetFunction<TR>(string name)
         {
             return GetFunction(name)
@@ -164,6 +189,10 @@ namespace Wasmtime
         /// <typeparam name="TA">First parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TR?>? GetFunction<TA, TR>(string name)
         {
             return GetFunction(name)
@@ -178,6 +207,10 @@ namespace Wasmtime
         /// <typeparam name="TB">Second parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TR?>? GetFunction<TA, TB, TR>(string name)
         {
             return GetFunction(name)
@@ -193,6 +226,10 @@ namespace Wasmtime
         /// <typeparam name="TC">Third parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TR?>? GetFunction<TA, TB, TC, TR>(string name)
         {
             return GetFunction(name)
@@ -209,6 +246,10 @@ namespace Wasmtime
         /// <typeparam name="TD">Fourth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TR?>? GetFunction<TA, TB, TC, TD, TR>(string name)
         {
             return GetFunction(name)
@@ -226,6 +267,10 @@ namespace Wasmtime
         /// <typeparam name="TE">Fifth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TR?>? GetFunction<TA, TB, TC, TD, TE, TR>(string name)
         {
             return GetFunction(name)
@@ -244,6 +289,10 @@ namespace Wasmtime
         /// <typeparam name="TF">Sixth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TR>(string name)
         {
             return GetFunction(name)
@@ -263,6 +312,10 @@ namespace Wasmtime
         /// <typeparam name="TG">Seventh parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TG, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TR>(string name)
         {
             return GetFunction(name)
@@ -283,6 +336,10 @@ namespace Wasmtime
         /// <typeparam name="TH">Eighth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TR>(string name)
         {
             return GetFunction(name)
@@ -304,6 +361,10 @@ namespace Wasmtime
         /// <typeparam name="TI">Ninth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>(string name)
         {
             return GetFunction(name)
@@ -326,6 +387,10 @@ namespace Wasmtime
         /// <typeparam name="TJ">Tenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>(string name)
         {
             return GetFunction(name)
@@ -349,6 +414,10 @@ namespace Wasmtime
         /// <typeparam name="TK">Eleventh parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>(string name)
         {
             return GetFunction(name)
@@ -373,6 +442,10 @@ namespace Wasmtime
         /// <typeparam name="TL">Twelfth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>(string name)
         {
             return GetFunction(name)
@@ -398,6 +471,10 @@ namespace Wasmtime
         /// <typeparam name="TM">Thirteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>(string name)
         {
             return GetFunction(name)
@@ -424,6 +501,10 @@ namespace Wasmtime
         /// <typeparam name="TN">Fourteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>(string name)
         {
             return GetFunction(name)
@@ -451,6 +532,10 @@ namespace Wasmtime
         /// <typeparam name="TO">Fifteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>(string name)
         {
             return GetFunction(name)
@@ -479,6 +564,10 @@ namespace Wasmtime
         /// <typeparam name="TP">Sixteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Wrapping functions with return types may require reflection.")]
+        [RequiresDynamicCode("Wrapping functions with return types may require runtime code generation for tuple types.")]
+#endif
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>(string name)
         {
             return GetFunction(name)
@@ -493,7 +582,12 @@ namespace Wasmtime
         /// <param name="returnType">The return type of the function. Null if no return type. Tuple of types is multiple returns expected.</param>
         /// <param name="parameterTypes">The expected parameters to the function</param>
         /// <returns>Returns the function if a function of that name and type signature was exported or null if not.</returns>
-        public Function? GetFunction(string name, Type? returnType, params Type[] parameterTypes)
+        public Function? GetFunction(string name,
+#if NET5_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+        Type? returnType,
+        params Type[] parameterTypes)
         {
             var func = GetFunction(name);
             if (func is null)

--- a/src/Linker.DefineFunction.cs
+++ b/src/Linker.DefineFunction.cs
@@ -10,6 +10,9 @@ using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Text;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -22,6 +25,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction(string module, string name, Action callback)
         {
             if (module is null)
@@ -121,6 +127,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T>(string module, string name, Action<T?> callback)
         {
             if (module is null)
@@ -221,6 +230,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2>(string module, string name, Action<T1?, T2?> callback)
         {
             if (module is null)
@@ -323,6 +335,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3>(string module, string name, Action<T1?, T2?, T3?> callback)
         {
             if (module is null)
@@ -427,6 +442,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4>(string module, string name, Action<T1?, T2?, T3?, T4?> callback)
         {
             if (module is null)
@@ -533,6 +551,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?> callback)
         {
             if (module is null)
@@ -641,6 +662,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?> callback)
         {
             if (module is null)
@@ -751,6 +775,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
         {
             if (module is null)
@@ -863,6 +890,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
         {
             if (module is null)
@@ -977,6 +1007,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
         {
             if (module is null)
@@ -1093,6 +1126,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
         {
             if (module is null)
@@ -1211,6 +1247,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
         {
             if (module is null)
@@ -1331,6 +1370,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
         {
             if (module is null)
@@ -1453,6 +1495,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<TResult>(string module, string name, Func<TResult> callback)
         {
             if (module is null)
@@ -1554,6 +1600,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T, TResult>(string module, string name, Func<T?, TResult> callback)
         {
             if (module is null)
@@ -1656,6 +1706,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, TResult>(string module, string name, Func<T1?, T2?, TResult> callback)
         {
             if (module is null)
@@ -1760,6 +1814,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, TResult>(string module, string name, Func<T1?, T2?, T3?, TResult> callback)
         {
             if (module is null)
@@ -1866,6 +1924,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, TResult> callback)
         {
             if (module is null)
@@ -1974,6 +2036,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, TResult> callback)
         {
             if (module is null)
@@ -2084,6 +2150,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
         {
             if (module is null)
@@ -2196,6 +2266,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
         {
             if (module is null)
@@ -2310,6 +2384,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
         {
             if (module is null)
@@ -2426,6 +2504,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
         {
             if (module is null)
@@ -2544,6 +2626,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
         {
             if (module is null)
@@ -2664,6 +2750,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
         {
             if (module is null)
@@ -2786,6 +2876,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
         {
             if (module is null)
@@ -2910,6 +3004,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<TResult1, TResult2>(string module, string name, Func<ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3013,6 +3111,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T, TResult1, TResult2>(string module, string name, Func<T?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3117,6 +3219,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, TResult1, TResult2>(string module, string name, Func<T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3223,6 +3329,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3331,6 +3441,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3441,6 +3555,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3553,6 +3671,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3667,6 +3789,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3783,6 +3909,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3901,6 +4031,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -4021,6 +4155,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -4143,6 +4281,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -4267,6 +4409,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -4393,6 +4539,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<TResult1, TResult2, TResult3>(string module, string name, Func<ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -4498,6 +4648,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T, TResult1, TResult2, TResult3>(string module, string name, Func<T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -4604,6 +4758,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -4712,6 +4870,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -4822,6 +4984,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -4934,6 +5100,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5048,6 +5218,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5164,6 +5338,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5282,6 +5460,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5402,6 +5584,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5524,6 +5710,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5648,6 +5838,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5774,6 +5968,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5902,6 +6100,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6009,6 +6211,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6117,6 +6323,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6227,6 +6437,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6339,6 +6553,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6453,6 +6671,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6569,6 +6791,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6687,6 +6913,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6807,6 +7037,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6929,6 +7163,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -7053,6 +7291,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -7179,6 +7421,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -7307,6 +7553,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -7437,6 +7687,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction(string module, string name, CallerAction callback)
         {
             if (module is null)
@@ -7536,6 +7789,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T>(string module, string name, CallerAction<T?> callback)
         {
             if (module is null)
@@ -7637,6 +7893,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2>(string module, string name, CallerAction<T1?, T2?> callback)
         {
             if (module is null)
@@ -7740,6 +7999,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3>(string module, string name, CallerAction<T1?, T2?, T3?> callback)
         {
             if (module is null)
@@ -7845,6 +8107,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4>(string module, string name, CallerAction<T1?, T2?, T3?, T4?> callback)
         {
             if (module is null)
@@ -7952,6 +8217,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?> callback)
         {
             if (module is null)
@@ -8061,6 +8329,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?> callback)
         {
             if (module is null)
@@ -8172,6 +8443,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
         {
             if (module is null)
@@ -8285,6 +8559,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
         {
             if (module is null)
@@ -8400,6 +8677,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
         {
             if (module is null)
@@ -8517,6 +8797,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
         {
             if (module is null)
@@ -8636,6 +8919,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
         {
             if (module is null)
@@ -8757,6 +9043,9 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
         {
             if (module is null)
@@ -8880,6 +9169,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<TResult>(string module, string name, CallerFunc<TResult> callback)
         {
             if (module is null)
@@ -8981,6 +9274,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T, TResult>(string module, string name, CallerFunc<T?, TResult> callback)
         {
             if (module is null)
@@ -9084,6 +9381,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, TResult>(string module, string name, CallerFunc<T1?, T2?, TResult> callback)
         {
             if (module is null)
@@ -9189,6 +9490,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, TResult> callback)
         {
             if (module is null)
@@ -9296,6 +9601,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, TResult> callback)
         {
             if (module is null)
@@ -9405,6 +9714,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, TResult> callback)
         {
             if (module is null)
@@ -9516,6 +9829,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
         {
             if (module is null)
@@ -9629,6 +9946,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
         {
             if (module is null)
@@ -9744,6 +10065,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
         {
             if (module is null)
@@ -9861,6 +10186,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
         {
             if (module is null)
@@ -9980,6 +10309,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
         {
             if (module is null)
@@ -10101,6 +10434,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
         {
             if (module is null)
@@ -10224,6 +10561,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
         {
             if (module is null)
@@ -10349,6 +10690,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<TResult1, TResult2>(string module, string name, CallerFunc<ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10452,6 +10797,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T, TResult1, TResult2>(string module, string name, CallerFunc<T?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10557,6 +10906,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10664,6 +11017,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10773,6 +11130,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10884,6 +11245,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10997,6 +11362,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11112,6 +11481,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11229,6 +11602,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11348,6 +11725,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11469,6 +11850,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11592,6 +11977,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11717,6 +12106,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11844,6 +12237,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<TResult1, TResult2, TResult3>(string module, string name, CallerFunc<ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -11949,6 +12346,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12056,6 +12457,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12165,6 +12570,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12276,6 +12685,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12389,6 +12802,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12504,6 +12921,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12621,6 +13042,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12740,6 +13165,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12861,6 +13290,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12984,6 +13417,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -13109,6 +13546,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -13236,6 +13677,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -13365,6 +13810,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -13472,6 +13921,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -13581,6 +14034,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -13692,6 +14149,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -13805,6 +14266,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -13920,6 +14385,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14037,6 +14506,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14156,6 +14629,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14277,6 +14754,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14400,6 +14881,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14525,6 +15010,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14652,6 +15141,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14781,6 +15274,10 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+#endif
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)

--- a/src/Linker.DefineFunction.tt
+++ b/src/Linker.DefineFunction.tt
@@ -21,6 +21,9 @@ using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Text;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -44,6 +47,12 @@ foreach (var (hasCaller, resultCount, parameterCount, methodGenerics, delegateTy
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Defining functions may require runtime code generation for parameter and result types.")]
+<# if (resultCount > 0) { #>
+        [RequiresUnreferencedCode("Defining functions with results may require reflection.")]
+<# } #>
+#endif
         public void DefineFunction<#= methodGenerics #>(string module, string name, <#= delegateType #> callback)
         {
             if (module is null)

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -46,13 +46,18 @@ namespace Wasmtime
             IsShared = false;
 
         #if WASMTIME_DEV
+        #if NET5_0_OR_GREATER
+            byte pageSizeLog2 = (byte)Math.Log2(PageSize);
+        #else
+            byte pageSizeLog2 = (byte)(Math.Log(PageSize) / Math.Log(2));
+        #endif
             var typeError = Native.wasmtime_memorytype_new(
                 (ulong)minimum,
                 maximum is not null,
                 (ulong)(maximum ?? 0),
                 is64Bit,
                 IsShared,
-                (byte)Math.Log2(PageSize),  // page_size_log2: 16 = 64KB pages (2^16 = 65536)
+                pageSizeLog2,
                 out IntPtr typeHandle);
 
             if (typeError != IntPtr.Zero)

--- a/src/Result.cs
+++ b/src/Result.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -245,7 +248,15 @@ namespace Wasmtime
 
     internal static class TypeExtensions
     {
-        public static Type? TryGetResultInterface(this Type type)
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:DynamicallyAccessedMembers",
+            Justification = "The interfaces we're looking for (IActionResult and IFunctionResult) are part of the type definition and will be preserved.")]
+#endif
+        public static Type? TryGetResultInterface(
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+            this Type type)
         {
             foreach (var @interface in type.GetInterfaces())
             {
@@ -264,12 +275,20 @@ namespace Wasmtime
             return null;
         }
 
-        public static bool IsResultType(this Type type)
+        public static bool IsResultType(
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+            this Type type)
         {
             return type.TryGetResultInterface() != null;
         }
 
-        public static Type? GetResultInnerType(this Type type)
+        public static Type? GetResultInnerType(
+#if NET5_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+            this Type type)
         {
             var result = type.TryGetResultInterface();
             if (result == null)

--- a/src/ReturnTypeFactory.cs
+++ b/src/ReturnTypeFactory.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -13,6 +16,14 @@ namespace Wasmtime
 
     internal static class ReturnTypeFactory<TReturn>
     {
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating factory instances requires runtime code generation which is not supported with AOT compilation.")]
+        [RequiresUnreferencedCode("Creating factory instances requires reflection which may break with trimming.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2055:MakeGenericType",
+            Justification = "The generic types are constrained by the function signature and will be available at runtime.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:DynamicallyAccessedMembers",
+            Justification = "The factory types have parameterless constructors by design.")]
+#endif
         public static IReturnTypeFactory<TReturn> Create()
         {
             // First, check if the value is a result builder
@@ -116,6 +127,10 @@ namespace Wasmtime
     {
         private readonly IReturnTypeFactory<TValue> _valueFactory;
 
+#if NET5_0_OR_GREATER
+        [RequiresUnreferencedCode("Calls Wasmtime.ReturnTypeFactory<TReturn>.Create()")]
+        [RequiresDynamicCode("Calls Wasmtime.ReturnTypeFactory<TReturn>.Create()")]
+#endif
         public FunctionResultFactory()
         {
             _valueFactory = ReturnTypeFactory<TValue>.Create();
@@ -141,6 +156,10 @@ namespace Wasmtime
     {
         private readonly IValueRawConverter<TReturn> converter;
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "NonTupleTypeFactory is instantiated through reflection-based code paths that are already marked with RequiresDynamicCode.")]
+#endif
         public NonTupleTypeFactory()
         {
             converter = ValueRaw.Converter<TReturn>();
@@ -163,6 +182,11 @@ namespace Wasmtime
     {
         protected TFunc Factory { get; }
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:MakeGenericMethod",
+            Justification = "The ValueTuple.Create method is available for all tuple arities used.")]
+        [RequiresDynamicCode("Calls System.Reflection.MethodInfo.MakeGenericMethod(params Type[])")]
+#endif
         protected BaseTupleFactory()
         {
             // Get all the generic arguments of TFunc. All of the Parameters, followed by the return type
@@ -193,6 +217,10 @@ namespace Wasmtime
         private readonly IValueRawConverter<TA> converterA;
         private readonly IValueRawConverter<TB> converterB;
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "Tuple factories are only instantiated through reflection which is already marked with RequiresDynamicCode.")]
+#endif
         public TupleFactory2()
         {
             converterA = ValueRaw.Converter<TA>();
@@ -220,6 +248,10 @@ namespace Wasmtime
         private readonly IValueRawConverter<TB> converterB;
         private readonly IValueRawConverter<TC> converterC;
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "Tuple factories are only instantiated through reflection which is already marked with RequiresDynamicCode.")]
+#endif
         public TupleFactory3()
         {
             converterA = ValueRaw.Converter<TA>();
@@ -250,6 +282,10 @@ namespace Wasmtime
         private readonly IValueRawConverter<TC> converterC;
         private readonly IValueRawConverter<TD> converterD;
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "Tuple factories are only instantiated through reflection which is already marked with RequiresDynamicCode.")]
+#endif
         public TupleFactory4()
         {
             converterA = ValueRaw.Converter<TA>();
@@ -283,6 +319,10 @@ namespace Wasmtime
         private readonly IValueRawConverter<TD> converterD;
         private readonly IValueRawConverter<TE> converterE;
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "Tuple factories are only instantiated through reflection which is already marked with RequiresDynamicCode.")]
+#endif
         public TupleFactory5()
         {
             converterA = ValueRaw.Converter<TA>();
@@ -319,6 +359,10 @@ namespace Wasmtime
         private readonly IValueRawConverter<TE> converterE;
         private readonly IValueRawConverter<TF> converterF;
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "Tuple factories are only instantiated through reflection which is already marked with RequiresDynamicCode.")]
+#endif
         public TupleFactory6()
         {
             converterA = ValueRaw.Converter<TA>();
@@ -358,6 +402,10 @@ namespace Wasmtime
         private readonly IValueRawConverter<TF> converterF;
         private readonly IValueRawConverter<TG> converterG;
 
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "Tuple factories are only instantiated through reflection which is already marked with RequiresDynamicCode.")]
+#endif
         public TupleFactory7()
         {
             converterA = ValueRaw.Converter<TA>();

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -217,7 +217,7 @@ namespace Wasmtime
     {
         public void Release(Store store)
         {
-            Native.wasmtime_val_unroot(store.Context.handle, this);
+            Native.wasmtime_val_unroot(this);
             GC.KeepAlive(store);
         }
 
@@ -470,7 +470,7 @@ namespace Wasmtime
             public delegate void Finalizer(IntPtr data);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_val_unroot(IntPtr context, in Value val);
+            public static extern void wasmtime_val_unroot(in Value val);
 
             [DllImport(Engine.LibraryName)]
             [return: MarshalAs(UnmanagedType.I1)]
@@ -480,7 +480,7 @@ namespace Wasmtime
             public static extern IntPtr wasmtime_externref_data(IntPtr context, in ExternRef externref);
 
             [DllImport(Engine.LibraryName)]
-            public static extern void wasmtime_externref_unroot(IntPtr context, in ExternRef externref);
+            public static extern void wasmtime_externref_unroot(in ExternRef externref);
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_externref_from_raw(IntPtr context, uint raw, out ExternRef @out);
@@ -531,6 +531,8 @@ namespace Wasmtime
         private uint __private1;
 
         private uint __private2;
+
+        private IntPtr __private3;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -541,5 +543,7 @@ namespace Wasmtime
         private uint __private1;
 
         private uint __private2;
+
+        private IntPtr __private3;
     }
 }

--- a/src/ValueRaw.cs
+++ b/src/ValueRaw.cs
@@ -281,7 +281,7 @@ namespace Wasmtime
                 }
                 finally
                 {
-                    Value.Native.wasmtime_externref_unroot(storeContext.handle, externref);
+                    Value.Native.wasmtime_externref_unroot(externref);
                 }
             }
 
@@ -331,7 +331,7 @@ namespace Wasmtime
                 {
                     // We still must unroot the old externref afterwards because
                     // wasmtime_externref_to_raw doesn't transfer ownership.
-                    Value.Native.wasmtime_externref_unroot(storeContext.handle, externref);
+                    Value.Native.wasmtime_externref_unroot(externref);
                 }
             }
 

--- a/src/ValueRaw.cs
+++ b/src/ValueRaw.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
+#if NET5_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace Wasmtime
 {
@@ -31,6 +34,11 @@ namespace Wasmtime
         [FieldOffset(0)]
         public IntPtr funcref;
 
+#if NET5_0_OR_GREATER
+        [RequiresDynamicCode("Creating converter instances for tuple types requires runtime code generation which is not supported with AOT compilation.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "Tuple converters require MakeGenericType which is annotated with RequiresDynamicCode.")]
+#endif
         public static IValueRawConverter<T> Converter<T>()
         {
             // Ensure we are on a little endian system. For big endian, we would need
@@ -336,8 +344,18 @@ namespace Wasmtime
     {
         public static readonly Tuple2ValueRawConverter<T1, T2> Instance = new();
 
-        private readonly IValueRawConverter<T1> Converter1 = ValueRaw.Converter<T1>();
-        private readonly IValueRawConverter<T2> Converter2 = ValueRaw.Converter<T2>();
+        private readonly IValueRawConverter<T1> Converter1;
+        private readonly IValueRawConverter<T2> Converter2;
+
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "Tuple converters are only instantiated through reflection which is already marked with RequiresDynamicCode.")]
+#endif
+        public Tuple2ValueRawConverter()
+        {
+            Converter1 = ValueRaw.Converter<T1>();
+            Converter2 = ValueRaw.Converter<T2>();
+        }
 
         public (T1, T2) Unbox(StoreContext storeContext, Store store, in ValueRaw valueRaw)
         {
@@ -365,9 +383,20 @@ namespace Wasmtime
     {
         public static Tuple3ValueRawConverter<T1, T2, T3> Instance = new();
 
-        private readonly IValueRawConverter<T1> Converter1 = ValueRaw.Converter<T1>();
-        private readonly IValueRawConverter<T2> Converter2 = ValueRaw.Converter<T2>();
-        private readonly IValueRawConverter<T3> Converter3 = ValueRaw.Converter<T3>();
+        private readonly IValueRawConverter<T1> Converter1;
+        private readonly IValueRawConverter<T2> Converter2;
+        private readonly IValueRawConverter<T3> Converter3;
+
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "Tuple converters are only instantiated through reflection which is already marked with RequiresDynamicCode.")]
+#endif
+        public Tuple3ValueRawConverter()
+        {
+            Converter1 = ValueRaw.Converter<T1>();
+            Converter2 = ValueRaw.Converter<T2>();
+            Converter3 = ValueRaw.Converter<T3>();
+        }
 
         public (T1, T2, T3) Unbox(StoreContext storeContext, Store store, in ValueRaw valueRaw)
         {
@@ -397,10 +426,22 @@ namespace Wasmtime
     {
         public static Tuple4ValueRawConverter<T1, T2, T3, T4> Instance = new();
 
-        private readonly IValueRawConverter<T1> Converter1 = ValueRaw.Converter<T1>();
-        private readonly IValueRawConverter<T2> Converter2 = ValueRaw.Converter<T2>();
-        private readonly IValueRawConverter<T3> Converter3 = ValueRaw.Converter<T3>();
-        private readonly IValueRawConverter<T4> Converter4 = ValueRaw.Converter<T4>();
+        private readonly IValueRawConverter<T1> Converter1;
+        private readonly IValueRawConverter<T2> Converter2;
+        private readonly IValueRawConverter<T3> Converter3;
+        private readonly IValueRawConverter<T4> Converter4;
+
+#if NET5_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+            Justification = "Tuple converters are only instantiated through reflection which is already marked with RequiresDynamicCode.")]
+#endif
+        public Tuple4ValueRawConverter()
+        {
+            Converter1 = ValueRaw.Converter<T1>();
+            Converter2 = ValueRaw.Converter<T2>();
+            Converter3 = ValueRaw.Converter<T3>();
+            Converter4 = ValueRaw.Converter<T4>();
+        }
 
         public (T1, T2, T3, T4) Unbox(StoreContext storeContext, Store store, in ValueRaw valueRaw)
         {

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -45,6 +45,8 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="build\wasmtime.targets" Pack="true" PackagePath="build\" />
+    <None Include="build\wasmtime.targets" Pack="true" PackagePath="buildTransitive\" />
   </ItemGroup>
   
   <ItemGroup>
@@ -107,6 +109,7 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       <RID>linux-x64</RID>
       <FileExtension>tar.xz</FileExtension>
       <LibraryFilename>libwasmtime.so</LibraryFilename>
+      <StaticLibraryFilename>libwasmtime.a</StaticLibraryFilename>
     </Wasmtime>
 
     <Wasmtime Include="linux-aarch64">
@@ -116,6 +119,7 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       <RID>linux-arm64</RID>
       <FileExtension>tar.xz</FileExtension>
       <LibraryFilename>libwasmtime.so</LibraryFilename>
+      <StaticLibraryFilename>libwasmtime.a</StaticLibraryFilename>
     </Wasmtime>
 
     <Wasmtime Include="macos-x86_64">
@@ -125,6 +129,7 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       <RID>osx-x64</RID>
       <FileExtension>tar.xz</FileExtension>
       <LibraryFilename>libwasmtime.dylib</LibraryFilename>
+      <StaticLibraryFilename>libwasmtime.a</StaticLibraryFilename>
     </Wasmtime>
 
     <Wasmtime Include="macos-aarch64">
@@ -134,6 +139,7 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       <RID>osx-arm64</RID>
       <FileExtension>tar.xz</FileExtension>
       <LibraryFilename>libwasmtime.dylib</LibraryFilename>
+      <StaticLibraryFilename>libwasmtime.a</StaticLibraryFilename>
     </Wasmtime>
 
     <Wasmtime Include="windows-x86_64">
@@ -143,6 +149,7 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       <RID>win-x64</RID>
       <FileExtension>zip</FileExtension>
       <LibraryFilename>wasmtime.dll</LibraryFilename>
+      <StaticLibraryFilename>wasmtime.lib</StaticLibraryFilename>
     </Wasmtime>
 
     <Wasmtime Include="windows-aarch64">
@@ -152,6 +159,7 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       <RID>win-arm64</RID>
       <FileExtension>zip</FileExtension>
       <LibraryFilename>wasmtime.dll</LibraryFilename>
+      <StaticLibraryFilename>wasmtime.lib</StaticLibraryFilename>
     </Wasmtime>
   </ItemGroup>
 
@@ -183,10 +191,14 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
       <Content Include="$(BaseIntermediateOutputPath)$(ReleaseFileNameBase)-%(Wasmtime.Arch)-%(Wasmtime.OS)-c-api/lib/%(Wasmtime.LibraryFilename)">
         <PackagePath>runtimes/%(Wasmtime.RID)/native/%(Wasmtime.LibraryFilename)</PackagePath>
       </Content>
+      <Content Include="$(BaseIntermediateOutputPath)$(ReleaseFileNameBase)-%(Wasmtime.Arch)-%(Wasmtime.OS)-c-api/lib/%(Wasmtime.StaticLibraryFilename)">
+        <PackagePath>runtimes/%(Wasmtime.RID)/native/%(Wasmtime.StaticLibraryFilename)</PackagePath>
+      </Content>
     </ItemGroup>
   </Target>
 
-   <Target Name="CopyWasmtimeLibrary" BeforeTargets="BeforeBuild">
+  <Target Name="CopyWasmtimeLibrary" AfterTargets="ResolveProjectReferences"
+    Condition="'$(PublishAot)'!='true' And '$(IsPublishing)'!='true' And '$(WasmtimeStaticLink)'!='true'">
     <ItemGroup>
       <Content Condition="'%(Wasmtime.Copy)'=='true'" Include="$(BaseIntermediateOutputPath)$(ReleaseFileNameBase)-%(Wasmtime.Arch)-%(Wasmtime.OS)-c-api/lib/%(Wasmtime.LibraryFilename)">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -38,6 +38,10 @@ The .NET embedding of Wasmtime enables .NET code to instantiate WebAssembly modu
     <ContinuousIntegrationBuild Condition="'$(DevBuild)'=='false'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(DevBuild)'=='true'">
+    <DefineConstants>$(DefineConstants);WASMTIME_DEV</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />

--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -20,6 +20,7 @@
     <RepositoryUrl>https://github.com/bytecodealliance/wasmtime-dotnet</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IsAotCompatible>true</IsAotCompatible>
     <PackageReleaseNotes>Update Wasmtime to $(WasmtimeVersion).</PackageReleaseNotes>
     <Summary>A .NET API for Wasmtime, a standalone WebAssembly runtime</Summary>
     <PackageTags>webassembly, .net, wasm, wasmtime</PackageTags>

--- a/src/build/wasmtime.targets
+++ b/src/build/wasmtime.targets
@@ -1,0 +1,69 @@
+<Project>
+  <PropertyGroup>
+    <WasmtimeLibPath Condition="'$(WasmtimeLibPath)'==''">$(MSBuildThisFileDirectory)..\runtimes</WasmtimeLibPath>
+    <WasmtimeLibPath Condition="!Exists('$(WasmtimeLibPath)')">$(MSBuildThisFileDirectory)..\obj</WasmtimeLibPath>
+    <WasmtimeStaticLink Condition="'$(WasmtimeStaticLink)'==''">false</WasmtimeStaticLink>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(PublishAot)'=='true' And '$(WasmtimeStaticLink)'=='true'">
+    <DirectPInvoke Include="wasmtime" />
+
+    <NativeLibrary Include="$(WasmtimeLibPath)\wasmtime-dev-aarch64-macos-c-api\lib\libwasmtime.a"
+      Condition="'$(RuntimeIdentifier)'=='osx-arm64' And Exists('$(WasmtimeLibPath)\wasmtime-dev-aarch64-macos-c-api\lib\libwasmtime.a')" />
+    <NativeLibrary Include="$(WasmtimeLibPath)\osx-arm64\native\libwasmtime.a"
+      Condition="'$(RuntimeIdentifier)'=='osx-arm64' And Exists('$(WasmtimeLibPath)\osx-arm64\native\libwasmtime.a')" />
+
+    <NativeLibrary Include="$(WasmtimeLibPath)\wasmtime-dev-x86_64-macos-c-api\lib\libwasmtime.a"
+      Condition="'$(RuntimeIdentifier)'=='osx-x64' And Exists('$(WasmtimeLibPath)\wasmtime-dev-x86_64-macos-c-api\lib\libwasmtime.a')" />
+    <NativeLibrary Include="$(WasmtimeLibPath)\osx-x64\native\libwasmtime.a"
+      Condition="'$(RuntimeIdentifier)'=='osx-x64' And Exists('$(WasmtimeLibPath)\osx-x64\native\libwasmtime.a')" />
+
+    <NativeLibrary Include="$(WasmtimeLibPath)\wasmtime-dev-aarch64-linux-c-api\lib\libwasmtime.a"
+      Condition="'$(RuntimeIdentifier)'=='linux-arm64' And Exists('$(WasmtimeLibPath)\wasmtime-dev-aarch64-linux-c-api\lib\libwasmtime.a')" />
+    <NativeLibrary Include="$(WasmtimeLibPath)\linux-arm64\native\libwasmtime.a"
+      Condition="'$(RuntimeIdentifier)'=='linux-arm64' And Exists('$(WasmtimeLibPath)\linux-arm64\native\libwasmtime.a')" />
+
+    <NativeLibrary Include="$(WasmtimeLibPath)\wasmtime-dev-x86_64-linux-c-api\lib\libwasmtime.a"
+      Condition="'$(RuntimeIdentifier)'=='linux-x64' And Exists('$(WasmtimeLibPath)\wasmtime-dev-x86_64-linux-c-api\lib\libwasmtime.a')" />
+    <NativeLibrary Include="$(WasmtimeLibPath)\linux-x64\native\libwasmtime.a"
+      Condition="'$(RuntimeIdentifier)'=='linux-x64' And Exists('$(WasmtimeLibPath)\linux-x64\native\libwasmtime.a')" />
+
+    <NativeLibrary Include="$(WasmtimeLibPath)\wasmtime-dev-x86_64-windows-c-api\lib\wasmtime.lib"
+      Condition="'$(RuntimeIdentifier)'=='win-x64' And Exists('$(WasmtimeLibPath)\wasmtime-dev-x86_64-windows-c-api\lib\wasmtime.lib')" />
+    <NativeLibrary Include="$(WasmtimeLibPath)\win-x64\native\wasmtime.lib"
+      Condition="'$(RuntimeIdentifier)'=='win-x64' And Exists('$(WasmtimeLibPath)\win-x64\native\wasmtime.lib')" />
+
+    <NativeLibrary Include="$(WasmtimeLibPath)\wasmtime-dev-aarch64-windows-c-api\lib\wasmtime.lib"
+      Condition="'$(RuntimeIdentifier)'=='win-arm64' And Exists('$(WasmtimeLibPath)\wasmtime-dev-aarch64-windows-c-api\lib\wasmtime.lib')" />
+    <NativeLibrary Include="$(WasmtimeLibPath)\win-arm64\native\wasmtime.lib"
+      Condition="'$(RuntimeIdentifier)'=='win-arm64' And Exists('$(WasmtimeLibPath)\win-arm64\native\wasmtime.lib')" />
+  </ItemGroup>
+
+  <Target Name="RemoveWasmtimeLibrariesForBuild"
+    BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory"
+    Condition="'$(PublishAot)'=='true' And '$(WasmtimeStaticLink)'=='true'">
+    <ItemGroup>
+      <_SourceItemsToCopyToOutputDirectory
+        Remove="@(_SourceItemsToCopyToOutputDirectory->'%(Identity)')"
+        Condition="'%(Filename)%(Extension)' == 'libwasmtime.so' Or 
+                                                       '%(Filename)%(Extension)' == 'libwasmtime.dylib' Or 
+                                                       '%(Filename)%(Extension)' == 'libwasmtime.a' Or
+                                                       '%(Filename)%(Extension)' == 'wasmtime.dll' Or
+                                                       '%(Filename)%(Extension)' == 'wasmtime.lib'" />
+    </ItemGroup>
+  </Target>
+
+
+  <Target Name="RemoveWasmtimeLibrariesForPublish"
+    AfterTargets="ComputeResolvedFilesToPublishList"
+    Condition="'$(PublishAot)'=='true' And '$(WasmtimeStaticLink)'=='true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish->'%(Identity)')"
+        Condition="'%(Filename)%(Extension)' == 'libwasmtime.so' Or 
+                                        '%(Filename)%(Extension)' == 'libwasmtime.dylib' Or 
+                                        '%(Filename)%(Extension)' == 'libwasmtime.a' Or
+                                        '%(Filename)%(Extension)' == 'wasmtime.dll' Or
+                                        '%(Filename)%(Extension)' == 'wasmtime.lib'" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/buildTransitive/wasmtime.targets
+++ b/src/buildTransitive/wasmtime.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="..\build\wasmtime.targets"/>
+</Project>

--- a/tests/Wasmtime.Tests.csproj
+++ b/tests/Wasmtime.Tests.csproj
@@ -17,6 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\src\Wasmtime.csproj" />
   </ItemGroup>
 

--- a/tests/xunit.runner.json
+++ b/tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1
+}


### PR DESCRIPTION
Gives consumers of wasmtime-dotnet the ability to statically link the native libraries into their executable when publishing with AOT compilation.

I also added all the necessary attributes on the reflection codepaths. 

```csharp
using System;
using System.Diagnostics.CodeAnalysis;
using Wasmtime;

[assembly: UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Wasmtime callback wrappers work correctly with AOT")]
[assembly: UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Wasmtime callback wrappers work correctly with AOT")]

const string wat = """
(module
  ;; Import the hello function from C#
  (import "" "hello" (func $hello))
  ;; Import the add function from C#
  (import "" "add" (func $add (param i32 i32) (result i32)))
  ;; Export a run function that calls hello
  (func (export "run")
    call $hello
  )
  ;; Export a test_math function that uses add and returns a value
  (func (export "test_math") (result i32)
    ;; Call add(10, 32) and return the result (should be 42)
    i32.const 10
    i32.const 32
    call $add
  )
)
""";

Console.WriteLine("Loading WebAssembly module from embedded WAT");
using var engine = new Engine();
using var module = Module.FromText(engine, "hello", wat);
using var linker = new Linker(engine);
using var store = new Store(engine);

linker.Define(
    "",
    "hello",
    Function.FromCallback(store, () => Console.WriteLine("Hello from C#, WebAssembly!"))
);

linker.Define(
    "",
    "add",
    Function.FromCallback(store, (int a, int b) => {
        var sum = a + b;
        Console.WriteLine($"C# add function: {a} + {b} = {sum}");
        return sum;
    })
);

var instance = linker.Instantiate(store, module);
var run = instance.GetAction("run");
if (run is null)
{
    Console.WriteLine("error: run export is missing");
    return;
}
run();

var mathTest = instance.GetFunction<int>("test_math");
if (mathTest is not null)
{
    var result = mathTest();
    Console.WriteLine($"test_math returned: {result}");
}
else
{
    Console.WriteLine("warning: test_math export is missing");
}

Console.WriteLine("All tests completed successfully!");
```

produces:
```console
➜  wasmtime-dotnet git:(main) /Users/andrew/projects/wasmtime-test/bin/Release/net9.0/osx-arm64/publish/test
Loading WebAssembly module from embedded WAT
Hello from C#, WebAssembly!
C# add function: 10 + 32 = 42
test_math returned: 42
All tests completed successfully!
➜  wasmtime-dotnet git:(main) otool -L /Users/andrew/projects/wasmtime-test/bin/Release/net9.0/osx-arm64/publish/test
/Users/andrew/projects/wasmtime-test/bin/Release/net9.0/osx-arm64/publish/test:
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1356.0.0)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
        /usr/lib/swift/libswiftCore.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/swift/libswiftFoundation.dylib (compatibility version 1.0.0, current version 120.100.0)
        /usr/lib/libicucore.A.dylib (compatibility version 1.0.0, current version 76.1.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 4103.0.0)
        /System/Library/Frameworks/CryptoKit.framework/Versions/A/CryptoKit (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 4103.0.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 61901.40.47)
        /System/Library/Frameworks/GSS.framework/Versions/A/GSS (compatibility version 1.0.0, current version 1.0.0)
➜  wasmtime-dotnet git:(main)
```

My recommendation would be to drop support for .NET Standard 2.1 to take advantage of static abstract members in interfaces to avoid using things like Activator.CreateInstance -  and introduce a source generator to to remove all dependencies on reflection. But for my use-case this PR is sufficient and unblocks me. 

Resolves #293 

