### PR TITLE
Fix Windows interop and toggle dev ABI with DevBuild

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,4 +6,7 @@
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>
     <WasmtimePackageVersion Condition="'$(WasmtimePackageVersion)'==''">$(WasmtimeVersion)$(WasmtimeDotnetVersion)</WasmtimePackageVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(DevBuild)'=='true'">
+    <DefineConstants>$(DefineConstants);WASMTIME_DEV</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ $ dotnet build Wasmtime.sln
 This will download the latest development snapshot of Wasmtime for your
 platform.
 
+By default, local builds set `DevBuild=true`, which uses the dev C API artifacts
+(`wasmtime-dev-*`) and enables a `WASMTIME_DEV` build define to match the dev
+ABI (value/trap layouts). To build against the stable Wasmtime release instead,
+override the flag:
+
+```
+$ dotnet build Wasmtime.sln -p:DevBuild=false
+```
+
+If you switch between `DevBuild=true` and `DevBuild=false`, you may need to
+delete `src/obj` to force the correct C API download.
+
 ### Testing
 
 Use `dotnet` to run the unit tests:

--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -168,11 +168,11 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern unsafe bool wasmtime_caller_export_get(IntPtr caller, byte* name, UIntPtr len, out Extern item);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_caller_context(IntPtr caller);
         }
 

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -382,76 +382,76 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_config_new();
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_config_delete(IntPtr config);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_debug_info_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_epoch_interruption_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_consume_fuel_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_max_wasm_stack_set(Handle config, nuint size);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_wasm_threads_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_wasm_reference_types_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_wasm_simd_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_wasm_relaxed_simd_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_wasm_relaxed_simd_deterministic_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_wasm_bulk_memory_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_wasm_multi_value_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_wasm_multi_memory_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_wasm_memory64_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_strategy_set(Handle config, byte strategy);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_cranelift_debug_verifier_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_cranelift_nan_canonicalization_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_cranelift_opt_level_set(Handle config, byte level);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_profiler_set(Handle config, byte strategy);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_memory_reservation_set(Handle config, ulong size);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_memory_guard_size_set(Handle config, ulong size);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_config_cache_config_load(Handle config, [MarshalAs(Extensions.LPUTF8Str)] string? path);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_config_macos_use_mach_ports(Handle config, [MarshalAs(UnmanagedType.I1)] bool enable);
         }
 

--- a/src/Engine.cs
+++ b/src/Engine.cs
@@ -79,19 +79,19 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(LibraryName)]
+            [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_engine_new();
             
-            [DllImport(LibraryName)]
+            [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_engine_new_with_config(Config.Handle config);
 
-            [DllImport(LibraryName)]
+            [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_engine_delete(IntPtr engine);
 
-            [DllImport(LibraryName)]
+            [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_engine_increment_epoch(Handle engine);
             
-            [DllImport(LibraryName)]
+            [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasmtime_engine_is_pulley(Handle engine);
         }

--- a/src/Export.cs
+++ b/src/Export.cs
@@ -56,14 +56,14 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_exporttype_vec_delete(in ExportTypeArray vec);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern byte wasm_externtype_kind(IntPtr valueType);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_exporttype_type(IntPtr exportType);
         }
     }
@@ -102,7 +102,7 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern ByteArray* wasm_exporttype_name(IntPtr type);
         }
     }
@@ -139,7 +139,7 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_externtype_as_functype_const(IntPtr type);
         }
     }
@@ -174,7 +174,7 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_externtype_as_globaltype_const(IntPtr type);
         }
     }
@@ -222,7 +222,7 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_externtype_as_memorytype_const(IntPtr type);
         }
     }
@@ -267,7 +267,7 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_externtype_as_tabletype_const(IntPtr type);
         }
     }

