### PR TITLE
General Cleanup #1

### DIFF
--- a/tests/CallExportFromImportTests.cs
+++ b/tests/CallExportFromImportTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class CallExportFromImportFixture : ModuleFixture
+    public sealed class CallExportFromImportFixture : ModuleFixture
     {
         protected override string ModuleFileName => "CallExportFromImport.wat";
     }
 
-    public class CallExportFromImportTests : IClassFixture<CallExportFromImportFixture>, IDisposable
+    public sealed class CallExportFromImportTests : IClassFixture<CallExportFromImportFixture>, IDisposable
     {
         private CallExportFromImportFixture Fixture { get; }
         private Store Store { get; }

--- a/tests/CallerTests.cs
+++ b/tests/CallerTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Wasmtime.Tests;
 
-public class CallerFixture : ModuleFixture
+public sealed class CallerFixture : ModuleFixture
 {
     protected override string ModuleFileName => "Caller.wat";
 
@@ -16,7 +16,7 @@ public class CallerFixture : ModuleFixture
     }
 }
 
-public class CallerTests : IClassFixture<CallerFixture>, IDisposable
+public sealed class CallerTests : IClassFixture<CallerFixture>, IDisposable
 {
     public Store Store { get; set; }
 

--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class ConfigTests
+    public sealed class ConfigTests
     {
         [Fact]
         public void ItSetsCompilerStrategy()

--- a/tests/EngineTests.cs
+++ b/tests/EngineTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Wasmtime.Tests;
 
-public class EngineTests
+public sealed class EngineTests
 {
     [Fact]
     public void ItCannotBeAccessedOnceDisposed()

--- a/tests/EpochInterruptionTests.cs
+++ b/tests/EpochInterruptionTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Wasmtime.Tests;
 
-public class EpochInterruptionFixture : ModuleFixture
+public sealed class EpochInterruptionFixture : ModuleFixture
 {
     protected override string ModuleFileName => "Interrupt.wat";
 
@@ -16,7 +16,7 @@ public class EpochInterruptionFixture : ModuleFixture
     }
 }
 
-public class EpochInterruptionTests : IClassFixture<EpochInterruptionFixture>, IDisposable
+public sealed class EpochInterruptionTests : IClassFixture<EpochInterruptionFixture>, IDisposable
 {
     public Store Store { get; set; }
 

--- a/tests/ErrorTests.cs
+++ b/tests/ErrorTests.cs
@@ -5,12 +5,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class ErrorFixture : ModuleFixture
+    public sealed class ErrorFixture : ModuleFixture
     {
         protected override string ModuleFileName => "Error.wat";
     }
 
-    public class ErrorTests : IClassFixture<ErrorFixture>, IDisposable
+    public sealed class ErrorTests : IClassFixture<ErrorFixture>, IDisposable
     {
         private ErrorFixture Fixture { get; set; }
 

--- a/tests/ExitErrorTests.cs
+++ b/tests/ExitErrorTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class ExitErrorTests
+    public sealed class ExitErrorTests
     {
         [Theory]
         [InlineData("ExitError.wat", 0)]

--- a/tests/ExternRefTests.cs
+++ b/tests/ExternRefTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class ExternRefFixture : ModuleFixture
+    public sealed class ExternRefFixture : ModuleFixture
     {
         protected override string ModuleFileName => "ExternRef.wat";
     }
 
-    public class ExternRefTests : IClassFixture<ExternRefFixture>, IDisposable
+    public sealed class ExternRefTests : IClassFixture<ExternRefFixture>, IDisposable
     {
         public ExternRefTests(ExternRefFixture fixture)
         {

--- a/tests/FuelConsumptionTests.cs
+++ b/tests/FuelConsumptionTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class FuelConsumptionFixture : ModuleFixture
+    public sealed class FuelConsumptionFixture : ModuleFixture
     {
         protected override string ModuleFileName => "FuelConsumption.wat";
 
@@ -15,7 +15,7 @@ namespace Wasmtime.Tests
         }
     }
 
-    public class FuelConsumptionTests : IClassFixture<FuelConsumptionFixture>, IDisposable
+    public sealed class FuelConsumptionTests : IClassFixture<FuelConsumptionFixture>, IDisposable
     {
         private Store Store { get; set; }
 

--- a/tests/FuncRefTests.cs
+++ b/tests/FuncRefTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class FuncRefFixture : ModuleFixture
+    public sealed class FuncRefFixture : ModuleFixture
     {
         protected override string ModuleFileName => "FuncRef.wat";
     }
 
-    public class FuncRefTests : IClassFixture<FuncRefFixture>, IDisposable
+    public sealed class FuncRefTests : IClassFixture<FuncRefFixture>, IDisposable
     {
         public FuncRefTests(FuncRefFixture fixture)
         {

--- a/tests/FunctionExportsTests.cs
+++ b/tests/FunctionExportsTests.cs
@@ -6,12 +6,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class FunctionExportsFixture : ModuleFixture
+    public sealed class FunctionExportsFixture : ModuleFixture
     {
         protected override string ModuleFileName => "FunctionExports.wat";
     }
 
-    public class FunctionExportsTests : IClassFixture<FunctionExportsFixture>
+    public sealed class FunctionExportsTests : IClassFixture<FunctionExportsFixture>
     {
         private Store Store { get; set; }
 

--- a/tests/FunctionImportsTests.cs
+++ b/tests/FunctionImportsTests.cs
@@ -6,12 +6,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class FunctionImportsFixture : ModuleFixture
+    public sealed class FunctionImportsFixture : ModuleFixture
     {
         protected override string ModuleFileName => "FunctionImports.wat";
     }
 
-    public class FunctionImportsTests : IClassFixture<FunctionImportsFixture>
+    public sealed class FunctionImportsTests : IClassFixture<FunctionImportsFixture>
     {
         public FunctionImportsTests(FunctionImportsFixture fixture)
         {

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -5,12 +5,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class FunctionsFixture : ModuleFixture
+    public sealed class FunctionsFixture : ModuleFixture
     {
         protected override string ModuleFileName => "Functions.wat";
     }
 
-    public class FunctionTests : IClassFixture<FunctionsFixture>, IDisposable
+    public sealed class FunctionTests : IClassFixture<FunctionsFixture>, IDisposable
     {
         const string THROW_MESSAGE = "Test error message for wasmtime dotnet unit tests.";
 
@@ -43,7 +43,7 @@ namespace Wasmtime.Tests
                         r[i] = i;
                     }
                 },
-                Array.Empty<ValueKind>(),
+                [],
                 Enumerable.Repeat(ValueKind.Int32, 15).ToArray()
             ));
 
@@ -57,7 +57,7 @@ namespace Wasmtime.Tests
                     }
                 },
                 Enumerable.Repeat(ValueKind.Int32, 15).ToArray(),
-                Array.Empty<ValueKind>()
+                []
             ));
 
             var emptyFunc = Function.FromCallback(Store, () => { });
@@ -73,17 +73,16 @@ namespace Wasmtime.Tests
                 r[5] = emptyFunc;
                 r[6] = "hello";
             },
-                Array.Empty<ValueKind>(),
-                new ValueKind[]
-                    {
-                        ValueKind.Int32,
-                        ValueKind.Int64,
-                        ValueKind.Float32,
-                        ValueKind.Float64,
-                        ValueKind.V128,
-                        ValueKind.FuncRef,
-                        ValueKind.ExternRef
-                    }
+                [],
+                [
+                    ValueKind.Int32,
+                    ValueKind.Int64,
+                    ValueKind.Float32,
+                    ValueKind.Float64,
+                    ValueKind.V128,
+                    ValueKind.FuncRef,
+                    ValueKind.ExternRef,
+                ]
             ));
 
             Linker.Define("env", "accept_all_types", Function.FromCallback(Store,
@@ -537,8 +536,8 @@ namespace Wasmtime.Tests
                         results[0] = new ValueBox(null);
                     }
                 },
-                Array.Empty<ValueKind>(),
-                new[] { ValueKind.Int32, ValueKind.Int64, ValueKind.Float32, ValueKind.Float64, ValueKind.V128, ValueKind.FuncRef, ValueKind.ExternRef }));
+                [],
+                [ ValueKind.Int32, ValueKind.Int64, ValueKind.Float32, ValueKind.Float64, ValueKind.V128, ValueKind.FuncRef, ValueKind.ExternRef ]));
 
             Linker.Define("env", "accept_all_types", Function.FromCallback(Store, (Caller caller, ReadOnlySpan<ValueBox> arguments, Span<ValueBox> results) =>
                 {
@@ -572,8 +571,9 @@ namespace Wasmtime.Tests
                     shouldThrow = () => arg6.AsInt32();
                     shouldThrow.Should().Throw<InvalidCastException>().WithMessage("Cannot convert from `ExternRef` to `Int32`");
                 },
-                new[] { ValueKind.Int32, ValueKind.Int64, ValueKind.Float32, ValueKind.Float64, ValueKind.V128, ValueKind.FuncRef, ValueKind.ExternRef },
-                Array.Empty<ValueKind>()));
+                [ ValueKind.Int32, ValueKind.Int64, ValueKind.Float32, ValueKind.Float64, ValueKind.V128, ValueKind.FuncRef, ValueKind.ExternRef ],
+                []
+            ));
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var action = instance.GetAction("get_and_pass_all_types");

