### PR TITLE
Update Supported Dotnet Versions

### DIFF
--- a/src/Wasmtime.csproj
+++ b/src/Wasmtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
- Dropped support for dotnet9 (STS, no longer supported) 
- Added support for dotnet10 (current LTS)