--- a/src/Externs.cs
+++ b/src/Externs.cs
@@ -111,7 +111,7 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_extern_delete(in Extern self);
         }
     }

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -730,10 +730,13 @@ namespace Wasmtime
 
         internal static class Native
         {
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void Finalizer(IntPtr data);
 
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public unsafe delegate IntPtr WasmtimeFuncCallback(IntPtr env, IntPtr caller, Value* args, nuint nargs, Value* results, nuint nresults);
 
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public unsafe delegate IntPtr WasmtimeFuncUncheckedCallback(IntPtr env, IntPtr caller, ValueRaw* args_and_results, nuint num_args_and_results);
 
             [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -736,41 +736,41 @@ namespace Wasmtime
 
             public unsafe delegate IntPtr WasmtimeFuncUncheckedCallback(IntPtr env, IntPtr caller, ValueRaw* args_and_results, nuint num_args_and_results);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_func_new(IntPtr context, IntPtr type, WasmtimeFuncCallback callback, IntPtr env, Finalizer? finalizer, out ExternFunc func);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_func_new_unchecked(IntPtr context, IntPtr type, WasmtimeFuncUncheckedCallback callback, IntPtr env, Finalizer? finalizer, out ExternFunc func);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_func_call(IntPtr context, in ExternFunc func, Value* args, nuint nargs, Value* results, nuint nresults, out IntPtr trap);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_func_call_unchecked(IntPtr context, in ExternFunc func, ValueRaw* args_and_results, nuint args_and_results_len, out IntPtr trap);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_func_type(IntPtr context, in ExternFunc func);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern void wasmtime_func_from_raw(IntPtr context, IntPtr raw, out ExternFunc func);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_func_to_raw(IntPtr context, in ExternFunc func);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_functype_new(in ValueTypeArray parameters, in ValueTypeArray results);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern unsafe ValueTypeArray* wasm_functype_params(IntPtr type);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern unsafe ValueTypeArray* wasm_functype_results(IntPtr type);
 
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_functype_delete(IntPtr functype);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_trap_new(byte* bytes, nuint len);
         }
 

--- a/src/Global.cs
+++ b/src/Global.cs
@@ -251,28 +251,28 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_global_new(IntPtr context, TypeHandle type, in Value val, out ExternGlobal global);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_global_get(IntPtr context, in ExternGlobal global, out Value val);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_global_set(IntPtr context, in ExternGlobal global, in Value val);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_global_type(IntPtr context, in ExternGlobal global);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_globaltype_new(IntPtr valueType, Mutability mutability);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_globaltype_content(IntPtr type);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern byte wasm_globaltype_mutability(IntPtr type);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_globaltype_delete(IntPtr type);
         }
 

--- a/src/Import.cs
+++ b/src/Import.cs
@@ -68,10 +68,10 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_importtype_vec_delete(in ImportTypeArray vec);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_importtype_type(IntPtr importType);
         }
     }
@@ -124,10 +124,10 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern ByteArray* wasm_importtype_module(IntPtr type);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern ByteArray* wasm_importtype_name(IntPtr type);
         }
     }