--- a/tests/GlobalExportsTests.cs
+++ b/tests/GlobalExportsTests.cs
@@ -6,12 +6,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class GlobalExportsFixture : ModuleFixture
+    public sealed class GlobalExportsFixture : ModuleFixture
     {
         protected override string ModuleFileName => "GlobalExports.wat";
     }
 
-    public class GlobalExportsTests : IClassFixture<GlobalExportsFixture>, IDisposable
+    public sealed class GlobalExportsTests : IClassFixture<GlobalExportsFixture>, IDisposable
     {
         private Store Store { get; set; }
 

--- a/tests/GlobalImportBindingTests.cs
+++ b/tests/GlobalImportBindingTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class GlobalImportBindingFixture : ModuleFixture
+    public sealed class GlobalImportBindingFixture : ModuleFixture
     {
         protected override string ModuleFileName => "GlobalImportBindings.wat";
     }
 
-    public class GlobalImportBindingTests : IClassFixture<GlobalImportBindingFixture>, IDisposable
+    public sealed class GlobalImportBindingTests : IClassFixture<GlobalImportBindingFixture>, IDisposable
     {
         private GlobalImportBindingFixture Fixture { get; set; }
 

--- a/tests/GlobalImportsTests.cs
+++ b/tests/GlobalImportsTests.cs
@@ -5,12 +5,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class GlobalImportsFixture : ModuleFixture
+    public sealed class GlobalImportsFixture : ModuleFixture
     {
         protected override string ModuleFileName => "GlobalImports.wat";
     }
 
-    public class GlobalImportsTests : IClassFixture<GlobalImportsFixture>
+    public sealed class GlobalImportsTests : IClassFixture<GlobalImportsFixture>
     {
         public GlobalImportsTests(GlobalImportsFixture fixture)
         {

--- a/tests/InstanceTests.cs
+++ b/tests/InstanceTests.cs
@@ -5,13 +5,13 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class InstanceFixture
+    public sealed class InstanceFixture
         : ModuleFixture
     {
         protected override string ModuleFileName => "hello.wat";
     }
 
-    public class InstanceTests
+    public sealed class InstanceTests
         : IClassFixture<InstanceFixture>, IDisposable
     {
         private Store Store { get; set; }

--- a/tests/InvalidModuleTests.cs
+++ b/tests/InvalidModuleTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class InvalidModuleTests
+    public sealed class InvalidModuleTests
     {
         [Fact]
         public void ItThrowsWithErrorMessageForInvalidModules()

--- a/tests/LinkerFunctionsTests.cs
+++ b/tests/LinkerFunctionsTests.cs
@@ -5,12 +5,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class LinkerFunctionsFixture : ModuleFixture
+    public sealed class LinkerFunctionsFixture : ModuleFixture
     {
         protected override string ModuleFileName => "Functions.wat";
     }
 
-    public class LinkerFunctionTests : IClassFixture<LinkerFunctionsFixture>, IDisposable
+    public sealed class LinkerFunctionTests : IClassFixture<LinkerFunctionsFixture>, IDisposable
     {
         const string THROW_MESSAGE = "Test error message for wasmtime dotnet unit tests.";
 
@@ -29,7 +29,7 @@ namespace Wasmtime.Tests
             Linker.DefineFunction("env", "do_throw", () => throw new Exception(THROW_MESSAGE));
             Linker.DefineFunction("env", "check_string", (Caller caller, int address, int length) =>
             {
-                caller.GetMemory("mem").ReadString(address, length).Should().Be("Hello World");
+                caller.GetMemory("mem")!.ReadString(address, length).Should().Be("Hello World");
             });
 
             Linker.DefineFunction("env", "return_i32", GetBoundFuncIntDelegate());
@@ -43,7 +43,7 @@ namespace Wasmtime.Tests
                         r[i] = i;
                     }
                 },
-                Array.Empty<ValueKind>(),
+                [],
                 Enumerable.Repeat(ValueKind.Int32, 15).ToArray()
             );
 
@@ -57,7 +57,7 @@ namespace Wasmtime.Tests
                     }
                 },
                 Enumerable.Repeat(ValueKind.Int32, 15).ToArray(),
-                Array.Empty<ValueKind>()
+                []
             );
 
             var emptyFunc = Function.FromCallback(Store, () => { });
@@ -73,17 +73,16 @@ namespace Wasmtime.Tests
                     r[5] = emptyFunc;
                     r[6] = "hello";
                 },
