### PR TITLE
WASM Exceptions And Tag Import/Export

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -258,13 +258,24 @@ namespace Wasmtime
         }
 
         /// <summary>
+        /// Configures whether the WebAssembly exceptions proposal is enabled.
+        /// </summary>
+        /// <param name="enable">True to enable exceptions or false to disable.</param>
+        /// <returns>Returns the current config.</returns>
+        public Config WithExceptions(bool enable)
+        {
+            Native.wasmtime_config_wasm_exceptions_set(handle, enable);
+            return this;
+        }
+
+        /// <summary>
         /// Sets whether the WebAssembly stack switching proposal is enabled. 
         /// </summary>
         /// <param name="enable">True to enable WebAssembly stack switching support or false to disable.</param>
         /// <returns>Returns the current config.</returns>
         private Config WithStackSwitching(bool enable)
         {
-            // todo: unlikely to be compatible with wasmtime-dotnet on Windows due to threads
+            // warning: **unlikely to be ever compatible with wasmtime-dotnet on Windows due to fibers**
 
             Native.wasmtime_config_wasm_stack_switching_set(handle, enable);
             return this;
@@ -631,6 +642,9 @@ namespace Wasmtime
 
             [DllImport(Engine.LibraryName)]
             public static extern void wasmtime_config_wasm_component_model_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool value);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern void wasmtime_config_wasm_exceptions_set(Handle config, [MarshalAs(UnmanagedType.I1)] bool value);
 
             // todo: void wasmtime_config_host_memory_creator_set(wasm_config_t *, wasmtime_memory_creator_t *)
         }

--- a/src/Export.cs
+++ b/src/Export.cs
@@ -23,19 +23,20 @@ namespace Wasmtime
             }
 
             var exports = new Export[(int)this.size];
-            for (int i = 0; i < (int)this.size; ++i)
+            for (var i = 0; i < (int)this.size; ++i)
             {
                 var exportType = this.data[i];
                 var externType = Native.wasm_exporttype_type(exportType);
 
-                exports[i] = (WasmExternKind)Native.wasm_externtype_kind(externType) switch
+                var kind = (WasmExternKind)Native.wasm_externtype_kind(externType);
+                exports[i] = kind switch
                 {
                     WasmExternKind.Func   => new FunctionExport(exportType, externType),
                     WasmExternKind.Global => new GlobalExport(exportType, externType),
                     WasmExternKind.Table  => new TableExport(exportType, externType),
                     WasmExternKind.Memory => new MemoryExport(exportType, externType),
-
-                    _ => throw new NotSupportedException("Unsupported export extern type.")
+                    WasmExternKind.Tag    => new TagExport(exportType, externType),
+                    _ => throw new NotSupportedException($"Unsupported export extern type: {kind}.")
                 };
             }
 
@@ -252,6 +253,47 @@ namespace Wasmtime
         {
             [DllImport(Engine.LibraryName)]
             public static extern IntPtr wasm_externtype_as_tabletype_const(IntPtr type);
+        }
+    }
+
+    /// <summary>
+    /// Represents a tag exported from a WebAssembly module or instance.
+    /// </summary>
+    public class TagExport
+        : Export
+    {
+        /// <summary>
+        /// Parameter types of this tag
+        /// </summary>
+        public ValueKind[] Parameters { get; set; }
+
+        internal TagExport(IntPtr exportType, IntPtr externType) : base(exportType)
+        {
+            var tagType = Native.wasm_externtype_as_tagtype_const(externType);
+            if (tagType == IntPtr.Zero)
+            {
+                throw new InvalidOperationException();
+            }
+
+            var funcType = Native.wasm_tagtype_functype(tagType);
+            if (funcType == IntPtr.Zero)
+            {
+                throw new InvalidOperationException();
+            }
+
+            unsafe
+            {
+                Parameters = (*Function.Native.wasm_functype_params(funcType)).ToArray();
+            }
+        }
+
+        internal static class Native
+        {
+            [DllImport(Engine.LibraryName)]
+            public static extern IntPtr wasm_externtype_as_tagtype_const(IntPtr type);
+
+            [DllImport(Engine.LibraryName)]
+            public static extern IntPtr wasm_tagtype_functype(IntPtr tagType);
         }
     }
 }

--- a/src/Import.cs
+++ b/src/Import.cs
@@ -8,10 +8,11 @@ namespace Wasmtime
     // in the Wasmtime API soon. The difference is the order of `Module` and `Instance`.
     internal enum WasmExternKind : byte
     {
-        Func,
-        Global,
-        Table,
-        Memory,
+        Func = 0,
+        Global = 1,
+        Table = 2,
+        Memory = 3,
+        Tag = 4,
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -36,18 +37,20 @@ namespace Wasmtime
             }
 
             var imports = new Import[(int)this.size];