@@ -235,7 +235,7 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_externtype_as_memorytype_const(IntPtr type);
         }
     }

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -713,14 +713,14 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern unsafe IntPtr wasmtime_instance_new(IntPtr context, Module.Handle module, Extern* imports, UIntPtr nimports, out ExternInstance instance, out IntPtr trap);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern unsafe bool wasmtime_instance_export_get(IntPtr context, in ExternInstance instance, byte* name, UIntPtr len, out Extern ext);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern unsafe bool wasmtime_instance_export_nth(IntPtr context, in ExternInstance instance, UIntPtr index, out byte* name, out UIntPtr len, out Extern ext);
         }

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -500,40 +500,40 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_linker_new(Engine.Handle engine);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_linker_delete(IntPtr linker);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_linker_allow_shadowing(Handle linker, [MarshalAs(UnmanagedType.I1)] bool allow);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_linker_define(Handle linker, IntPtr context, byte* module, nuint moduleLen, byte* name, nuint nameLen, in Extern item);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_linker_define_wasi(Handle linker);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_linker_define_instance(Handle linker, IntPtr context, byte* name, nuint len, in ExternInstance instance);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_linker_define_func(Handle linker, byte* module, nuint moduleLen, byte* name, nuint nameLen, IntPtr type, Function.Native.WasmtimeFuncCallback callback, IntPtr data, Function.Native.Finalizer? finalizer);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_linker_define_func_unchecked(Handle linker, byte* module, nuint moduleLen, byte* name, nuint nameLen, IntPtr type, Function.Native.WasmtimeFuncUncheckedCallback callback, IntPtr data, Function.Native.Finalizer? finalizer);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_linker_instantiate(Handle linker, IntPtr context, Module.Handle module, out ExternInstance instance, out IntPtr trap);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_linker_module(Handle linker, IntPtr context, byte* name, nuint len, Module.Handle module);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_linker_get_default(Handle linker, IntPtr context, byte* name, nuint len, out ExternFunc func);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static unsafe extern bool wasmtime_linker_get(Handle linker, IntPtr context, byte* module, nuint moduleLen, byte* name, nuint nameLen, out Extern func);
         }

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -45,11 +45,26 @@ namespace Wasmtime
             Is64Bit = is64Bit;
             IsShared = false;
             
-            var typeHandle = Native.wasmtime_memorytype_new((ulong)minimum, maximum is not null, (ulong)(maximum ?? 0), is64Bit, IsShared);
+            var error = Native.wasmtime_memorytype_new(
+                (ulong)minimum,
+                maximum is not null,
+                (ulong)(maximum ?? 0),
+                is64Bit,
+                IsShared,
+                Native.DefaultMemoryPageSizeLog2,
+                out var typeHandle
+            );
+            if (error != IntPtr.Zero)
+            {
+                throw WasmtimeException.FromOwnedError(error);
+            }
+            if (typeHandle == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Failed to create a WebAssembly memory type.");
+            }
             try
             {
-
-                var error = Native.wasmtime_memory_new(store.Context.handle, typeHandle, out this.memory);
+                error = Native.wasmtime_memory_new(store.Context.handle, typeHandle, out this.memory);
                 GC.KeepAlive(store);
 
                 if (error != IntPtr.Zero)
@@ -59,7 +74,10 @@ namespace Wasmtime
             }
             finally
             {
-                Native.wasm_memorytype_delete(typeHandle);
+                if (typeHandle != IntPtr.Zero)
+                {
+                    Native.wasm_memorytype_delete(typeHandle);
+                }
             }
         }
         
@@ -583,39 +601,48 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            public const byte DefaultMemoryPageSizeLog2 = 16;
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_memory_new(IntPtr context, IntPtr typeHandle, out ExternMemory memory);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern byte* wasmtime_memory_data(IntPtr context, in ExternMemory memory);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern nuint wasmtime_memory_data_size(IntPtr context, in ExternMemory memory);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern ulong wasmtime_memory_size(IntPtr context, in ExternMemory memory);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_memory_grow(IntPtr context, in ExternMemory memory, ulong delta, out ulong prev);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_memory_type(IntPtr context, in ExternMemory memory);
 
-            [DllImport(Engine.LibraryName)]
-            public static extern IntPtr wasmtime_memorytype_new(ulong min, [MarshalAs(UnmanagedType.I1)] bool max_present, ulong max, [MarshalAs(UnmanagedType.I1)] bool is_64, [MarshalAs(UnmanagedType.I1)] bool shared);
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern IntPtr wasmtime_memorytype_new(
+                ulong min,
+                [MarshalAs(UnmanagedType.I1)] bool max_present,
+                ulong max,
+                [MarshalAs(UnmanagedType.I1)] bool is_64,
+                [MarshalAs(UnmanagedType.I1)] bool shared,
+                byte page_size_log2,
+                out IntPtr ret
+            );
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern ulong wasmtime_memorytype_minimum(IntPtr type);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasmtime_memorytype_maximum(IntPtr type, out ulong max);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasmtime_memorytype_is64(IntPtr type);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_memorytype_delete(IntPtr handle);
         }
 