-                Array.Empty<ValueKind>(),
-                new ValueKind[]
-                    {
-                        ValueKind.Int32,
-                        ValueKind.Int64,
-                        ValueKind.Float32,
-                        ValueKind.Float64,
-                        ValueKind.V128,
-                        ValueKind.FuncRef,
-                        ValueKind.ExternRef
-                    }
+                [],
+                [
+                    ValueKind.Int32,
+                    ValueKind.Int64,
+                    ValueKind.Float32,
+                    ValueKind.Float64,
+                    ValueKind.V128,
+                    ValueKind.FuncRef,
+                    ValueKind.ExternRef,
+                ]
             );
 
             Linker.DefineFunction("env", "accept_all_types",
@@ -127,14 +126,14 @@ namespace Wasmtime.Tests
         public void ItBindsImportMethodsAndCallsThemCorrectly()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var add = instance.GetFunction("add");
-            var swap = instance.GetFunction("swap");
-            var check = instance.GetFunction("check_string"); ;
-            var getInt32 = instance.GetFunction<int>("return_i32");
+            var add = instance.GetFunction("add")!;
+            var swap = instance.GetFunction("swap")!;
+            var check = instance.GetFunction("check_string")!;
+            var getInt32 = instance.GetFunction<int>("return_i32")!;
 
-            int x = (int)add.Invoke(40, 2);
+            int x = (int)add.Invoke(40, 2)!;
             x.Should().Be(42);
-            x = (int)add.Invoke(22, 5);
+            x = (int)add.Invoke(22, 5)!;
             x.Should().Be(27);
 
             x = getInt32.Invoke();
@@ -239,7 +238,7 @@ namespace Wasmtime.Tests
                         r[i] = i + 1;
                     }
                 },
