### PR TITLE
Disable DevBuild by default

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <DevBuild Condition="'$(DevBuild)'==''">true</DevBuild>
+    <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
     <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">35.0.0</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>


### PR DESCRIPTION
It's very confusing when the main branch and even the release branches do not work (pass tests) without changing the DevBuild setting. It should be disabled by default, and only enabled by those wishing to work on synchronizing wasmtime-dotnet with the dev branch of Wasmtime.

Fixes #357 