-            for (int i = 0; i < (int)this.size; ++i)
+            for (var i = 0; i < (int)this.size; ++i)
             {
                 var importType = this.data[i];
                 var externType = Native.wasm_importtype_type(importType);
 
-                imports[i] = (WasmExternKind)ExportTypeArray.Native.wasm_externtype_kind(externType) switch
+                var kind = (WasmExternKind)ExportTypeArray.Native.wasm_externtype_kind(externType);
+                imports[i] = kind switch
                 {
                     WasmExternKind.Func   => new FunctionImport(importType, externType),
                     WasmExternKind.Global => new GlobalImport(importType, externType),
                     WasmExternKind.Table  => new TableImport(importType, externType),
                     WasmExternKind.Memory => new MemoryImport(importType, externType),
-                    _ => throw new NotSupportedException("Unsupported import extern type.")
+                    WasmExternKind.Tag    => new TagImport(importType, externType),
+                    _ => throw new NotSupportedException($"Unsupported import extern type: {kind}.")
                 };
             }
             return imports;
@@ -77,14 +80,9 @@ namespace Wasmtime
                            : Extensions.PtrToStringUTF8((IntPtr)moduleName->data, checked((int)moduleName->size));
 
                 var name = Native.wasm_importtype_name(importType);
-                if (name is null || name->size == 0)
-                {
-                    Name = String.Empty;
-                }
-                else
-                {
-                    Name = Extensions.PtrToStringUTF8((IntPtr)name->data, checked((int)name->size));
-                }
+                Name = name is null || name->size == 0
+                     ? string.Empty
+                     : Extensions.PtrToStringUTF8((IntPtr)name->data, checked((int)name->size));
             }
         }
 
@@ -259,5 +257,38 @@ namespace Wasmtime
         /// The maximum number of elements in the table.
         /// </summary>
         public uint Maximum { get; private set; }
+    }
+
+    /// <summary>
+    /// Represents a tag imported to a WebAssembly module or instance.
+    /// </summary>
+    public class TagImport
+        : Import
+    {
+        /// <summary>
+        /// Parameter types of this tag
+        /// </summary>
+        public ValueKind[] Parameters { get; set; }
+
+        internal TagImport(IntPtr exportType, IntPtr externType)
+            : base(exportType)
+        {
+            var tagType = TagExport.Native.wasm_externtype_as_tagtype_const(externType);
+            if (tagType == IntPtr.Zero)
+            {
+                throw new InvalidOperationException();
+            }
+
+            var funcType = TagExport.Native.wasm_tagtype_functype(tagType);
+            if (funcType == IntPtr.Zero)
+            {
+                throw new InvalidOperationException();
+            }
+
+            unsafe
+            {
+                Parameters = (*Function.Native.wasm_functype_params(funcType)).ToArray();
+            }
+        }
     }
 }

--- a/tests/ExportTagsTests.cs
+++ b/tests/ExportTagsTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq;
+using Xunit;
+
+namespace Wasmtime.Tests;
+
+public class ExportTagsFixture
+    : ModuleFixture
+{
+    protected override string ModuleFileName => "ExportTags.wat";
+
+    public override Config GetEngineConfig()
+    {
+        return base.GetEngineConfig()
+                   .WithExceptions(true);
+    }
+}
+
+public sealed class ExportTagsTests
+    : IClassFixture<ExportTagsFixture>, IDisposable
+{
+    private ExportTagsFixture Fixture { get; set; }
+
+    private Store Store { get; set; }
+
+    private Linker Linker { get; set; }
+
+    public ExportTagsTests(ExportTagsFixture fixture)
+    {
+        Fixture = fixture;
+        Store = new Store(Fixture.Engine);
+        Linker = new Linker(Fixture.Engine);
+    }
+
+    public void Dispose()
+    {
+        Store.Dispose();
+        Linker.Dispose();
+    }
+
+    [Fact]
+    public void ItExportsTags()
+    {
+        Assert.Single(Fixture.Module.Exports);
+
+        var export = (TagExport)Fixture.Module.Exports.Single();
+
+        Assert.Equal("$export_tag", export.Name);
+
+        Assert.Single(export.Parameters);
+        Assert.Equal(ValueKind.Int32, export.Parameters.Single());
+    }
+
+    [Fact]
+    public void ItImportsTags()
+    {
+        Assert.Single(Fixture.Module.Imports);
+
+        var export = (TagImport)Fixture.Module.Imports.Single();
+
+        Assert.Equal("$import_tag", export.Name);
+
+        Assert.Single(export.Parameters);
+        Assert.Equal(ValueKind.Int32, export.Parameters.Single());
+    }
+}

--- a/tests/Modules/ExportTags.wat
+++ b/tests/Modules/ExportTags.wat
@@ -1,0 +1,10 @@
+﻿(module
+  ;; import a tag from the host
+  (import "test" "$import_tag" (tag $import_tag (param i32)))
+
+  ;; Define a tag
+  (tag $export_tag (param i32))
+
+  ;; export the tag
+  (export "$export_tag" (tag $export_tag))
+)


### PR DESCRIPTION
 - Added support for WASM tag types (import/export)
 - Added support for enabling WASM exceptions

This adds the ability to load modules which depend upon WASM exceptions. It does *not* add any support for catching, throwing or interacting with exceptions in any way (still working on that for a follow-up PR).