-                Array.Empty<ValueKind>(),
+                [],
                 Enumerable.Repeat(ValueKind.Int32, 19).ToArray()
             );
 
@@ -306,8 +305,8 @@ namespace Wasmtime.Tests
                         results[0] = new ValueBox(null);
                     }
                 },
-                Array.Empty<ValueKind>(),
-                new[] { ValueKind.Int32, ValueKind.Int64, ValueKind.Float32, ValueKind.Float64, ValueKind.V128, ValueKind.FuncRef, ValueKind.ExternRef });
+                [],
+                [ ValueKind.Int32, ValueKind.Int64, ValueKind.Float32, ValueKind.Float64, ValueKind.V128, ValueKind.FuncRef, ValueKind.ExternRef ]);
 
             Linker.DefineFunction("env", "accept_all_types", (Caller caller, ReadOnlySpan<ValueBox> arguments, Span<ValueBox> results) =>
                 {
@@ -341,14 +340,15 @@ namespace Wasmtime.Tests
                     shouldThrow = () => arg6.AsInt32();
                     shouldThrow.Should().Throw<InvalidCastException>().WithMessage("Cannot convert from `ExternRef` to `Int32`");
                 },
-                new[] { ValueKind.Int32, ValueKind.Int64, ValueKind.Float32, ValueKind.Float64, ValueKind.V128, ValueKind.FuncRef, ValueKind.ExternRef },
-                Array.Empty<ValueKind>());
+                [ ValueKind.Int32, ValueKind.Int64, ValueKind.Float32, ValueKind.Float64, ValueKind.V128, ValueKind.FuncRef, ValueKind.ExternRef ],
+                []
+            );
 
             var instance = Linker.Instantiate(Store, Fixture.Module);
             var action = instance.GetAction("get_and_pass_all_types");
             action.Should().NotBeNull();
 
