### PR TITLE
General Cleanup #2

### DIFF
--- a/src/Caller.cs
+++ b/src/Caller.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Wasmtime
 {

--- a/src/Export.cs
+++ b/src/Export.cs
@@ -28,27 +28,15 @@ namespace Wasmtime
                 var exportType = this.data[i];
                 var externType = Native.wasm_exporttype_type(exportType);
 
-                switch ((WasmExternKind)Native.wasm_externtype_kind(externType))
+                exports[i] = (WasmExternKind)Native.wasm_externtype_kind(externType) switch
                 {
-                    case WasmExternKind.Func:
-                        exports[i] = new FunctionExport(exportType, externType);
-                        break;
+                    WasmExternKind.Func   => new FunctionExport(exportType, externType),
+                    WasmExternKind.Global => new GlobalExport(exportType, externType),
+                    WasmExternKind.Table  => new TableExport(exportType, externType),
+                    WasmExternKind.Memory => new MemoryExport(exportType, externType),
 
-                    case WasmExternKind.Global:
-                        exports[i] = new GlobalExport(exportType, externType);
-                        break;
-
-                    case WasmExternKind.Table:
-                        exports[i] = new TableExport(exportType, externType);
-                        break;
-
-                    case WasmExternKind.Memory:
-                        exports[i] = new MemoryExport(exportType, externType);
-                        break;
-
-                    default:
-                        throw new NotSupportedException("Unsupported export extern type.");
-                }
+                    _ => throw new NotSupportedException("Unsupported export extern type.")
+                };
             }
 
             return exports;
@@ -78,21 +66,16 @@ namespace Wasmtime
             unsafe
             {
                 var name = Native.wasm_exporttype_name(exportType);
-                if (name->size == 0)
-                {
-                    Name = String.Empty;
-                }
-                else
-                {
-                    Name = Extensions.PtrToStringUTF8((IntPtr)name->data, checked((int)name->size));
-                }
+                Name = name->size == 0
+                     ? string.Empty
+                     : Extensions.PtrToStringUTF8((IntPtr)name->data, checked((int)name->size));
             }
         }
 
         /// <summary>
         /// The name of the export.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/Function.cs
+++ b/src/Function.cs
@@ -2,7 +2,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -78,12 +77,12 @@ namespace Wasmtime
         /// <summary>
         /// The types of the parameters of the WebAssembly function.
         /// </summary>
-        public IReadOnlyList<ValueKind> Parameters { get; private set; }
+        public IReadOnlyList<ValueKind> Parameters { get; }
 
         /// <summary>
         /// The types of the results of the WebAssembly function.
         /// </summary>
-        public IReadOnlyList<ValueKind> Results { get; private set; }
+        public IReadOnlyList<ValueKind> Results { get; }
 
         /// <summary>
         /// Determines if the underlying function reference is null.
@@ -93,7 +92,7 @@ namespace Wasmtime
         /// <summary>
         /// Represents a null function reference.
         /// </summary>
-        public static Function Null => _null;
+        public static Function Null { get; } = new();
 
         /// <summary>
         /// Check if this function has the given type signature
@@ -586,7 +585,7 @@ namespace Wasmtime
             {
                 if (parameterTypes[i] == typeof(Caller))
                 {
-                    throw new WasmtimeException($"A 'Caller' parameter must be the first parameter of the callback.");
+                    throw new WasmtimeException("A 'Caller' parameter must be the first parameter of the callback.");
                 }
 
                 if (!Value.TryGetKind(parameterTypes[i], out var kind))
@@ -608,12 +607,12 @@ namespace Wasmtime
 
             if (hasCaller && !allowCaller)
             {
-                throw new InvalidOperationException($"A 'Caller' parameter is not allowed for this callback.");
+                throw new InvalidOperationException("A 'Caller' parameter is not allowed for this callback.");
             }
 
             if (returnsTuple && !allowTuple)
             {
-                throw new InvalidOperationException($"Returning a ValueTuple is not allowed for this callback; use an overload that implicitly returns ValueTuple or an untyped callback for returning more than 4 values.");
+                throw new InvalidOperationException("Returning a ValueTuple is not allowed for this callback; use an overload that implicitly returns ValueTuple or an untyped callback for returning more than 4 values.");
             }
 
             return (parameterKinds, resultKinds);
@@ -790,7 +789,5 @@ namespace Wasmtime
         /// </remarks>
         [ThreadStatic]
         internal static Exception? CallbackErrorCause;
-
-        private static readonly Function _null = new Function();
     }
 }

