### PR TITLE
Fixed AnyRef/ExternRef Field Size

### DIFF
--- a/src/Value.cs
+++ b/src/Value.cs
@@ -524,7 +524,7 @@ namespace Wasmtime
 
         private uint __private2;
 
-        private uint __private3;
+        private nint __private3;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -536,6 +536,6 @@ namespace Wasmtime
 
         private uint __private2;
 
-        private uint __private3;
+        private nint __private3;
     }
 }


### PR DESCRIPTION
Fixed __private3 fields for AnyRef and ExternRef to be the correct size.

Spotted by @kpreisser in review of https://github.com/bytecodealliance/wasmtime-dotnet/pull/359