### PR TITLE
Disabled DevBuild Setting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,6 @@ jobs:
   build:
     name: Test .NET embedding of Wasmtime
     runs-on: ${{ matrix.os }}
-    env:
-      DevBuild: 'false'
     strategy:
       fail-fast: false
       matrix:
@@ -45,11 +43,6 @@ jobs:
     #  workaround for actions/setup-dotnet#155
     - name: Clear package cache
       run: dotnet clean Wasmtime.sln && dotnet nuget locals all --clear
-    - name: Enable development builds for the main branch
-      if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
-      shell: bash
-      run: |
-        echo "DevBuild=true" >> $GITHUB_ENV
     - name: Restore packages
       run: dotnet restore Wasmtime.sln
     - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <DevBuild Condition="'$(DevBuild)'==''">true</DevBuild>
+    <DevBuild Condition="'$(DevBuild)'==''">false</DevBuild>
     <WasmtimeVersion Condition="'$(WasmtimeVersion)'==''">44.0.0</WasmtimeVersion>
     <WasmtimeDotnetVersion Condition="'$(WasmtimeDotnetVersion)'==''"></WasmtimeDotnetVersion>
     <WasmtimePackageVersion Condition="'$(DevBuild)'=='true'">$(WasmtimeVersion)$(WasmtimeDotnetVersion)-dev</WasmtimePackageVersion>


### PR DESCRIPTION
Disabled DevBuild, this downloads a potentially incompatible version of wasmtime and should not be enabled by default! This setting was causing CI to fail.

There were three settings for this:
 - `Directory.Build.props`
 - CI env hardcoded to false
 - CI conditionally overwriting this to true

I have set the props file to `false` and removed both of the CI options.