--- a/src/Module.cs
+++ b/src/Module.cs
@@ -20,7 +20,7 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_byte_vec_delete(in ByteArray vec);
         }
     }
@@ -413,31 +413,31 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_module_new(Engine.Handle engine, byte* bytes, UIntPtr size, out IntPtr handle);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_module_delete(IntPtr module);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_module_imports(IntPtr module, out ImportTypeArray imports);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_module_exports(IntPtr module, out ExportTypeArray exports);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern IntPtr wasmtime_wat2wasm(byte* text, nuint len, out ByteArray bytes);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern unsafe IntPtr wasmtime_module_validate(Engine.Handle engine, byte* bytes, UIntPtr size);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_module_serialize(Handle module, out ByteArray bytes);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern unsafe IntPtr wasmtime_module_deserialize(Engine.Handle engine, byte* bytes, UIntPtr size, out IntPtr handle);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_module_deserialize_file(Engine.Handle engine, [MarshalAs(Extensions.LPUTF8Str)] string path, out IntPtr handle);
         }
 

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -318,6 +318,7 @@ namespace Wasmtime
 
         private static class Native
         {
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void Finalizer(IntPtr data);
 
             [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]

--- a/src/Store.cs
+++ b/src/Store.cs
@@ -83,22 +83,22 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_context_gc(IntPtr handle);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_context_set_fuel(IntPtr handle, ulong fuel);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_context_get_fuel(IntPtr handle, out ulong fuel);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_context_set_wasi(IntPtr handle, IntPtr config);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_context_set_epoch_deadline(IntPtr handle, ulong ticksBeyondCurrent);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_context_get_data(IntPtr handle);
         }
 
@@ -320,16 +320,16 @@ namespace Wasmtime
         {
             public delegate void Finalizer(IntPtr data);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_store_new(Engine.Handle engine, IntPtr data, Finalizer? finalizer);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_store_context(Handle store);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_store_delete(IntPtr store);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_store_limiter(Handle store, long memory_size, long table_elements, long instances, long tables, long memories);
         }
 

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -256,35 +256,35 @@ namespace Wasmtime
                 public uint max;
             }
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_table_new(IntPtr context, TypeHandle type, in Value val, out ExternTable table);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasmtime_table_get(IntPtr context, in ExternTable table, ulong index, out Value val);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_table_set(IntPtr context, in ExternTable table, ulong index, in Value val);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern ulong wasmtime_table_size(IntPtr context, in ExternTable table);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_table_grow(IntPtr context, in ExternTable table, ulong delta, in Value value, out ulong prev);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_table_type(IntPtr context, in ExternTable table);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_tabletype_new(IntPtr valueType, in Limits limits);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_tabletype_element(IntPtr type);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static unsafe extern Limits* wasm_tabletype_limits(IntPtr type);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_tabletype_delete(IntPtr handle);
         }
 

--- a/src/TrapException.cs
+++ b/src/TrapException.cs
@@ -37,8 +37,112 @@ namespace Wasmtime
         Unreachable = 9,
         /// <summary>The trap was the result of interrupting execution.</summary>
         Interrupt = 10,
+#if WASMTIME_DEV
+        /// <summary>The trap was the result of running out of the configured fuel amount.</summary>
+        OutOfFuel = 11,
         /// <summary>
