### PR TITLE
Pin GitHub Actions in CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,8 @@ jobs:
             os: windows-2025
             config: release
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: '9.0.x'
     #  workaround for actions/setup-dotnet#155

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,8 @@ jobs:
     env:
       DevBuild: 'false'
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: '9.0.x'
     - name: Create NuGet package


### PR DESCRIPTION
CI workflows currently reference mutable GitHub Action tags, which can change over time. This pins the action versions to immutable commit SHAs while retaining the release version in comments for readability.

This updates `actions/checkout` to `v6.0.3` and `actions/setup-dotnet` to `v5.3.0` in both the CI and NuGet publish workflows.