-            action.Invoke();
+            action!.Invoke();
 
             setResults = false;
             action.Should().Throw<WasmtimeException>().WithMessage("*Cannot convert from `ExternRef` to `Int32`*")

--- a/tests/Memory64AccessTests.cs
+++ b/tests/Memory64AccessTests.cs
@@ -5,12 +5,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class Memory64AccessFixture : ModuleFixture
+    public sealed class Memory64AccessFixture : ModuleFixture
     {
         protected override string ModuleFileName => "Memory64Access.wat";
     }
 
-    public class Memory64AccessTests : IClassFixture<Memory64AccessFixture>, IDisposable
+    public sealed class Memory64AccessTests : IClassFixture<Memory64AccessFixture>, IDisposable
     {
         private Memory64AccessFixture Fixture { get; set; }
 

--- a/tests/MemoryAccessTests.cs
+++ b/tests/MemoryAccessTests.cs
@@ -5,12 +5,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class MemoryAccessFixture : ModuleFixture
+    public sealed class MemoryAccessFixture : ModuleFixture
     {
         protected override string ModuleFileName => "MemoryAccess.wat";
     }
 
-    public class MemoryAccessTests : IClassFixture<MemoryAccessFixture>, IDisposable
+    public sealed class MemoryAccessTests : IClassFixture<MemoryAccessFixture>, IDisposable
     {
         private MemoryAccessFixture Fixture { get; set; }
 

--- a/tests/MemoryExportsTests.cs
+++ b/tests/MemoryExportsTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using FluentAssertions;
 using Xunit;
 

--- a/tests/MemoryImportBindingTests.cs
+++ b/tests/MemoryImportBindingTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class MemoryImportBindingFixture : ModuleFixture
+    public sealed class MemoryImportBindingFixture : ModuleFixture
     {
         protected override string ModuleFileName => "MemoryImportBinding.wat";
     }
 
-    public class MemoryImportBindingTests : IClassFixture<MemoryImportBindingFixture>, IDisposable
+    public sealed class MemoryImportBindingTests : IClassFixture<MemoryImportBindingFixture>, IDisposable
     {
         private MemoryImportBindingFixture Fixture { get; set; }
 

--- a/tests/MemoryImportFromModuleTests.cs
+++ b/tests/MemoryImportFromModuleTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class MemoryImportFromModuleFixture : ModuleFixture
+    public sealed class MemoryImportFromModuleFixture : ModuleFixture
     {
         protected override string ModuleFileName => "MemoryImportFromModule.wat";
     }
 
-    public class MemoryImportFromModuleTests : IClassFixture<MemoryImportFromModuleFixture>
+    public sealed class MemoryImportFromModuleTests : IClassFixture<MemoryImportFromModuleFixture>
     {
         public MemoryImportFromModuleTests(MemoryImportFromModuleFixture fixture)
         {

--- a/tests/MemoryImportNoUpperBoundTests.cs
+++ b/tests/MemoryImportNoUpperBoundTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class MemoryImportNoUpperBoundFixture : ModuleFixture
+    public sealed class MemoryImportNoUpperBoundFixture : ModuleFixture
     {
         protected override string ModuleFileName => "MemoryImportNoUpperBound.wat";
     }
 
-    public class MemoryImportNoUpperBoundTests : IClassFixture<MemoryImportNoUpperBoundFixture>
+    public sealed class MemoryImportNoUpperBoundTests : IClassFixture<MemoryImportNoUpperBoundFixture>
     {
         public MemoryImportNoUpperBoundTests(MemoryImportNoUpperBoundFixture fixture)
         {

--- a/tests/MemoryImportWithUpperBoundTests.cs
+++ b/tests/MemoryImportWithUpperBoundTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class MemoryImportWithUpperBoundFixture : ModuleFixture
+    public sealed class MemoryImportWithUpperBoundFixture : ModuleFixture
     {
         protected override string ModuleFileName => "MemoryImportWithUpperBound.wat";
     }
 
-    public class MemoryImportWithUpperBoundTests : IClassFixture<MemoryImportWithUpperBoundFixture>
+    public sealed class MemoryImportWithUpperBoundTests : IClassFixture<MemoryImportWithUpperBoundFixture>
     {
         public MemoryImportWithUpperBoundTests(MemoryImportWithUpperBoundFixture fixture)
         {

--- a/tests/ModuleFixture.cs
+++ b/tests/ModuleFixture.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using Wasmtime;
 
 namespace Wasmtime.Tests
 {

--- a/tests/ModuleLoadTests.cs
+++ b/tests/ModuleLoadTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class ModuleLoadTests
+    public sealed class ModuleLoadTests
     {
         [Fact]
         public void ItLoadsModuleFromEmbeddedResource()

--- a/tests/ModuleSerializationTests.cs
+++ b/tests/ModuleSerializationTests.cs
@@ -1,11 +1,10 @@
-using System;
 using System.IO;
 using FluentAssertions;
 using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class ModuleSerializationTests
+    public sealed class ModuleSerializationTests
     {
         [Fact]
         public void ItSerializesAndDeserializesAModule()

--- a/tests/MultiMemoryTests.cs
+++ b/tests/MultiMemoryTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class MultiMemoryTests
+    public sealed class MultiMemoryTests
     {
         [Fact]
         public void ItFailsWithMultiMemoryDisabled()

--- a/tests/StoreDataTests.cs
+++ b/tests/StoreDataTests.cs
@@ -1,18 +1,15 @@
 using System;
-using System.Diagnostics.Metrics;
-using System.Linq;
 using FluentAssertions;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class StoreDataFixture : ModuleFixture
+    public sealed class StoreDataFixture : ModuleFixture
     {
         protected override string ModuleFileName => "hello.wat";
     }
 
-    public class StoreDataTests : IClassFixture<StoreDataFixture>, IDisposable
+    public sealed class StoreDataTests : IClassFixture<StoreDataFixture>, IDisposable
     {
         private StoreDataFixture Fixture { get; }
 

--- a/tests/StoreFixture.cs
+++ b/tests/StoreFixture.cs
@@ -1,6 +1,4 @@
 using System;
-using System.IO;
-using Wasmtime;
 
 namespace Wasmtime.Tests
 {

--- a/tests/StoreTests.cs
+++ b/tests/StoreTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class StoreTests
+    public sealed class StoreTests
         : StoreFixture
     {
         [Fact]

--- a/tests/TableExportsTests.cs
+++ b/tests/TableExportsTests.cs
@@ -6,12 +6,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class TableExportsFixture : ModuleFixture
+    public sealed class TableExportsFixture : ModuleFixture
     {
         protected override string ModuleFileName => "TableExports.wat";
     }
 
-    public class TableExportsTests : IClassFixture<TableExportsFixture>, IDisposable
+    public sealed class TableExportsTests : IClassFixture<TableExportsFixture>, IDisposable
     {
         private TableExportsFixture Fixture { get; set; }
 

--- a/tests/TableImportBindingTests.cs
+++ b/tests/TableImportBindingTests.cs
@@ -4,12 +4,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class TableImportBindingFixture : ModuleFixture
+    public sealed class TableImportBindingFixture : ModuleFixture
     {
         protected override string ModuleFileName => "TableImportBinding.wat";
     }
 
-    public class TableImportBindingTests : IClassFixture<TableImportBindingFixture>, IDisposable
+    public sealed class TableImportBindingTests : IClassFixture<TableImportBindingFixture>, IDisposable
     {
         private TableImportBindingFixture Fixture { get; set; }
         private Store Store { get; set; }

--- a/tests/TableImportsTests.cs
+++ b/tests/TableImportsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -6,12 +5,12 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class TableImportsFixture : ModuleFixture
+    public sealed class TableImportsFixture : ModuleFixture
     {
         protected override string ModuleFileName => "TableImports.wat";
     }
 
-    public class TableImportsTests : IClassFixture<TableImportsFixture>
+    public sealed class TableImportsTests : IClassFixture<TableImportsFixture>
     {
         public TableImportsTests(TableImportsFixture fixture)
         {
@@ -24,7 +23,7 @@ namespace Wasmtime.Tests
         [MemberData(nameof(GetTableImports))]
         public void ItHasTheExpectedTableImports(string importModule, string importName, ValueKind expectedKind, uint expectedMinimum, uint expectedMaximum)
         {
-            var import = Fixture.Module.Imports.Where(f => f.ModuleName == importModule && f.Name == importName).FirstOrDefault() as TableImport;
+            var import = Fixture.Module.Imports.FirstOrDefault(f => f.ModuleName == importModule && f.Name == importName) as TableImport;
             import.Should().NotBeNull();
             import.Kind.Should().Be(expectedKind);
             import.Minimum.Should().Be(expectedMinimum);

--- a/tests/TrapTests.cs
+++ b/tests/TrapTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class TrapFixture : ModuleFixture
+    public sealed class TrapFixture : ModuleFixture
     {
         protected override string ModuleFileName => "Trap.wat";
     }
@@ -40,7 +40,7 @@ namespace Wasmtime.Tests
         }
     }
 
-    public class TrapTests : IClassFixture<TrapFixture>, IDisposable
+    public sealed class TrapTests : IClassFixture<TrapFixture>, IDisposable
     {
         private TrapFixture Fixture { get; set; }
 

--- a/tests/ValueBoxTests.cs
+++ b/tests/ValueBoxTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class ValueBoxTests
+    public sealed class ValueBoxTests
         : StoreFixture
     {
         /// <summary>
@@ -131,7 +131,7 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItConvertsByteArrayToV128()
         {
-            var b = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+            byte[] b = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ];
             var box = (ValueBox)b;
             Convert(Store, box, new V128(b));
         }
@@ -139,7 +139,7 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItConvertsByteSpanToV128()
         {
-            ReadOnlySpan<byte> b = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+            ReadOnlySpan<byte> b = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ];
             var box = (ValueBox)b;
             Convert(Store, box, new V128(b));
         }
@@ -147,7 +147,7 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItFailsToConvertLongByteArrayToV128()
         {
-            var b = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+            byte[] b = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ];
             var act = () => (ValueBox)b;
             act.Should().Throw<ArgumentException>();
         }
@@ -155,7 +155,7 @@ namespace Wasmtime.Tests
         [Fact]
         public void ItFailsToConvertLongByteSpanToV128()
         {
-            var b = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
+            byte[] b = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ];
             var act = () => new V128(b.AsSpan());
             act.Should().Throw<ArgumentException>();
         }

--- a/tests/WasiTests.cs
+++ b/tests/WasiTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Wasmtime.Tests
 {
-    public class WasiTests
+    public sealed class WasiTests
     {
         [Theory]
         [InlineData("Wasi.wat")]


### PR DESCRIPTION
Doing some spring cleaning on the test project.

 - Removed unnecessary `using` statements across project 
 - Using array expressions
 - Sealed test classes to fix `GC.SuppressFinalize` warnings in disposers