-        /// The trap was the result of executing a function that was `canon lift`'d, then `canonlower`'d, then called. 
+        /// The trap was the result of atomic wait operations on non-shared memory.
+        /// </summary>
+        AtomicWaitNonSharedMemory = 12,
+        /// <summary>
+        /// The trap was the result of a call to a null reference.
+        /// </summary>
+        NullReference = 13,
+        /// <summary>
+        /// The trap was the result of an attempt to access beyond the bounds of an array.
+        /// </summary>
+        ArrayOutOfBounds = 14,
+        /// <summary>
+        /// The trap was the result of an allocation that was too large to succeed.
+        /// </summary>
+        AllocationTooLarge = 15,
+        /// <summary>
+        /// The trap was the result of an attempt to cast a reference to a type that it is not an instance of.
+        /// </summary>
+        CastFailure = 16,
+        /// <summary>
+        /// The trap was the result of a component calling another component that would have violated the reentrance rules.
+        /// </summary>
+        CannotEnterComponent = 17,
+        /// <summary>
+        /// The trap was the result of an async-lifted export failing to return a valid async result.
+        /// </summary>
+        /// <remarks>
+        /// An async-lifted export failed to produce a result by calling `task.return` before returning `STATUS_DONE`
+        /// and/or after all host tasks completed.
+        /// </remarks>
+        NoAsyncResult = 18,
+        /// <summary>
+        /// The trap was the result of suspending to a tag for which there is no active handler.
+        /// </summary>
+        UnhandledTag = 19,
+        /// <summary>
+        /// The trap was the result of an attempt to resume a continuation twice.
+        /// </summary>
+        ContinuationAlreadyConsumed = 20,
+        /// <summary>
+        /// The trap was the result of a Pulley opcode executed at runtime when the opcode was disabled at compile time.
+        /// </summary>
+        DisabledOpCode = 21,
+        /// <summary>
+        /// The trap was the result of an async event loop deadlock.
+        /// </summary>
+        /// <remarks>
+        /// The async event loop cannot make further progress given that all host tasks have completed
+        /// and any/all host-owned stream/future handles have been dropped.
+        /// </remarks>
+        AsyncDeadlock = 22,
+        /// <summary>
+        /// The trap was the result of a component instance trying to call an import or intrinsic when not allowed.
+        /// </summary>
+        /// <remarks>
+        /// When the component-model feature is enabled this trap represents a scenario where a component instance
+        /// tried to call an import or intrinsic when it wasn't allowed to, e.g. from a post-return function.
+        /// </remarks>
+        CannotLeaveComponent = 23,
+        /// <summary>
+        /// The trap was the result of a synchronous task attempting to make a potentially blocking call prior to returning.
+        /// </summary>
+        CannotBlockSyncTask = 24,
+        /// <summary>
+        /// The trap was the result of a component trying to lift a char with an invalid bit pattern.
+        /// </summary>
+        InvalidChar = 25,
+        /// <summary>
+        /// Debug assertion generated for a fused adapter regarding the expected completion of a string encoding operation.
+        /// </summary>
+        DebugAssertStringEncodingFinished = 26,
+        /// <summary>
+        /// Debug assertion generated for a fused adapter regarding a string encoding operation.
+        /// </summary>
+        DebugAssertEqualCodeUnits = 27,
+        /// <summary>
+        /// Debug assertion generated for a fused adapter regarding the alignment of a pointer.
+        /// </summary>
+        DebugAssertPointerAligned = 28,
+        /// <summary>
+        /// Debug assertion generated for a fused adapter regarding the upper bits of a 64-bit value.
+        /// </summary>
+        DebugAssertUpperBitsUnset = 29,
+        /// <summary>
+        /// The trap was the result of a component trying to lift or lower a string past the end of its memory.
+        /// </summary>
+        StringOutOfBounds = 30,
+        /// <summary>
+        /// The trap was the result of a component trying to lift or lower a list past the end of its memory.
+        /// </summary>
+        ListOutOfBounds = 31,
+        /// <summary>
+        /// The trap was the result of a component using an invalid discriminant when lowering a variant value.
+        /// </summary>
+        InvalidDiscriminant = 32,
+        /// <summary>
+        /// The trap was the result of a component passing an unaligned pointer when lifting or lowering a value.
+        /// </summary>
+        UnalignedPointer = 33
+#else
+        /// <summary>
+        /// The trap was the result of executing a function that was `canon lift`'d, then `canonlower`'d, then called.
         /// </summary>
         /// <remarks>
         /// When the component model feature is enabled this trap represents a function that was `canon lift`'d,