--- a/src/Global.cs
+++ b/src/Global.cs
@@ -303,10 +303,7 @@ namespace Wasmtime
             /// <summary>
             /// Gets the mutability of the global.
             /// </summary>
-            public Mutability Mutability
-            {
-                get => _global.Mutability;
-            }
+            public Mutability Mutability => _global.Mutability;
 
             /// <summary>
             /// Gets the value of the global.

--- a/src/Import.cs
+++ b/src/Import.cs
@@ -41,27 +41,14 @@ namespace Wasmtime
                 var importType = this.data[i];
                 var externType = Native.wasm_importtype_type(importType);
 
-                switch ((WasmExternKind)ExportTypeArray.Native.wasm_externtype_kind(externType))
+                imports[i] = (WasmExternKind)ExportTypeArray.Native.wasm_externtype_kind(externType) switch
                 {
-                    case WasmExternKind.Func:
-                        imports[i] = new FunctionImport(importType, externType);
-                        break;
-
-                    case WasmExternKind.Global:
-                        imports[i] = new GlobalImport(importType, externType);
-                        break;
-
-                    case WasmExternKind.Table:
-                        imports[i] = new TableImport(importType, externType);
-                        break;
-
-                    case WasmExternKind.Memory:
-                        imports[i] = new MemoryImport(importType, externType);
-                        break;
-
-                    default:
-                        throw new NotSupportedException("Unsupported import extern type.");
-                }
+                    WasmExternKind.Func   => new FunctionImport(importType, externType),
+                    WasmExternKind.Global => new GlobalImport(importType, externType),
+                    WasmExternKind.Table  => new TableImport(importType, externType),
+                    WasmExternKind.Memory => new MemoryImport(importType, externType),
+                    _ => throw new NotSupportedException("Unsupported import extern type.")
+                };
             }
             return imports;
         }
@@ -85,14 +72,9 @@ namespace Wasmtime
             unsafe
             {
                 var moduleName = Native.wasm_importtype_module(importType);
-                if (moduleName->size == 0)
-                {
-                    ModuleName = String.Empty;
-                }
-                else
-                {
-                    ModuleName = Extensions.PtrToStringUTF8((IntPtr)moduleName->data, checked((int)moduleName->size));
-                }
+                ModuleName = moduleName->size == 0
+                           ? string.Empty
+                           : Extensions.PtrToStringUTF8((IntPtr)moduleName->data, checked((int)moduleName->size));
 
                 var name = Native.wasm_importtype_name(importType);
                 if (name is null || name->size == 0)
@@ -109,12 +91,12 @@ namespace Wasmtime
         /// <summary>
         /// The module name of the import.
         /// </summary>
-        public string ModuleName { get; private set; }
+        public string ModuleName { get; }
 
         /// <summary>
         /// The name of the import.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -40,8 +40,7 @@ namespace Wasmtime
                 var externs = stackalloc Extern[imports.Length];
                 for (int i = 0; i < imports.Length; ++i)
                 {
-                    var external = imports[i] as IExternal;
-                    if (external is null)
+                    if (imports[i] is not IExternal external)
                     {
                         throw new ArgumentException($"Objects of type `{imports[i].GetType()}` cannot be imported.");
                     }

--- a/src/Linker.cs
+++ b/src/Linker.cs
@@ -56,7 +56,7 @@ namespace Wasmtime
             var store = item.Store;
             if (store is null)
             {
-                throw new ArgumentException($"The item is not associated with a store.");
+                throw new ArgumentException("The item is not associated with a store.");
             }
 
             var ext = item.AsExtern();

--- a/src/Memory.cs
+++ b/src/Memory.cs
@@ -325,10 +325,7 @@ namespace Wasmtime
         /// <returns>Returns the string read from memory.</returns>
         public string ReadString(long address, int length, Encoding? encoding = null)
         {
-            if (encoding is null)
-            {
-                encoding = Encoding.UTF8;
-            }
+            encoding ??= Encoding.UTF8;
 
             return encoding.GetString(GetSpan(address, length));
         }
@@ -353,7 +350,7 @@ namespace Wasmtime
                 throw new InvalidOperationException("string is not null terminated");
             }
 
-            return Encoding.UTF8.GetString(slice.Slice(0, terminator));
+            return Encoding.UTF8.GetString(slice[..terminator]);
         }
 
         /// <summary>
