### PR TITLE
Improved Test Coverage

### DIFF
--- a/src/Function.FromCallback.cs
+++ b/src/Function.FromCallback.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wasmtime
 {
@@ -19,6 +20,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback(Store store, Action callback)
         {
             if (store is null)
@@ -80,6 +82,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T>(Store store, Action<T?> callback)
         {
             if (store is null)
@@ -142,6 +145,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2>(Store store, Action<T1?, T2?> callback)
         {
             if (store is null)
@@ -206,6 +210,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3>(Store store, Action<T1?, T2?, T3?> callback)
         {
             if (store is null)
@@ -272,6 +277,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4>(Store store, Action<T1?, T2?, T3?, T4?> callback)
         {
             if (store is null)
@@ -340,6 +346,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5>(Store store, Action<T1?, T2?, T3?, T4?, T5?> callback)
         {
             if (store is null)
@@ -410,6 +417,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?> callback)
         {
             if (store is null)
@@ -482,6 +490,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
         {
             if (store is null)
@@ -556,6 +565,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
         {
             if (store is null)
@@ -632,6 +642,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
         {
             if (store is null)
@@ -710,6 +721,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
         {
             if (store is null)
@@ -790,6 +802,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
         {
             if (store is null)
@@ -872,6 +885,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Store store, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
         {
             if (store is null)
@@ -956,6 +970,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<TResult>(Store store, Func<TResult> callback)
         {
             if (store is null)
@@ -1019,6 +1034,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T, TResult>(Store store, Func<T?, TResult> callback)
         {
             if (store is null)
@@ -1083,6 +1099,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, TResult>(Store store, Func<T1?, T2?, TResult> callback)
         {
             if (store is null)
@@ -1149,6 +1166,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, TResult>(Store store, Func<T1?, T2?, T3?, TResult> callback)
         {
             if (store is null)
@@ -1217,6 +1235,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, TResult>(Store store, Func<T1?, T2?, T3?, T4?, TResult> callback)
         {
             if (store is null)
@@ -1287,6 +1306,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, TResult> callback)
         {
             if (store is null)
@@ -1359,6 +1379,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
         {
             if (store is null)
@@ -1433,6 +1454,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
         {
             if (store is null)
@@ -1509,6 +1531,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
         {
             if (store is null)
@@ -1587,6 +1610,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
         {
             if (store is null)
@@ -1667,6 +1691,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
         {
             if (store is null)
@@ -1749,6 +1774,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
         {
             if (store is null)
@@ -1833,6 +1859,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
         {
             if (store is null)
@@ -1919,6 +1946,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<TResult1, TResult2>(Store store, Func<ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -1984,6 +2012,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T, TResult1, TResult2>(Store store, Func<T?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2050,6 +2079,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, TResult1, TResult2>(Store store, Func<T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2118,6 +2148,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2188,6 +2219,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2260,6 +2292,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2334,6 +2367,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2410,6 +2444,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2488,6 +2523,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2568,6 +2604,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2650,6 +2687,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2734,6 +2772,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2820,6 +2859,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -2908,6 +2948,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<TResult1, TResult2, TResult3>(Store store, Func<ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -2975,6 +3016,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T, TResult1, TResult2, TResult3>(Store store, Func<T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3043,6 +3085,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3113,6 +3156,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3185,6 +3229,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3259,6 +3304,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3335,6 +3381,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3413,6 +3460,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3493,6 +3541,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3575,6 +3624,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3659,6 +3709,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3745,6 +3796,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3833,6 +3885,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -3923,6 +3976,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<TResult1, TResult2, TResult3, TResult4>(Store store, Func<ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -3992,6 +4046,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4062,6 +4117,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4134,6 +4190,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4208,6 +4265,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4284,6 +4342,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4362,6 +4421,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4442,6 +4502,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4524,6 +4585,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4608,6 +4670,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4694,6 +4757,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4782,6 +4846,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4872,6 +4937,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(Store store, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -4964,6 +5030,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback(Store store, CallerAction callback)
         {
             if (store is null)
@@ -5028,6 +5095,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T>(Store store, CallerAction<T?> callback)
         {
             if (store is null)
@@ -5094,6 +5162,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2>(Store store, CallerAction<T1?, T2?> callback)
         {
             if (store is null)
@@ -5162,6 +5231,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3>(Store store, CallerAction<T1?, T2?, T3?> callback)
         {
             if (store is null)
@@ -5232,6 +5302,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4>(Store store, CallerAction<T1?, T2?, T3?, T4?> callback)
         {
             if (store is null)
@@ -5304,6 +5375,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?> callback)
         {
             if (store is null)
@@ -5378,6 +5450,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?> callback)
         {
             if (store is null)
@@ -5454,6 +5527,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
         {
             if (store is null)
@@ -5532,6 +5606,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
         {
             if (store is null)
@@ -5612,6 +5687,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
         {
             if (store is null)
@@ -5694,6 +5770,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
         {
             if (store is null)
@@ -5778,6 +5855,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
         {
             if (store is null)
@@ -5864,6 +5942,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Store store, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
         {
             if (store is null)
@@ -5952,6 +6031,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<TResult>(Store store, CallerFunc<TResult> callback)
         {
             if (store is null)
@@ -6018,6 +6098,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T, TResult>(Store store, CallerFunc<T?, TResult> callback)
         {
             if (store is null)
@@ -6086,6 +6167,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, TResult>(Store store, CallerFunc<T1?, T2?, TResult> callback)
         {
             if (store is null)
@@ -6156,6 +6238,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, TResult>(Store store, CallerFunc<T1?, T2?, T3?, TResult> callback)
         {
             if (store is null)
@@ -6228,6 +6311,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, TResult> callback)
         {
             if (store is null)
@@ -6302,6 +6386,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, TResult> callback)
         {
             if (store is null)
@@ -6378,6 +6463,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
         {
             if (store is null)
@@ -6456,6 +6542,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
         {
             if (store is null)
@@ -6536,6 +6623,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
         {
             if (store is null)
@@ -6618,6 +6706,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
         {
             if (store is null)
@@ -6702,6 +6791,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
         {
             if (store is null)
@@ -6788,6 +6878,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
         {
             if (store is null)
@@ -6876,6 +6967,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
         {
             if (store is null)
@@ -6966,6 +7058,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<TResult1, TResult2>(Store store, CallerFunc<ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7034,6 +7127,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T, TResult1, TResult2>(Store store, CallerFunc<T?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7104,6 +7198,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7176,6 +7271,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7250,6 +7346,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7326,6 +7423,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7404,6 +7502,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7484,6 +7583,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7566,6 +7666,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7650,6 +7751,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7736,6 +7838,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7824,6 +7927,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -7914,6 +8018,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (store is null)
@@ -8006,6 +8111,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<TResult1, TResult2, TResult3>(Store store, CallerFunc<ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8076,6 +8182,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T, TResult1, TResult2, TResult3>(Store store, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8148,6 +8255,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8222,6 +8330,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8298,6 +8407,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8376,6 +8486,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8456,6 +8567,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8538,6 +8650,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8622,6 +8735,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8708,6 +8822,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8796,6 +8911,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8886,6 +9002,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -8978,6 +9095,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (store is null)
@@ -9072,6 +9190,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9144,6 +9263,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9218,6 +9338,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9294,6 +9415,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9372,6 +9494,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9452,6 +9575,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9534,6 +9658,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9618,6 +9743,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9704,6 +9830,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9792,6 +9919,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9882,6 +10010,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -9974,6 +10103,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)
@@ -10068,6 +10198,7 @@ namespace Wasmtime
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(Store store, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (store is null)

--- a/src/Function.FromCallback.tt
+++ b/src/Function.FromCallback.tt
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wasmtime
 {
@@ -41,6 +42,7 @@ foreach (var (hasCaller, resultCount, parameterCount, methodGenerics, delegateTy
         /// </summary>
         /// <param name="store">The store to create the function in.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public static Function FromCallback<#= methodGenerics #>(Store store, <#= delegateType #> callback)
         {
             if (store is null)

--- a/src/Function.Wrap.cs
+++ b/src/Function.Wrap.cs
@@ -7,6 +7,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wasmtime
 {
@@ -18,6 +19,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action? WrapAction()
         {
             if (store is null || IsNull)
@@ -64,6 +66,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T>? WrapAction<T>()
         {
             if (store is null || IsNull)
@@ -112,6 +115,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2>? WrapAction<T1, T2>()
         {
             if (store is null || IsNull)
@@ -162,6 +166,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3>? WrapAction<T1, T2, T3>()
         {
             if (store is null || IsNull)
@@ -214,6 +219,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4>? WrapAction<T1, T2, T3, T4>()
         {
             if (store is null || IsNull)
@@ -268,6 +274,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5>? WrapAction<T1, T2, T3, T4, T5>()
         {
             if (store is null || IsNull)
@@ -324,6 +331,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6>? WrapAction<T1, T2, T3, T4, T5, T6>()
         {
             if (store is null || IsNull)
@@ -382,6 +390,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6, T7>? WrapAction<T1, T2, T3, T4, T5, T6, T7>()
         {
             if (store is null || IsNull)
@@ -442,6 +451,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6, T7, T8>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8>()
         {
             if (store is null || IsNull)
@@ -504,6 +514,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9>()
         {
             if (store is null || IsNull)
@@ -568,6 +579,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>()
         {
             if (store is null || IsNull)
@@ -634,6 +646,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>()
         {
             if (store is null || IsNull)
@@ -702,6 +715,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>()
         {
             if (store is null || IsNull)
@@ -772,6 +786,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>()
         {
             if (store is null || IsNull)
@@ -844,6 +859,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>()
         {
             if (store is null || IsNull)
@@ -918,6 +934,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>()
         {
             if (store is null || IsNull)
@@ -994,6 +1011,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as an <c>Action</c>. Wrapped <c>Action</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Action</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>? WrapAction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>()
         {
             if (store is null || IsNull)
@@ -1072,6 +1090,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TResult?>? WrapFunc<TResult>()
         {
             if (store is null || IsNull)
@@ -1121,6 +1140,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T, TResult?>? WrapFunc<T, TResult>()
         {
             if (store is null || IsNull)
@@ -1172,6 +1192,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, TResult?>? WrapFunc<T1, T2, TResult>()
         {
             if (store is null || IsNull)
@@ -1225,6 +1246,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, TResult?>? WrapFunc<T1, T2, T3, TResult>()
         {
             if (store is null || IsNull)
@@ -1280,6 +1302,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, TResult?>? WrapFunc<T1, T2, T3, T4, TResult>()
         {
             if (store is null || IsNull)
@@ -1337,6 +1360,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, TResult?>? WrapFunc<T1, T2, T3, T4, T5, TResult>()
         {
             if (store is null || IsNull)
@@ -1396,6 +1420,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, TResult>()
         {
             if (store is null || IsNull)
@@ -1457,6 +1482,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, T7, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, TResult>()
         {
             if (store is null || IsNull)
@@ -1520,6 +1546,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, TResult>()
         {
             if (store is null || IsNull)
@@ -1585,6 +1612,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>()
         {
             if (store is null || IsNull)
@@ -1652,6 +1680,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>()
         {
             if (store is null || IsNull)
@@ -1721,6 +1750,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>()
         {
             if (store is null || IsNull)
@@ -1792,6 +1822,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>()
         {
             if (store is null || IsNull)
@@ -1865,6 +1896,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>()
         {
             if (store is null || IsNull)
@@ -1940,6 +1972,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>()
         {
             if (store is null || IsNull)
@@ -2017,6 +2050,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>()
         {
             if (store is null || IsNull)
@@ -2096,6 +2130,7 @@ namespace Wasmtime
         /// Attempt to wrap this function as a <c>Func</c>. Wrapped <c>Func</c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c>Func</c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult?>? WrapFunc<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>()
         {
             if (store is null || IsNull)

--- a/src/Function.Wrap.tt
+++ b/src/Function.Wrap.tt
@@ -18,6 +18,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wasmtime
 {
@@ -39,6 +40,7 @@ foreach (var (_, returnTypeCount, parameterCount, methodGenerics, delegateType, 
         /// Attempt to wrap this function as <#= returnTypeCount > 0 ? "a <c>Func</c>" : "an <c>Action</c>" #>. Wrapped <c><#= returnTypeCount > 0 ? "Func" : "Action" #></c> is faster than a normal Invoke call.
         /// </summary>
         /// <returns>A <c><#= returnTypeCount > 0 ? "Func" : "Action" #></c> to invoke this function, or <c>null</c> if the type signature is incompatible.</returns>
+        [ExcludeFromCodeCoverage]
         public <#= delegateType #>? Wrap<#= returnTypeCount > 0 ? "Func" : "Action" #><#= methodGenerics #>()
         {
             if (store is null || IsNull)

--- a/src/Instance.cs
+++ b/src/Instance.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -108,6 +109,7 @@ namespace Wasmtime
         /// <typeparam name="TB">Second parameter type</typeparam>
         /// <typeparam name="TC">Third parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<TA, TB, TC>? GetAction<TA, TB, TC>(string name)
         {
             return GetFunction(name)
@@ -123,6 +125,7 @@ namespace Wasmtime
         /// <typeparam name="TC">Third parameter type</typeparam>
         /// <typeparam name="TD">Fourth parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<TA, TB, TC, TD>? GetAction<TA, TB, TC, TD>(string name)
         {
             return GetFunction(name)
@@ -139,6 +142,7 @@ namespace Wasmtime
         /// <typeparam name="TD">Fourth parameter type</typeparam>
         /// <typeparam name="TE">Fifth parameter type</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Action<TA, TB, TC, TD, TE>? GetAction<TA, TB, TC, TD, TE>(string name)
         {
             return GetFunction(name)
@@ -209,6 +213,7 @@ namespace Wasmtime
         /// <typeparam name="TD">Fourth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TR?>? GetFunction<TA, TB, TC, TD, TR>(string name)
         {
             return GetFunction(name)
@@ -226,6 +231,7 @@ namespace Wasmtime
         /// <typeparam name="TE">Fifth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TR?>? GetFunction<TA, TB, TC, TD, TE, TR>(string name)
         {
             return GetFunction(name)
@@ -244,6 +250,7 @@ namespace Wasmtime
         /// <typeparam name="TF">Sixth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TR>(string name)
         {
             return GetFunction(name)
@@ -263,6 +270,7 @@ namespace Wasmtime
         /// <typeparam name="TG">Seventh parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TG, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TR>(string name)
         {
             return GetFunction(name)
@@ -283,6 +291,7 @@ namespace Wasmtime
         /// <typeparam name="TH">Eighth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TR>(string name)
         {
             return GetFunction(name)
@@ -304,6 +313,7 @@ namespace Wasmtime
         /// <typeparam name="TI">Ninth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TR>(string name)
         {
             return GetFunction(name)
@@ -326,6 +336,7 @@ namespace Wasmtime
         /// <typeparam name="TJ">Tenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TR>(string name)
         {
             return GetFunction(name)
@@ -349,6 +360,7 @@ namespace Wasmtime
         /// <typeparam name="TK">Eleventh parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TR>(string name)
         {
             return GetFunction(name)
@@ -373,6 +385,7 @@ namespace Wasmtime
         /// <typeparam name="TL">Twelfth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TR>(string name)
         {
             return GetFunction(name)
@@ -398,6 +411,7 @@ namespace Wasmtime
         /// <typeparam name="TM">Thirteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TR>(string name)
         {
             return GetFunction(name)
@@ -424,6 +438,7 @@ namespace Wasmtime
         /// <typeparam name="TN">Fourteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TR>(string name)
         {
             return GetFunction(name)
@@ -451,6 +466,7 @@ namespace Wasmtime
         /// <typeparam name="TO">Fifteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TR>(string name)
         {
             return GetFunction(name)
@@ -479,6 +495,7 @@ namespace Wasmtime
         /// <typeparam name="TP">Sixteenth parameter type</typeparam>
         /// <typeparam name="TR">Return type. Use a tuple for multiple return values</typeparam>
         /// <returns>Returns the function if a function of that name and type was exported or null if not.</returns>
+        [ExcludeFromCodeCoverage]
         public Func<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR?>? GetFunction<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM, TN, TO, TP, TR>(string name)
         {
             return GetFunction(name)

--- a/src/Linker.DefineFunction.cs
+++ b/src/Linker.DefineFunction.cs
@@ -10,6 +10,7 @@ using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wasmtime
 {
@@ -22,6 +23,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction(string module, string name, Action callback)
         {
             if (module is null)
@@ -121,6 +123,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T>(string module, string name, Action<T?> callback)
         {
             if (module is null)
@@ -221,6 +224,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2>(string module, string name, Action<T1?, T2?> callback)
         {
             if (module is null)
@@ -323,6 +327,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3>(string module, string name, Action<T1?, T2?, T3?> callback)
         {
             if (module is null)
@@ -427,6 +432,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4>(string module, string name, Action<T1?, T2?, T3?, T4?> callback)
         {
             if (module is null)
@@ -533,6 +539,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?> callback)
         {
             if (module is null)
@@ -641,6 +648,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?> callback)
         {
             if (module is null)
@@ -751,6 +759,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
         {
             if (module is null)
@@ -863,6 +872,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
         {
             if (module is null)
@@ -977,6 +987,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
         {
             if (module is null)
@@ -1093,6 +1104,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
         {
             if (module is null)
@@ -1211,6 +1223,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
         {
             if (module is null)
@@ -1331,6 +1344,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string module, string name, Action<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
         {
             if (module is null)
@@ -1453,6 +1467,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<TResult>(string module, string name, Func<TResult> callback)
         {
             if (module is null)
@@ -1554,6 +1569,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T, TResult>(string module, string name, Func<T?, TResult> callback)
         {
             if (module is null)
@@ -1656,6 +1672,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, TResult>(string module, string name, Func<T1?, T2?, TResult> callback)
         {
             if (module is null)
@@ -1760,6 +1777,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, TResult>(string module, string name, Func<T1?, T2?, T3?, TResult> callback)
         {
             if (module is null)
@@ -1866,6 +1884,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, TResult> callback)
         {
             if (module is null)
@@ -1974,6 +1993,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, TResult> callback)
         {
             if (module is null)
@@ -2084,6 +2104,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
         {
             if (module is null)
@@ -2196,6 +2217,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
         {
             if (module is null)
@@ -2310,6 +2332,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
         {
             if (module is null)
@@ -2426,6 +2449,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
         {
             if (module is null)
@@ -2544,6 +2568,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
         {
             if (module is null)
@@ -2664,6 +2689,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
         {
             if (module is null)
@@ -2786,6 +2812,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
         {
             if (module is null)
@@ -2910,6 +2937,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<TResult1, TResult2>(string module, string name, Func<ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3013,6 +3041,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T, TResult1, TResult2>(string module, string name, Func<T?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3117,6 +3146,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, TResult1, TResult2>(string module, string name, Func<T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3223,6 +3253,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3331,6 +3362,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3441,6 +3473,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3553,6 +3586,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3667,6 +3701,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3783,6 +3818,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -3901,6 +3937,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -4021,6 +4058,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -4143,6 +4181,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -4267,6 +4306,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -4393,6 +4433,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<TResult1, TResult2, TResult3>(string module, string name, Func<ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -4498,6 +4539,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T, TResult1, TResult2, TResult3>(string module, string name, Func<T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -4604,6 +4646,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -4712,6 +4755,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -4822,6 +4866,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -4934,6 +4979,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5048,6 +5094,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5164,6 +5211,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5282,6 +5330,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5402,6 +5451,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5524,6 +5574,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5648,6 +5699,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5774,6 +5826,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -5902,6 +5955,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6009,6 +6063,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6117,6 +6172,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6227,6 +6283,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6339,6 +6396,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6453,6 +6511,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6569,6 +6628,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6687,6 +6747,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6807,6 +6868,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -6929,6 +6991,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -7053,6 +7116,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -7179,6 +7243,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -7307,6 +7372,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(string module, string name, Func<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -7437,6 +7503,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction(string module, string name, CallerAction callback)
         {
             if (module is null)
@@ -7536,6 +7603,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T>(string module, string name, CallerAction<T?> callback)
         {
             if (module is null)
@@ -7637,6 +7705,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2>(string module, string name, CallerAction<T1?, T2?> callback)
         {
             if (module is null)
@@ -7740,6 +7809,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3>(string module, string name, CallerAction<T1?, T2?, T3?> callback)
         {
             if (module is null)
@@ -7845,6 +7915,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4>(string module, string name, CallerAction<T1?, T2?, T3?, T4?> callback)
         {
             if (module is null)
@@ -7952,6 +8023,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?> callback)
         {
             if (module is null)
@@ -8061,6 +8133,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?> callback)
         {
             if (module is null)
@@ -8172,6 +8245,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?> callback)
         {
             if (module is null)
@@ -8285,6 +8359,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?> callback)
         {
             if (module is null)
@@ -8400,6 +8475,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?> callback)
         {
             if (module is null)
@@ -8517,6 +8593,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?> callback)
         {
             if (module is null)
@@ -8636,6 +8713,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?> callback)
         {
             if (module is null)
@@ -8757,6 +8835,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string module, string name, CallerAction<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?> callback)
         {
             if (module is null)
@@ -8880,6 +8959,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<TResult>(string module, string name, CallerFunc<TResult> callback)
         {
             if (module is null)
@@ -8981,6 +9061,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T, TResult>(string module, string name, CallerFunc<T?, TResult> callback)
         {
             if (module is null)
@@ -9084,6 +9165,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, TResult>(string module, string name, CallerFunc<T1?, T2?, TResult> callback)
         {
             if (module is null)
@@ -9189,6 +9271,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, TResult> callback)
         {
             if (module is null)
@@ -9296,6 +9379,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, TResult> callback)
         {
             if (module is null)
@@ -9405,6 +9489,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, TResult> callback)
         {
             if (module is null)
@@ -9516,6 +9601,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, TResult> callback)
         {
             if (module is null)
@@ -9629,6 +9715,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, TResult> callback)
         {
             if (module is null)
@@ -9744,6 +9831,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, TResult> callback)
         {
             if (module is null)
@@ -9861,6 +9949,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, TResult> callback)
         {
             if (module is null)
@@ -9980,6 +10069,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, TResult> callback)
         {
             if (module is null)
@@ -10101,6 +10191,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, TResult> callback)
         {
             if (module is null)
@@ -10224,6 +10315,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, TResult> callback)
         {
             if (module is null)
@@ -10349,6 +10441,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<TResult1, TResult2>(string module, string name, CallerFunc<ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10452,6 +10545,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T, TResult1, TResult2>(string module, string name, CallerFunc<T?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10557,6 +10651,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10664,6 +10759,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10773,6 +10869,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10884,6 +10981,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -10997,6 +11095,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11112,6 +11211,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11229,6 +11329,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11348,6 +11449,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11469,6 +11571,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11592,6 +11695,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11717,6 +11821,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2>> callback)
         {
             if (module is null)
@@ -11844,6 +11949,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<TResult1, TResult2, TResult3>(string module, string name, CallerFunc<ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -11949,6 +12055,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12056,6 +12163,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12165,6 +12273,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12276,6 +12385,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12389,6 +12499,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12504,6 +12615,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12621,6 +12733,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12740,6 +12853,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12861,6 +12975,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -12984,6 +13099,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -13109,6 +13225,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -13236,6 +13353,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3>> callback)
         {
             if (module is null)
@@ -13365,6 +13483,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -13472,6 +13591,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -13581,6 +13701,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -13692,6 +13813,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -13805,6 +13927,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -13920,6 +14043,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14037,6 +14161,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14156,6 +14281,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14277,6 +14403,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14400,6 +14527,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14525,6 +14653,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14652,6 +14781,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)
@@ -14781,6 +14911,7 @@ namespace Wasmtime
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult1, TResult2, TResult3, TResult4>(string module, string name, CallerFunc<T1?, T2?, T3?, T4?, T5?, T6?, T7?, T8?, T9?, T10?, T11?, T12?, ValueTuple<TResult1, TResult2, TResult3, TResult4>> callback)
         {
             if (module is null)

--- a/src/Linker.DefineFunction.tt
+++ b/src/Linker.DefineFunction.tt
@@ -21,6 +21,7 @@ using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Wasmtime
 {
@@ -44,6 +45,7 @@ foreach (var (hasCaller, resultCount, parameterCount, methodGenerics, delegateTy
         /// <param name="module">The module name of the function.</param>
         /// <param name="name">The name of the function.</param>
         /// <param name="callback">The callback for when the function is invoked.</param>
+        [ExcludeFromCodeCoverage]
         public void DefineFunction<#= methodGenerics #>(string module, string name, <#= delegateType #> callback)
         {
             if (module is null)

--- a/src/PoolingAllocationConfig.cs
+++ b/src/PoolingAllocationConfig.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Win32.SafeHandles;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Wasmtime;
@@ -73,6 +74,7 @@ public class PoolingAllocationConfig
     /// </summary>
     /// <param name="bytes"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     private PoolingAllocationConfig WithAsyncStackKeepResidentBytes(nuint bytes)
     {
         // todo: Wasmtime-dotnet does not support async! Expose this if support is added.
@@ -205,6 +207,7 @@ public class PoolingAllocationConfig
     /// </summary>
     /// <param name="count"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     private PoolingAllocationConfig WithMaxStacks(uint count)
     {
         // todo: Wasmtime-dotnet does not support async! Expose this if support is added.

--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -198,7 +198,20 @@ namespace Wasmtime.Tests
                 .WithMaxGcHeaps(15)
                 .WithMaxMemorySize(16)
                 .WithMaxUnusedWarmSlots(23)
-                .WithTableKeepResidentBytes(42);
+                .WithTableKeepResidentBytes(42)
+                .WithMaxMemoriesPerModule(67)
+                .WithMaxTableElements(69)
+                .WithMaxTablesPerModule(420)
+                .WithMaxTables(666)
+                .WithMaxCoreInstances(80085)
+                .WithMaxTables(23)
+                .WithMaxMemoriesPerComponent(1)
+                .WithMaxTablesPerComponent(2)
+                .WithMaxMemories(3)
+                .WithTotalComponentInstances(4)
+                .WithMaxComponentInstanceSize(5)
+                .WithMaxCoreInstanceSize(6)
+                .WithMaxCoreInstancesPerComponent(7);
 
             using var config = new Config();
             config.WithPoolingAllocationStrategy(strategy);

--- a/tests/FunctionTests.cs
+++ b/tests/FunctionTests.cs
@@ -187,11 +187,22 @@ namespace Wasmtime.Tests
         public void ItWrapsArgumentsInValueBox()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);
-            var add = instance.GetFunction("add");
+            var add = instance.GetFunction("add")!;
 
             var args = new ValueBox[] { 40, 2 };
-            int x = (int)add.Invoke(args.AsSpan());
+            int x = (int)add.Invoke(args.AsSpan())!;
             x.Should().Be(42);
+        }
+
+        [Fact]
+        public void ItThrowsWithMismatchedParameterCount()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var add = instance.GetFunction("add")!;
+
+            var args = new ValueBox[] { 40, 2, 9 };
+
+            Assert.Throws<WasmtimeException>(() => add.Invoke(args.AsSpan()));
         }
 
         [Fact]

--- a/tests/GlobalImportBindingTests.cs
+++ b/tests/GlobalImportBindingTests.cs
@@ -39,6 +39,13 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItFailsWithInvalidMutability()
+        {
+            var act = () => new Global(Store, (ValueKind)byte.MaxValue, 0, new Mutability(42));
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
         public void ItFailsToInstantiateWithMissingImport()
         {
             Action action = () => { Linker.Instantiate(Store, Fixture.Module); };

--- a/tests/InstanceTests.cs
+++ b/tests/InstanceTests.cs
@@ -43,6 +43,18 @@ namespace Wasmtime.Tests
             results.Single().Name.Should().Be("run");
         }
 
+        [Fact]
+        public void ItThrowsWithNullStore()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Instance(null!, Fixture.Module));
+        }
+
+        [Fact]
+        public void ItThrowsWithNullModule()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Instance(Store, null!));
+        }
+
         public void Dispose()
         {
             Store.Dispose();

--- a/tests/LinkerFunctionsTests.cs
+++ b/tests/LinkerFunctionsTests.cs
@@ -123,6 +123,18 @@ namespace Wasmtime.Tests
         private LinkerFunctionsFixture Fixture { get; }
 
         [Fact]
+        public void ItThrowsWithNullStore()
+        {
+            Assert.Throws<ArgumentNullException>(() => Linker.Instantiate(null!, Fixture.Module));
+        }
+
+        [Fact]
+        public void ItThrowsWithNullModule()
+        {
+            Assert.Throws<ArgumentNullException>(() => Linker.Instantiate(Store, null!));
+        }
+
+        [Fact]
         public void ItBindsImportMethodsAndCallsThemCorrectly()
         {
             var instance = Linker.Instantiate(Store, Fixture.Module);

--- a/tests/MemoryAccessTests.cs
+++ b/tests/MemoryAccessTests.cs
@@ -1,6 +1,6 @@
+using FluentAssertions;
 using System;
 using System.Linq;
-using FluentAssertions;
 using Xunit;
 
 namespace Wasmtime.Tests
@@ -129,6 +129,26 @@ namespace Wasmtime.Tests
 
             action = () => memory.GetSpan<short>(0xFFFFFFFF, 1);
             action.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void ItThrowForNegativePointerReadString()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var memory = instance.GetMemory("mem");
+
+            var action = () => memory.ReadNullTerminatedString(-1);
+            action.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void ItThrowForNegativePointerWriteString()
+        {
+            var instance = Linker.Instantiate(Store, Fixture.Module);
+            var memory = instance.GetMemory("mem");
+
+            var action = () => memory.WriteString(-1, "hello");
+            action.Should().Throw<ArgumentOutOfRangeException>();
         }
 
         public void Dispose()

--- a/tests/StoreTests.cs
+++ b/tests/StoreTests.cs
@@ -15,6 +15,21 @@ namespace Wasmtime.Tests
         }
 
         [Fact]
+        public void ItEnforcesValidLimits()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Store.SetLimits(memorySize: -1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Store.SetLimits(memories: -1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Store.SetLimits(instances: -1); });
+            Assert.Throws<ArgumentOutOfRangeException>(() => { Store.SetLimits(tables: -1); });
+        }
+
+        [Fact]
+        public void ItFailsWithNullEngine()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Store(null!));
+        }
+
+        [Fact]
         public void ItSetsDefaultLimits()
         {
             Store.SetLimits(null, null, null, null, null);


### PR DESCRIPTION
 - Added `[ExcludeFromCodeCoverage]` to generated code
 - Added tests on previously uncovered code - mostly trivial edge cases (e.g. null arguments)

Previously we were on 17% coverage and it was a useless measure - too much noise from the generated code. Now we're up to 78% and it's a much more useful measure.