@@ -84,6 +188,7 @@ namespace Wasmtime
         /// The trap was the result of a Pulley opcode executed at runtime when the opcode was disabled at compile time.
         /// </summary>
         DisabledOpCode = 20
+#endif
     }
 
     /// <summary>

--- a/src/TrapException.cs
+++ b/src/TrapException.cs
@@ -134,16 +134,16 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern nuint wasm_frame_func_offset(IntPtr frame);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern nuint wasm_frame_module_offset(IntPtr frame);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern unsafe ByteArray* wasmtime_frame_func_name(IntPtr frame);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern unsafe ByteArray* wasmtime_frame_module_name(IntPtr frame);
         }
     }
@@ -339,19 +339,19 @@ namespace Wasmtime
                 }
             }
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_trap_message(IntPtr trap, out ByteArray message);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_trap_trace(IntPtr trap, out FrameArray frames);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_trap_delete(IntPtr trap);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_frame_vec_delete(in FrameArray vec);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             internal static extern bool wasmtime_trap_code(IntPtr trap, out byte exitCode);
         }

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -142,10 +142,10 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasm_valtype_new(byte kind);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern byte wasm_valtype_kind(IntPtr valueType);
         }
@@ -188,10 +188,10 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_valtype_vec_delete(in ValueTypeArray vec);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasm_valtype_vec_new_uninitialized(out ValueTypeArray vec, UIntPtr len);
         }
     }