@@ -370,10 +367,7 @@ namespace Wasmtime
                 throw new ArgumentOutOfRangeException(nameof(address));
             }
 
-            if (encoding is null)
-            {
-                encoding = Encoding.UTF8;
-            }
+            encoding ??= Encoding.UTF8;
 
             return encoding.GetBytes(value, GetSpan(address, (int)Math.Min(int.MaxValue, GetLength() - address)));
         }

--- a/src/Result.cs
+++ b/src/Result.cs
@@ -143,17 +143,12 @@ namespace Wasmtime
         /// <exception cref="ArgumentOutOfRangeException">Thrown if Type property contains an unknown value</exception>
         public static explicit operator T?(FunctionResult<T> value)
         {
-            switch (value.Type)
+            return value.Type switch
             {
-                case ResultType.Ok:
-                    return value._value;
-
-                case ResultType.Trap:
-                    throw value._trap!;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(value), $"Unknown Result Type property value '{value.Type}'");
-            }
+                ResultType.Ok => value._value,
+                ResultType.Trap => throw value._trap!,
+                _ => throw new ArgumentOutOfRangeException(nameof(value), $"Unknown Result Type property value '{value.Type}'")
+            };
         }
 
         /// <summary>

--- a/src/ReturnTypeFactory.cs
+++ b/src/ReturnTypeFactory.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace Wasmtime
 {
@@ -114,12 +113,7 @@ namespace Wasmtime
         where TBuilder : struct, IFunctionResultBuilder<TResult, TValue>
         where TResult : struct
     {
-        private readonly IReturnTypeFactory<TValue> _valueFactory;
-
-        public FunctionResultFactory()
-        {
-            _valueFactory = ReturnTypeFactory<TValue>.Create();
-        }
+        private readonly IReturnTypeFactory<TValue> _valueFactory = ReturnTypeFactory<TValue>.Create();
 
         public TResult Create(StoreContext storeContext, Store store, IntPtr trap, Span<ValueRaw> values)
         {
@@ -139,12 +133,7 @@ namespace Wasmtime
     internal class NonTupleTypeFactory<TReturn>
         : IReturnTypeFactory<TReturn>
     {
-        private readonly IValueRawConverter<TReturn> converter;
-
-        public NonTupleTypeFactory()
-        {
-            converter = ValueRaw.Converter<TReturn>();
-        }
+        private readonly IValueRawConverter<TReturn> converter = ValueRaw.Converter<TReturn>();
 
         public TReturn? Create(StoreContext storeContext, Store store, IntPtr trap, Span<ValueRaw> values)
         {
@@ -190,14 +179,8 @@ namespace Wasmtime
     internal class TupleFactory2<TReturn, TA, TB>
         : BaseTupleFactory<TReturn, Func<TA?, TB?, TReturn>>
     {
-        private readonly IValueRawConverter<TA> converterA;
-        private readonly IValueRawConverter<TB> converterB;
-
-        public TupleFactory2()
-        {
-            converterA = ValueRaw.Converter<TA>();
-            converterB = ValueRaw.Converter<TB>();
-        }
+        private readonly IValueRawConverter<TA> converterA = ValueRaw.Converter<TA>();
+        private readonly IValueRawConverter<TB> converterB = ValueRaw.Converter<TB>();
 
         public override TReturn Create(StoreContext storeContext, Store store, IntPtr trap, Span<ValueRaw> values)
         {
@@ -216,16 +199,9 @@ namespace Wasmtime
     internal class TupleFactory3<TReturn, TA, TB, TC>
         : BaseTupleFactory<TReturn, Func<TA?, TB?, TC?, TReturn>>
     {
-        private readonly IValueRawConverter<TA> converterA;
-        private readonly IValueRawConverter<TB> converterB;
-        private readonly IValueRawConverter<TC> converterC;
-
-        public TupleFactory3()
-        {
-            converterA = ValueRaw.Converter<TA>();
-            converterB = ValueRaw.Converter<TB>();
-            converterC = ValueRaw.Converter<TC>();
-        }
+        private readonly IValueRawConverter<TA> converterA = ValueRaw.Converter<TA>();
+        private readonly IValueRawConverter<TB> converterB = ValueRaw.Converter<TB>();
+        private readonly IValueRawConverter<TC> converterC = ValueRaw.Converter<TC>();
 
         public override TReturn Create(StoreContext storeContext, Store store, IntPtr trap, Span<ValueRaw> values)
         {
@@ -245,18 +221,10 @@ namespace Wasmtime
     internal class TupleFactory4<TReturn, TA, TB, TC, TD>
         : BaseTupleFactory<TReturn, Func<TA?, TB?, TC?, TD?, TReturn>>
     {
-        private readonly IValueRawConverter<TA> converterA;
-        private readonly IValueRawConverter<TB> converterB;
-        private readonly IValueRawConverter<TC> converterC;
-        private readonly IValueRawConverter<TD> converterD;
-
-        public TupleFactory4()
-        {
-            converterA = ValueRaw.Converter<TA>();
-            converterB = ValueRaw.Converter<TB>();
-            converterC = ValueRaw.Converter<TC>();
-            converterD = ValueRaw.Converter<TD>();
-        }
+        private readonly IValueRawConverter<TA> converterA = ValueRaw.Converter<TA>();
+        private readonly IValueRawConverter<TB> converterB = ValueRaw.Converter<TB>();
+        private readonly IValueRawConverter<TC> converterC = ValueRaw.Converter<TC>();
+        private readonly IValueRawConverter<TD> converterD = ValueRaw.Converter<TD>();
 
         public override TReturn Create(StoreContext storeContext, Store store, IntPtr trap, Span<ValueRaw> values)
         {
@@ -277,20 +245,11 @@ namespace Wasmtime
     internal class TupleFactory5<TReturn, TA, TB, TC, TD, TE>
         : BaseTupleFactory<TReturn, Func<TA?, TB?, TC?, TD?, TE?, TReturn>>
     {
-        private readonly IValueRawConverter<TA> converterA;
-        private readonly IValueRawConverter<TB> converterB;
-        private readonly IValueRawConverter<TC> converterC;
-        private readonly IValueRawConverter<TD> converterD;
-        private readonly IValueRawConverter<TE> converterE;
-
-        public TupleFactory5()
-        {
-            converterA = ValueRaw.Converter<TA>();
-            converterB = ValueRaw.Converter<TB>();
-            converterC = ValueRaw.Converter<TC>();
-            converterD = ValueRaw.Converter<TD>();
-            converterE = ValueRaw.Converter<TE>();
-        }
+        private readonly IValueRawConverter<TA> converterA = ValueRaw.Converter<TA>();
+        private readonly IValueRawConverter<TB> converterB = ValueRaw.Converter<TB>();
+        private readonly IValueRawConverter<TC> converterC = ValueRaw.Converter<TC>();
+        private readonly IValueRawConverter<TD> converterD = ValueRaw.Converter<TD>();
+        private readonly IValueRawConverter<TE> converterE = ValueRaw.Converter<TE>();
 
         public override TReturn Create(StoreContext storeContext, Store store, IntPtr trap, Span<ValueRaw> values)
         {
@@ -312,22 +271,12 @@ namespace Wasmtime
     internal class TupleFactory6<TReturn, TA, TB, TC, TD, TE, TF>
         : BaseTupleFactory<TReturn, Func<TA?, TB?, TC?, TD?, TE?, TF?, TReturn>>
     {
-        private readonly IValueRawConverter<TA> converterA;
-        private readonly IValueRawConverter<TB> converterB;
-        private readonly IValueRawConverter<TC> converterC;
-        private readonly IValueRawConverter<TD> converterD;
-        private readonly IValueRawConverter<TE> converterE;
-        private readonly IValueRawConverter<TF> converterF;
-
-        public TupleFactory6()
-        {
-            converterA = ValueRaw.Converter<TA>();
-            converterB = ValueRaw.Converter<TB>();
-            converterC = ValueRaw.Converter<TC>();
-            converterD = ValueRaw.Converter<TD>();
-            converterE = ValueRaw.Converter<TE>();
-            converterF = ValueRaw.Converter<TF>();
-        }
+        private readonly IValueRawConverter<TA> converterA = ValueRaw.Converter<TA>();
+        private readonly IValueRawConverter<TB> converterB = ValueRaw.Converter<TB>();
+        private readonly IValueRawConverter<TC> converterC = ValueRaw.Converter<TC>();
+        private readonly IValueRawConverter<TD> converterD = ValueRaw.Converter<TD>();
+        private readonly IValueRawConverter<TE> converterE = ValueRaw.Converter<TE>();
+        private readonly IValueRawConverter<TF> converterF = ValueRaw.Converter<TF>();
 
         public override TReturn Create(StoreContext storeContext, Store store, IntPtr trap, Span<ValueRaw> values)
         {
@@ -350,24 +299,13 @@ namespace Wasmtime
     internal class TupleFactory7<TReturn, TA, TB, TC, TD, TE, TF, TG>
         : BaseTupleFactory<TReturn, Func<TA?, TB?, TC?, TD?, TE?, TF?, TG?, TReturn>>
     {
-        private readonly IValueRawConverter<TA> converterA;
-        private readonly IValueRawConverter<TB> converterB;
-        private readonly IValueRawConverter<TC> converterC;
-        private readonly IValueRawConverter<TD> converterD;
-        private readonly IValueRawConverter<TE> converterE;
-        private readonly IValueRawConverter<TF> converterF;
-        private readonly IValueRawConverter<TG> converterG;
-
-        public TupleFactory7()
-        {
-            converterA = ValueRaw.Converter<TA>();
-            converterB = ValueRaw.Converter<TB>();
-            converterC = ValueRaw.Converter<TC>();
-            converterD = ValueRaw.Converter<TD>();
-            converterE = ValueRaw.Converter<TE>();
-            converterF = ValueRaw.Converter<TF>();
-            converterG = ValueRaw.Converter<TG>();
-        }
+        private readonly IValueRawConverter<TA> converterA = ValueRaw.Converter<TA>();
+        private readonly IValueRawConverter<TB> converterB = ValueRaw.Converter<TB>();
+        private readonly IValueRawConverter<TC> converterC = ValueRaw.Converter<TC>();
+        private readonly IValueRawConverter<TD> converterD = ValueRaw.Converter<TD>();
+        private readonly IValueRawConverter<TE> converterE = ValueRaw.Converter<TE>();
+        private readonly IValueRawConverter<TF> converterF = ValueRaw.Converter<TF>();
+        private readonly IValueRawConverter<TG> converterG = ValueRaw.Converter<TG>();
 
         public override TReturn Create(StoreContext storeContext, Store store, IntPtr trap, Span<ValueRaw> values)
         {

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -102,7 +102,7 @@ namespace Wasmtime
         /// Gets the value kind of the table.
         /// </summary>
         /// <value></value>
-        public TableKind Kind { get; private set; }
+        public TableKind Kind { get; }
 
         /// <summary>
         /// The minimum table element size.

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -56,7 +56,7 @@ namespace Wasmtime
 
             if (kind != TableKind.ExternRef && kind != TableKind.FuncRef)
             {
-                throw new WasmtimeException($"Table elements must be externref or funcref.");
+                throw new WasmtimeException("Table elements must be externref or funcref.");
             }
 
             if (maximum < initial)
@@ -69,9 +69,11 @@ namespace Wasmtime
             Minimum = initial;
             Maximum = maximum;
 
-            var limits = new Native.Limits();
-            limits.min = initial;
-            limits.max = maximum;
+            var limits = new Native.Limits
+            {
+                min = initial,
+                max = maximum,
+            };
 
             using var tableType = new TypeHandle(Native.wasm_tabletype_new(
                 ValueType.FromKind(kind),

--- a/src/TrapException.cs
+++ b/src/TrapException.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
 using System.Text;
 
 namespace Wasmtime

--- a/src/V128.cs
+++ b/src/V128.cs
@@ -11,7 +11,7 @@ namespace Wasmtime
         /// <summary>
         /// Get a V128 with all bits set to 1
         /// </summary>
-        public static readonly V128 AllBitsSet = new V128(
+        public static readonly V128 AllBitsSet = new(
             byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue,
             byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue,
             byte.MaxValue, byte.MaxValue, byte.MaxValue, byte.MaxValue,

--- a/src/Value.cs
+++ b/src/Value.cs
@@ -166,7 +166,7 @@ namespace Wasmtime
             }
         }
 
-        public ValueKind[] ToArray()
+        public readonly ValueKind[] ToArray()
         {
             var arr = new ValueKind[(int)size];
 
@@ -263,9 +263,11 @@ namespace Wasmtime
 
         public static Value FromValueBox(Store store, ValueBox box)
         {
-            var value = new Value();
-            value.kind = box.Kind;
-            value.of = box.Union;
+            var value = new Value
+            {
+                kind = box.Kind,
+                of = box.Union,
+            };
 
             if (value.kind == ValueKind.ExternRef)
             {
@@ -300,7 +302,7 @@ namespace Wasmtime
             return value;
         }
 
-        public ValueBox ToValueBox(Store store)
+        public readonly ValueBox ToValueBox(Store store)
         {
             if (kind != ValueKind.ExternRef)
             {
@@ -319,8 +321,10 @@ namespace Wasmtime
 
         public static Value FromObject(Store store, object? o, ValueKind kind)
         {
-            var value = new Value();
-            value.kind = kind;
+            var value = new Value
+            {
+                kind = kind,
+            };
 
             try
             {
@@ -386,19 +390,12 @@ namespace Wasmtime
                         break;
 
                     case ValueKind.FuncRef:
-                        switch (o)
+                        value.of.funcref = o switch
                         {
-                            case null:
-                                value.of.funcref = Function.Null.func;
-                                break;
-
-                            case Function f:
-                                value.of.funcref = f.func;
-                                break;
-
-                            default:
-                                throw new ArgumentException("expected a function value", nameof(o));
-                        }
+                            null       => Function.Null.func,
+                            Function f => f.func,
+                            _          => throw new ArgumentException("expected a function value", nameof(o))
+                        };
                         break;
 
                     default:
@@ -413,37 +410,22 @@ namespace Wasmtime
             return value;
         }
 
-        public object? ToObject(Store store)
+        public readonly object? ToObject(Store store)
         {
-            switch (kind)
+            return kind switch
             {
-                case ValueKind.Int32:
-                    return of.i32;
-
-                case ValueKind.Int64:
-                    return of.i64;
-
-                case ValueKind.Float32:
-                    return of.f32;
-
-                case ValueKind.Float64:
-                    return of.f64;
-
-                case ValueKind.V128:
-                    return of.v128;
-
-                case ValueKind.ExternRef:
-                    return ResolveExternRef(store);
-
-                case ValueKind.FuncRef:
-                    return store.GetCachedExtern(of.funcref);
-
-                default:
-                    throw new NotSupportedException("Unsupported value kind.");
-            }
+                ValueKind.Int32   => of.i32,
+                ValueKind.Int64   => of.i64,
+                ValueKind.Float32 => of.f32,
+                ValueKind.Float64 => of.f64,
+                ValueKind.V128    => of.v128,
+                ValueKind.ExternRef => ResolveExternRef(store),
+                ValueKind.FuncRef   => store.GetCachedExtern(of.funcref),
+                _ => throw new NotSupportedException("Unsupported value kind.")
+            };
         }
 
-        private object? ResolveExternRef(Store store)
+        private readonly object? ResolveExternRef(Store store)
         {
             if (of.externref.IsNull())
             {

--- a/src/ValueBox.cs
+++ b/src/ValueBox.cs
@@ -301,7 +301,7 @@ namespace Wasmtime
     internal class Int32ValueBoxConverter
         : IValueBoxConverter<int>
     {
-        public static readonly Int32ValueBoxConverter Instance = new Int32ValueBoxConverter();
+        public static readonly Int32ValueBoxConverter Instance = new();
 
         private Int32ValueBoxConverter()
         {
@@ -321,7 +321,7 @@ namespace Wasmtime
     internal class Int64ValueBoxConverter
         : IValueBoxConverter<long>
     {
-        public static readonly Int64ValueBoxConverter Instance = new Int64ValueBoxConverter();
+        public static readonly Int64ValueBoxConverter Instance = new();
 
         private Int64ValueBoxConverter()
         {
@@ -341,7 +341,7 @@ namespace Wasmtime
     internal class Float32ValueBoxConverter
         : IValueBoxConverter<float>
     {
-        public static readonly Float32ValueBoxConverter Instance = new Float32ValueBoxConverter();
+        public static readonly Float32ValueBoxConverter Instance = new();
 
         private Float32ValueBoxConverter()
         {
@@ -361,7 +361,7 @@ namespace Wasmtime
     internal class Float64ValueBoxConverter
         : IValueBoxConverter<double>
     {
-        public static readonly Float64ValueBoxConverter Instance = new Float64ValueBoxConverter();
+        public static readonly Float64ValueBoxConverter Instance = new();
 
         private Float64ValueBoxConverter()
         {
@@ -381,7 +381,7 @@ namespace Wasmtime
     internal class FuncRefValueBoxConverter
         : IValueBoxConverter<Function>
     {
-        public static readonly FuncRefValueBoxConverter Instance = new FuncRefValueBoxConverter();
+        public static readonly FuncRefValueBoxConverter Instance = new();
 
         private FuncRefValueBoxConverter()
         {
@@ -401,7 +401,7 @@ namespace Wasmtime
     internal class V128ValueBoxConverter
         : IValueBoxConverter<V128>
     {
-        public static readonly V128ValueBoxConverter Instance = new V128ValueBoxConverter();
+        public static readonly V128ValueBoxConverter Instance = new();
 
         private V128ValueBoxConverter()
         {
@@ -421,7 +421,7 @@ namespace Wasmtime
     internal class GenericValueBoxConverter<T>
         : IValueBoxConverter<T?>
     {
-        public static readonly GenericValueBoxConverter<T> Instance = new GenericValueBoxConverter<T>();
+        public static readonly GenericValueBoxConverter<T> Instance = new();
 
         private GenericValueBoxConverter()
         {

--- a/src/WasmtimeException.cs
+++ b/src/WasmtimeException.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
 using System.Text;
 
 namespace Wasmtime


### PR DESCRIPTION
Followup to #364, doing general cleanup of minor issues. Driven by ReSharper code quality suggestions:
 - Removed unnecessary `using`s
 - Replaced some switch statements with expressions
 - Target typed new
 - Added `readonly` to some methods on `Value`
 - Expression body properties
 - Make some properties `get` only
 - Used some pattern matching instead of traditional checks