### PR TITLE
Use trusted publishing for NuGet releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
     tags:
     - 'v*'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     name: "Publish NuGet Package"
@@ -24,7 +28,12 @@ jobs:
       run: |
         cd src
         dotnet pack -c Release /p:Packing=true
+    - name: NuGet login
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841
+      id: login
+      with:
+        user: jsturtevant
     - name: Publish NuGet Package
       run: |
         cd src/bin/Release
-        dotnet nuget push Wasmtime.${GITHUB_REF_NAME:1}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+        dotnet nuget push Wasmtime.${GITHUB_REF_NAME:1}.nupkg -k ${{ steps.login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
NuGet releases can avoid relying on a long-lived API key secret by using GitHub OIDC to request a short-lived NuGet API key at publish time.

This updates the publish workflow to grant `id-token: write`, authenticate with `NuGet/login` pinned to the full commit hash, and use the action output when pushing the generated package.

https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing

note: unfortunately you have to use your own username but the trusted publishing registration owner is bytecodealliance