@@ -469,23 +469,23 @@ namespace Wasmtime
         {
             public delegate void Finalizer(IntPtr data);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_val_unroot(IntPtr context, in Value val);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasmtime_externref_new(IntPtr context, IntPtr data, Finalizer? finalizer, ref ExternRef @out);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasmtime_externref_data(IntPtr context, in ExternRef externref);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_externref_unroot(IntPtr context, in ExternRef externref);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_externref_from_raw(IntPtr context, uint raw, out ExternRef @out);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern uint wasmtime_externref_to_raw(IntPtr context, in ExternRef externref);
         }
 

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -467,6 +467,7 @@ namespace Wasmtime
 
         public static class Native
         {
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void Finalizer(IntPtr data);
 
             [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -212,9 +212,27 @@ namespace Wasmtime
     /// <see cref="Store"/>.
     /// </para>
     /// </remarks>
+#if WASMTIME_DEV
+    [StructLayout(LayoutKind.Explicit, Size = 32)]
+    internal struct Value
+    {
+        static Value()
+        {
+            // Ensure the struct size matches the expected wasmtime_val_t size.
+            System.Diagnostics.Debug.Assert(Marshal.SizeOf(typeof(Value)) == 32,
+                $"Value struct size mismatch: expected 32, got {Marshal.SizeOf(typeof(Value))}");
+        }
+#else
     [StructLayout(LayoutKind.Sequential)]
     internal struct Value
     {
+        static Value()
+        {
+            // Ensure the struct size matches the expected wasmtime_val_t size.
+            System.Diagnostics.Debug.Assert(Marshal.SizeOf(typeof(Value)) == 24,
+                $"Value struct size mismatch: expected 24, got {Marshal.SizeOf(typeof(Value))}");
+        }
+#endif
         public void Release(Store store)
         {
             Native.wasmtime_val_unroot(store.Context.handle, this);
@@ -491,9 +509,16 @@ namespace Wasmtime
         }
 
         public static readonly Native.Finalizer Finalizer = (p) => GCHandle.FromIntPtr(p).Free();
+#if WASMTIME_DEV
+        [FieldOffset(0)]
+        private ValueKind kind;
 
+        [FieldOffset(8)]
+        private ValueUnion of;
+#else
         private ValueKind kind;
         private ValueUnion of;
+#endif
     }
 
     [StructLayout(LayoutKind.Explicit)]
@@ -524,9 +549,40 @@ namespace Wasmtime
         public V128 v128;
     }
 
+#if WASMTIME_DEV
     [StructLayout(LayoutKind.Sequential)]
     internal struct AnyRef
     {
+        static AnyRef() => System.Diagnostics.Debug.Assert(Marshal.SizeOf(typeof(AnyRef)) == 24);
+
+        public ulong store;
+
+        private uint __private1;
+
+        private uint __private2;
+
+        private IntPtr __private3;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ExternRef
+    {
+        static ExternRef() => System.Diagnostics.Debug.Assert(Marshal.SizeOf(typeof(ExternRef)) == 24);
+
+        public ulong store;
+
+        private uint __private1;
+
+        private uint __private2;
+
+        private IntPtr __private3;
+    }
+#else
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct AnyRef
+    {
+        static AnyRef() => System.Diagnostics.Debug.Assert(Marshal.SizeOf(typeof(AnyRef)) == 16);
+
         public ulong store;
 
         private uint __private1;
@@ -537,10 +593,13 @@ namespace Wasmtime
     [StructLayout(LayoutKind.Sequential)]
     internal struct ExternRef
     {
+        static ExternRef() => System.Diagnostics.Debug.Assert(Marshal.SizeOf(typeof(ExternRef)) == 16);
+
         public ulong store;
 
         private uint __private1;
 
         private uint __private2;
     }
+#endif
 }

--- a/src/WasiConfiguration.cs
+++ b/src/WasiConfiguration.cs
@@ -487,17 +487,17 @@ namespace Wasmtime
 
         private static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern IntPtr wasi_config_new();
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasi_config_delete(IntPtr config);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public unsafe static extern bool wasi_config_set_argv(Handle config, nuint argc, byte** argv);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern unsafe bool wasi_config_set_env(
                 Handle config,
@@ -506,40 +506,40 @@ namespace Wasmtime
                 byte*[] values
             );
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasi_config_inherit_env(Handle config);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasi_config_set_stdin_file(
                 Handle config,
                 [MarshalAs(Extensions.LPUTF8Str)] string path
             );
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasi_config_inherit_stdin(Handle config);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasi_config_set_stdout_file(
                 Handle config,
                 [MarshalAs(Extensions.LPUTF8Str)] string path
             );
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasi_config_inherit_stdout(Handle config);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasi_config_set_stderr_file(
                 Handle config,
                 [MarshalAs(Extensions.LPUTF8Str)] string path
             );
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasi_config_inherit_stderr(Handle config);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasi_config_preopen_dir(
                 Handle config,

--- a/src/WasmtimeException.cs
+++ b/src/WasmtimeException.cs
@@ -82,16 +82,16 @@ namespace Wasmtime
 
         internal static class Native
         {
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_error_message(IntPtr error, out ByteArray message);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_error_wasm_trace(IntPtr error, out TrapException.Native.FrameArray frames);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             public static extern void wasmtime_error_delete(IntPtr error);
 
-            [DllImport(Engine.LibraryName)]
+            [DllImport(Engine.LibraryName, CallingConvention = CallingConvention.Cdecl)]
             [return: MarshalAs(UnmanagedType.I1)]
             public static extern bool wasmtime_error_exit_status(IntPtr error, out int exitStatus);
         }


### PR DESCRIPTION
## Summary
  - Use cdecl for wasmtime P/Invoke and native callbacks.
  - Toggle dev/stable ABI layouts and TrapCode by DevBuild.
  - Document DevBuild switch in README.

## Why
CI runs with DevBuild=true (wasmtime-dev), which requires dev ABI layouts.
This fixes test-host crashes such as `unknown wasmtime_valkind_t`.

  ## Tests
  - (CI) `dotnet test Wasmtime.sln`